### PR TITLE
fix docker/Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 FROM ubuntu:22.04
 
 RUN apt-get -q update && \
-    apt-get -q -y install build-essential libnetcdf-dev liblapacke-dev libopenmpi-dev python3-pip python-is-python3 git wget
+    apt-get -q -y install build-essential libnetcdf-dev liblapacke-dev libopenmpi-dev python3-pip python-is-python3 git wget ninja-build
 RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.24.1/bazelisk-linux-amd64 \
     && mv bazelisk-linux-amd64 /usr/local/bin/bazel \
     && chmod u+x /usr/local/bin/bazel

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,6 @@ RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.24.1/bazeli
     && mv bazelisk-linux-amd64 /usr/local/bin/bazel \
     && chmod u+x /usr/local/bin/bazel
 
-RUN git clone https://github.com/proximafusion/vmecpp.git
+RUN git clone https://github.com/proximafusion/vmecpp.git --recurse-submodules
 WORKDIR /vmecpp
 RUN python -m pip install .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 FROM ubuntu:22.04
 
 RUN apt-get -q update && \
-    apt-get -q -y install build-essential libnetcdf-dev liblapacke-dev libopenmpi-dev python3-pip python-is-python3 git wget ninja-build
+    apt-get -q -y install build-essential libnetcdf-dev liblapacke-dev libopenmpi-dev python3-pip python-is-python3 git wget ninja-build libeigen3-dev
 RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.24.1/bazelisk-linux-amd64 \
     && mv bazelisk-linux-amd64 /usr/local/bin/bazel \
     && chmod u+x /usr/local/bin/bazel

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,5 @@
 # run as:
-# env GITHUB_TOKEN=XYZ docker build --secret id=GITHUB_TOKEN .
-# where XYZ is a github token that has permissions to read jons-pf/vmecpp.
+# docker build -t ghcr.io/jons-pf/vmecpp:latest  .
 FROM ubuntu:22.04
 
 RUN apt-get -q update && \
@@ -9,6 +8,6 @@ RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.24.1/bazeli
     && mv bazelisk-linux-amd64 /usr/local/bin/bazel \
     && chmod u+x /usr/local/bin/bazel
 
-RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN git clone https://$GITHUB_TOKEN@github.com/jons-pf/vmecpp.git
+RUN git clone https://github.com/proximafusion/vmecpp.git
 WORKDIR /vmecpp
 RUN python -m pip install .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 FROM ubuntu:22.04
 
 RUN apt-get -q update && \
-    apt-get -q -y install build-essential libnetcdf-dev liblapacke-dev libopenmpi-dev python3-pip python-is-python3 git wget ninja-build libeigen3-dev
+    apt-get -q -y install build-essential libnetcdf-dev liblapacke-dev libopenmpi-dev python3-pip python-is-python3 git wget ninja-build libeigen3-dev nlohmann-json3-dev
 RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.24.1/bazelisk-linux-amd64 \
     && mv bazelisk-linux-amd64 /usr/local/bin/bazel \
     && chmod u+x /usr/local/bin/bazel


### PR DESCRIPTION
In case it's useful: a few small things to make the `Dockerfile` build for me locally:

- clone the public github repo rather than the private one (so no `GITHUB_TOKEN` needed for that part) (I'm assuming `jons-pf/vmecpp` is the private one and the `proximafusion/vmecpp` is the new public one)
  - also recursively clone the submodules
- add a few Debian dependencies that seemed missing

After this the `docker build -t ghcr.io/jons-pf/vmecpp:latest  .` completed for me (although I don't know how to test it properly!)
```
PS C:\Users\dave\github.com\djs55\vmecpp\docker> docker build -t ghcr.io/jons-pf/vmecpp:latest  .
[+] Building 249.4s (10/10) FINISHED                                                               docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                               0.0s
 => => transferring dockerfile: 629B                                                                               0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.04                                                    0.5s
 => [internal] load .dockerignore                                                                                  0.0s
 => => transferring context: 2B                                                                                    0.0s
 => [1/6] FROM docker.io/library/ubuntu:22.04@sha256:ed1544e454989078f5dec1bfdabd8c5cc9c48e0705d07b678ab6ae3fb619  0.0s
 => => resolve docker.io/library/ubuntu:22.04@sha256:ed1544e454989078f5dec1bfdabd8c5cc9c48e0705d07b678ab6ae3fb619  0.0s
 => CACHED [2/6] RUN apt-get -q update &&     apt-get -q -y install build-essential libnetcdf-dev liblapacke-dev   0.0s
 => CACHED [3/6] RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.24.1/bazelisk-linux-amd64    0.0s
 => CACHED [4/6] RUN git clone https://github.com/proximafusion/vmecpp.git --recurse-submodules                    0.0s
 => CACHED [5/6] WORKDIR /vmecpp                                                                                   0.0s
 => [6/6] RUN python -m pip install .                                                                            206.2s
 => exporting to image                                                                                            42.5s
 => => exporting layers                                                                                           35.7s
 => => exporting manifest sha256:95df734eb90de7d19557cd5275fe1f4339ac0eb111999bc3b1e11d67284253db                  0.0s
 => => exporting config sha256:1fa400529c670db6000fb1f41439a6059b8ba2cfc0d1ec3c46d5e07ccb53ed72                    0.0s
 => => exporting attestation manifest sha256:c209eec6dcdf7dabc877b226ab07b1b67bcb873a197b2752185c9c3e0847be2b      0.0s
 => => exporting manifest list sha256:c461fec894b14063986726b949c1f1590d6b34055137fcec4cdcc536939e2c73             0.0s
 => => naming to ghcr.io/jons-pf/vmecpp:latest                                                                     0.0s
 => => unpacking to ghcr.io/jons-pf/vmecpp:latest                                                                  6.7s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/qxth3gzkau9aik0n1nvsfivcw
```