### PR TITLE
Change dedicated C++ build test to Bazel, not CMake

### DIFF
--- a/.github/workflows/test_bazel.yaml
+++ b/.github/workflows/test_bazel.yaml
@@ -1,4 +1,4 @@
-name: Build using CMake
+name: Build using bazel
 
 on:
   pull_request:
@@ -14,27 +14,21 @@ concurrency:
 
 jobs:
   tests:
-    name: Build using CMake
-    runs-on: ${{ matrix.os }}
-    strategy:
-        matrix:
-            os: [ubuntu-22.04, macos-latest]
+    name: Build using bazel
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          lfs: true  # for the mgrid test data
       - name: Install required system packages for Ubuntu
-        if: ${{ contains(matrix.os, 'ubuntu') }}
         run: |
           sudo apt-get update && sudo apt-get install -y build-essential cmake gcc g++ libeigen3-dev libhdf5-dev liblapacke-dev libnetcdf-dev libopenmpi-dev nlohmann-json3-dev python3-pip python-is-python3
-      - name: Install required system packages for MacOS
-        if: ${{ contains(matrix.os, 'macos') }}
+      - name: Build VMEC++ via bazel
         run: |
-          brew install gcc cmake ninja libomp netcdf-cxx eigen nlohmann-json protobuf lapack git open-mpi
-          # Add missing symbolic links for gfortran
-          ln -s $(which gfortran-14) /usr/local/bin/gfortran
-          ln -s $(which gcc-14) /usr/local/bin/gcc
-      - name: Build VMEC++
+          cd src/vmecpp/cpp
+          bazel build -- //...
+      - name: Run C++ tests via bazel
         run: |
-          cmake -B build
-          cmake --build build --parallel
+          cd src/vmecpp/cpp
+          bazel test --jobs=1 --test_output=errors -- //...


### PR DESCRIPTION
Now that we use CMake by default from pip install.