### PR TITLE
Remove lapacke dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ include_directories(${EIGEN3_INCLUDE_DIR})
 
 find_package(nlohmann_json REQUIRED)
 
-find_package(LAPACK REQUIRED C)
+find_package(LAPACK REQUIRED)
 
 find_package(OpenMP)
 
@@ -59,15 +59,7 @@ add_library (vmecpp_core STATIC ${vmecpp_sources})
 target_link_libraries(vmecpp_core PRIVATE ${HDF5_CXX_LIBRARIES} ${HDF5_LIBRARIES})
 target_link_libraries(vmecpp_core PRIVATE netCDF::netcdf)
 target_link_libraries(vmecpp_core PRIVATE nlohmann_json::nlohmann_json)
-if(APPLE)
-  # We assume we are building against dependencies installed via homebrew.
-  # These must be public for the _vmecpp target to pick them up transitively.
-  target_include_directories(vmecpp_core PUBLIC /opt/homebrew/opt/lapack/include)
-  target_link_directories(vmecpp_core PUBLIC /opt/homebrew/opt/lapack/lib)
-  target_link_libraries(vmecpp_core PUBLIC LAPACK::LAPACK -llapacke)
-else()
-  target_link_libraries(vmecpp_core PRIVATE LAPACK::LAPACK -llapacke)
-endif()
+target_link_libraries(vmecpp_core PRIVATE LAPACK::LAPACK)
 target_link_libraries(vmecpp_core PRIVATE absl::algorithm absl::base absl::synchronization absl::strings absl::str_format absl::log absl::string_view absl::check absl::status absl::statusor)
 if(OpenMP_CXX_FOUND)
   target_link_libraries(vmecpp_core PRIVATE OpenMP::OpenMP_CXX)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Otherwise the Ubuntu package `python-is-python3` provides the `python` alias.
 1. Install dependencies via [Homebrew](https://brew.sh/):
 
 ```shell
-brew install python@3.10 gcc cmake ninja libomp netcdf-cxx eigen nlohmann-json protobuf lapack git open-mpi
+brew install python@3.10 gcc cmake ninja libomp netcdf-cxx eigen nlohmann-json protobuf git open-mpi
 ```
 
 2. Install VMEC++ as a Python package (possibly after creating a virtual environment):

--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/BUILD.bazel
@@ -14,6 +14,6 @@ cc_library(
         "//vmecpp/free_boundary/tangential_partitioning:tangential_partitioning",
     ],
     linkopts = [
-        "-llapacke",
+        "-llapack",
     ],
 )

--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.h
@@ -4,8 +4,6 @@
 #ifndef VMECPP_FREE_BOUNDARY_LAPLACE_SOLVER_LAPLACE_SOLVER_H_
 #define VMECPP_FREE_BOUNDARY_LAPLACE_SOLVER_LAPLACE_SOLVER_H_
 
-#include <lapacke.h>
-
 #include <vector>
 
 #include "vmecpp/common/fourier_basis_fast_toroidal/fourier_basis_fast_toroidal.h"


### PR DESCRIPTION
This removes the use of lapacke which is not standard across all LAPACK vendors. This enables building on macOS without home-brew.