### PR TITLE
Fix GitHub pages build

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           sudo apt-get install libnetcdf-dev liblapacke-dev libopenmpi-dev
           # must actually install the package otherwise sphinx can't autogenerate the API reference
-          python -m pip install -vvv -e .[docs]
+          python -m pip install -vvv .[docs]
           sphinx-apidoc --module-first --no-toc --force --separate -o docs/api src/vmecpp/ && sphinx-build docs html_docs
       - name: Upload artifacts
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Editable installs are not supported now that we use scikit-build-core's hatch plugin.