### PR TITLE
Fix race condition in ensure_vmecpp_input

### DIFF
--- a/tests/test_simsopt_compat.py
+++ b/tests/test_simsopt_compat.py
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: MIT
 """Tests for VMEC++'s'SIMSOPT compatibility layer."""
 
+import json
 import math
+import os
 from pathlib import Path
 
 import netCDF4
@@ -267,3 +269,23 @@ def test_ensure_vmec2000_input_from_vmecpp_input():
                             :, 101 - ntor : 101 + ntor + 1
                         ]
                 np.testing.assert_allclose(vmecpp_var, vmec2000_var_truncated)
+
+
+def test_ensure_vmecpp_input_noop():
+    vmecpp_input_file = TEST_DATA_DIR / "cma.json"
+
+    with simsopt_compat.ensure_vmecpp_input(vmecpp_input_file) as new_input_file:
+        assert new_input_file == vmecpp_input_file
+
+
+def test_ensure_vmecpp_input():
+    vmec2000_input_file = TEST_DATA_DIR / "input.cma"
+
+    with simsopt_compat.ensure_vmecpp_input(vmec2000_input_file) as vmecpp_input_file:
+        assert vmecpp_input_file == TEST_DATA_DIR / f"cma.{os.getpid()}.json"
+        with open(vmecpp_input_file) as f:
+            vmecpp_input_dict = json.load(f)
+            # check the output is remotely sensible: we don't want to test indata_to_json's
+            # correctness here, just that nothing went terribly wrong
+            assert vmecpp_input_dict["mpol"] == 5
+            assert vmecpp_input_dict["ntor"] == 6

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -23,9 +23,23 @@ def test_indata_to_json_success():
     ):
         test_file = TEST_DATA_DIR / "input.cma"
         json_input_file = _util.indata_to_json(test_file)
-        expected_json_input_file = Path("cma.json")
+        expected_json_input_file = Path(tmpdir, "cma.json").resolve()
         assert json_input_file.exists()
         assert json_input_file == expected_json_input_file
+
+
+def test_indata_to_json_output_override():
+    with tempfile.TemporaryDirectory() as tmpdir, _util.change_working_directory_to(
+        Path(tmpdir)
+    ):
+        test_file = TEST_DATA_DIR / "input.cma"
+        json_input_file = _util.indata_to_json(
+            test_file, output_override=Path("override_path")
+        )
+        expected_json_input_file = Path("override_path").resolve()
+        assert json_input_file.exists()
+        assert json_input_file == expected_json_input_file
+        assert json_input_file.parent == Path.cwd()
 
 
 def test_indata_to_json_not_found_file():


### PR DESCRIPTION
Before this patch, when multiple processes called
ensure_vmecpp_input on the same input file,
each process would create and then try to delete
the same temporary VMEC++ input file.

With this patch, ensure_vmecpp_input adds the PID
to the name of the temporary input file, removing
the race condition.