### PR TITLE
Use https instead of ssh for git submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "pybind11"]
 	path = pybind11
-	url = git@github.com:pybind/pybind11.git
+	url = https://github.com/pybind/pybind11.git
 [submodule "abscab-cpp"]
 	path = abscab-cpp
-	url = git@github.com:jonathanschilling/abscab-cpp.git
+	url = https://github.com/jonathanschilling/abscab-cpp.git
 [submodule "abseil-cpp"]
 	path = abseil-cpp
-	url = git@github.com:abseil/abseil-cpp.git
+	url = https://github.com/abseil/abseil-cpp.git
 [submodule "indata2json"]
 	path = indata2json
-	url = git@github.com:jonathanschilling/indata2json.git
+	url = https://github.com/jonathanschilling/indata2json.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/abseil/abseil-cpp.git
 [submodule "indata2json"]
 	path = indata2json
-	url = https://github.com/jonathanschilling/indata2json.git
+	url = https://github.com/eguiraud-pf/indata2json.git


### PR DESCRIPTION
So there is no need for ssh credentials to clone the VMEC++ repo.

Thanks to @rogeriojorge for the suggestion.