### PR TITLE
Bump version of Python package to 0.1

### DIFF
--- a/src/vmecpp/__about__.py
+++ b/src/vmecpp/__about__.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.0.1"
+# NOTE: must also update src/vmecpp/cpp/MODULE.bazel
+__version__ = "0.1.0"

--- a/src/vmecpp/cpp/MODULE.bazel
+++ b/src/vmecpp/cpp/MODULE.bazel
@@ -1,5 +1,6 @@
 # Find available modules at https://registry.bazel.build
 
+# NOTE: if updating the version, must also update src/vmecpp/__about__.py
 module(name = "vmecpp", version = "0.1")
 
 bazel_dep(name = "abseil-cpp", version = "20230802.0.bcr.1")


### PR DESCRIPTION
To align it with the latest git tag and what we
advertise from the MODULE.bazel.