### PR TITLE
applied clang tidy across codebase

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/composed_types_lib/composed_types_lib_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/composed_types_lib/composed_types_lib_test.cc
@@ -1,9 +1,11 @@
-// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+// <info@proximafusion.com>
 //
 // SPDX-License-Identifier: MIT
 #include "vmecpp/common/composed_types_lib/composed_types_lib.h"
 
 #include <cmath>
+#include <numbers>
 #include <string>
 
 #include "absl/status/statusor.h"
@@ -15,14 +17,14 @@ namespace composed_types {
 
 using testing::IsCloseRelAbs;
 
+using std::numbers::inv_sqrt3;
+using std::numbers::sqrt2;
+using std::numbers::sqrt3;
 using ::testing::ElementsAre;
 using ::testing::ElementsAreArray;
 
 TEST(ComposedTypesLibTest, CheckLength) {
   static constexpr double kTolerance = 1.0e-15;
-
-  const double kSqrt2 = std::sqrt(2.0);
-  const double kSqrt3 = std::sqrt(3.0);
 
   Vector3d vector_x;
   vector_x.set_x(1.0);
@@ -46,25 +48,25 @@ TEST(ComposedTypesLibTest, CheckLength) {
   vector_xy.set_x(1.0);
   vector_xy.set_y(1.0);
   vector_xy.set_z(0.0);
-  EXPECT_TRUE(IsCloseRelAbs(kSqrt2, Length(vector_xy), kTolerance));
+  EXPECT_TRUE(IsCloseRelAbs(sqrt2, Length(vector_xy), kTolerance));
 
   Vector3d vector_xz;
   vector_xz.set_x(1.0);
   vector_xz.set_y(0.0);
   vector_xz.set_z(1.0);
-  EXPECT_TRUE(IsCloseRelAbs(kSqrt2, Length(vector_xz), kTolerance));
+  EXPECT_TRUE(IsCloseRelAbs(sqrt2, Length(vector_xz), kTolerance));
 
   Vector3d vector_yz;
   vector_yz.set_x(0.0);
   vector_yz.set_y(1.0);
   vector_yz.set_z(1.0);
-  EXPECT_TRUE(IsCloseRelAbs(kSqrt2, Length(vector_yz), kTolerance));
+  EXPECT_TRUE(IsCloseRelAbs(sqrt2, Length(vector_yz), kTolerance));
 
   Vector3d vector_xyz;
   vector_xyz.set_x(1.0);
   vector_xyz.set_y(1.0);
   vector_xyz.set_z(1.0);
-  EXPECT_TRUE(IsCloseRelAbs(kSqrt3, Length(vector_xyz), kTolerance));
+  EXPECT_TRUE(IsCloseRelAbs(sqrt3, Length(vector_xyz), kTolerance));
 }  // CheckLength
 
 TEST(ComposedTypesLibTest, CheckScaleToInPlane) {
@@ -72,7 +74,7 @@ TEST(ComposedTypesLibTest, CheckScaleToInPlane) {
 
   static constexpr double kDesiredLength = 1.23;
 
-  const double kExpectedComponent = kDesiredLength / std::sqrt(2.0);
+  const double kExpectedComponent = kDesiredLength / sqrt2;
 
   Vector3d vector_xy;
   vector_xy.set_x(1.0);
@@ -107,7 +109,7 @@ TEST(ComposedTypesLibTest, CheckScaleToInVolume) {
 
   static constexpr double kDesiredLength = 1.23;
 
-  const double kExpectedComponent = kDesiredLength / std::sqrt(3.0);
+  const double kExpectedComponent = kDesiredLength / sqrt3;
 
   Vector3d vector_xyz;
   vector_xyz.set_x(1.0);
@@ -125,8 +127,7 @@ TEST(ComposedTypesLibTest, CheckScaleToInVolume) {
 TEST(ComposedTypesLibTest, CheckNormalize) {
   static constexpr double kTolerance = 1.0e-15;
 
-  const double kInverseSqrt2 = 1.0 / std::sqrt(2.0);
-  const double kInverseSqrt3 = 1.0 / std::sqrt(3.0);
+  static constexpr double kInverseSqrt2 = 1.0 / sqrt2;
 
   Vector3d vector_xy;
   vector_xy.set_x(1.0);
@@ -160,9 +161,9 @@ TEST(ComposedTypesLibTest, CheckNormalize) {
   vector_xyz.set_y(1.0);
   vector_xyz.set_z(1.0);
   Vector3d normalized_xyz = Normalize(vector_xyz);
-  EXPECT_TRUE(IsCloseRelAbs(kInverseSqrt3, normalized_xyz.x(), kTolerance));
-  EXPECT_TRUE(IsCloseRelAbs(kInverseSqrt3, normalized_xyz.y(), kTolerance));
-  EXPECT_TRUE(IsCloseRelAbs(kInverseSqrt3, normalized_xyz.z(), kTolerance));
+  EXPECT_TRUE(IsCloseRelAbs(inv_sqrt3, normalized_xyz.x(), kTolerance));
+  EXPECT_TRUE(IsCloseRelAbs(inv_sqrt3, normalized_xyz.y(), kTolerance));
+  EXPECT_TRUE(IsCloseRelAbs(inv_sqrt3, normalized_xyz.z(), kTolerance));
 }  // CheckNormalize
 
 TEST(ComposedTypesLibTest, CheckAdd) {

--- a/src/vmecpp/cpp/vmecpp/common/flow_control/flow_control.h
+++ b/src/vmecpp/cpp/vmecpp/common/flow_control/flow_control.h
@@ -13,7 +13,7 @@ namespace vmecpp {
 
 // enumerates values of `restart_reason`
 // was `irst` = 1, 2, 3, 4 in Fortran VMEC
-enum class RestartReason {
+enum class RestartReason : std::uint8_t {
   // irst == 1, no restart required, instead make backup of current state vector
   // when calling Vmec::RestartIteration
   NO_RESTART,

--- a/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_poloidal/fourier_basis_fast_poloidal.cc
+++ b/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_poloidal/fourier_basis_fast_poloidal.cc
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <vector>
+#include <numbers>
 
 #include "absl/algorithm/container.h"
 #include "absl/log/check.h"
@@ -64,7 +65,7 @@ void FourierBasisFastPoloidal::computeFourierBasisFastPoloidal(int nfp) {
     if (m == 0) {
       mscale[m] = 1.0;
     } else {
-      mscale[m] = std::sqrt(2.0);
+      mscale[m] = std::numbers::sqrt2;
     }
   }  // m
 
@@ -106,7 +107,7 @@ void FourierBasisFastPoloidal::computeFourierBasisFastPoloidal(int nfp) {
     if (n == 0) {
       nscale[n] = 1.0;
     } else {
-      nscale[n] = std::sqrt(2.0);
+      nscale[n] = std::numbers::sqrt2;
     }
   }  // n
 

--- a/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_toroidal/fourier_basis_fast_toroidal.cc
+++ b/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_toroidal/fourier_basis_fast_toroidal.cc
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <vector>
+#include <numbers>
 
 #include "absl/algorithm/container.h"
 #include "absl/log/check.h"
@@ -64,7 +65,7 @@ void FourierBasisFastToroidal::computeFourierBasisFastToroidal(int nfp) {
     if (m == 0) {
       mscale[m] = 1.0;
     } else {
-      mscale[m] = std::sqrt(2.0);
+      mscale[m] = std::numbers::sqrt2;
     }
   }  // m
 
@@ -106,7 +107,7 @@ void FourierBasisFastToroidal::computeFourierBasisFastToroidal(int nfp) {
     if (n == 0) {
       nscale[n] = 1.0;
     } else {
-      nscale[n] = std::sqrt(2.0);
+      nscale[n] = std::numbers::sqrt2;
     }
   }  // n
 

--- a/src/vmecpp/cpp/vmecpp/common/magnetic_configuration_definition/magnetic_configuration.h
+++ b/src/vmecpp/cpp/vmecpp/common/magnetic_configuration_definition/magnetic_configuration.h
@@ -2,7 +2,9 @@
 #define VMECPP_COMMON_MAGNETIC_CONFIGURATION_DEFINITION_MAGNETIC_CONFIGURATION_H_
 
 #include <string>
+#include <cstdint>
 #include <list>
+#include <string>
 
 #include "vmecpp/common/composed_types_definition/composed_types.h"
 
@@ -227,7 +229,7 @@ struct InfiniteStraightFilament {
 
 struct CurrentCarrier {
   // oneof type
-  enum TypeCase {
+  enum TypeCase : std::uint8_t {
     kInfiniteStraightFilament = 1,
     kCircularFilament         = 2,
     kPolygonFilament          = 3,

--- a/src/vmecpp/cpp/vmecpp/common/magnetic_configuration_lib/magnetic_configuration_lib.cc
+++ b/src/vmecpp/cpp/vmecpp/common/magnetic_configuration_lib/magnetic_configuration_lib.cc
@@ -569,32 +569,32 @@ void PrintInfiniteStraightFilament(
     prefix += " ";
   }
 
-  std::cout << prefix << "InfiniteStraightFilament {" << std::endl;
+  std::cout << prefix << "InfiniteStraightFilament {" << '\n';
 
   if (infinite_straight_filament.has_name()) {
     std::cout << prefix << "  name: '" << infinite_straight_filament.name()
-              << "'" << std::endl;
+              << "'" << '\n';
   } else {
-    std::cout << prefix << "  name: none" << std::endl;
+    std::cout << prefix << "  name: none" << '\n';
   }
 
   if (infinite_straight_filament.has_origin()) {
     const Vector3d& origin = infinite_straight_filament.origin();
     std::cout << prefix << "  origin: [" << origin.x() << ", " << origin.y()
-              << ", " << origin.z() << "]" << std::endl;
+              << ", " << origin.z() << "]" << '\n';
   } else {
-    std::cout << prefix << "  origin: none" << std::endl;
+    std::cout << prefix << "  origin: none" << '\n';
   }
 
   if (infinite_straight_filament.has_direction()) {
     const Vector3d& direction = infinite_straight_filament.direction();
     std::cout << prefix << "  direction: [" << direction.x() << ", "
-              << direction.y() << ", " << direction.z() << "]" << std::endl;
+              << direction.y() << ", " << direction.z() << "]" << '\n';
   } else {
-    std::cout << prefix << "  direction: none" << std::endl;
+    std::cout << prefix << "  direction: none" << '\n';
   }
 
-  std::cout << prefix << "}" << std::endl;
+  std::cout << prefix << "}" << '\n';
 }  // PrintInfiniteStraightFilament
 
 void PrintCircularFilament(const CircularFilament& circular_filament,
@@ -604,39 +604,39 @@ void PrintCircularFilament(const CircularFilament& circular_filament,
     prefix += " ";
   }
 
-  std::cout << prefix << "CircularFilament {" << std::endl;
+  std::cout << prefix << "CircularFilament {" << '\n';
 
   if (circular_filament.has_name()) {
     std::cout << prefix << "  name: '" << circular_filament.name() << "'"
-              << std::endl;
+              << '\n';
   } else {
-    std::cout << prefix << "  name: none" << std::endl;
+    std::cout << prefix << "  name: none" << '\n';
   }
 
   if (circular_filament.has_center()) {
     const Vector3d& center = circular_filament.center();
     std::cout << prefix << "  center: [" << center.x() << ", " << center.y()
-              << ", " << center.z() << "]" << std::endl;
+              << ", " << center.z() << "]" << '\n';
   } else {
-    std::cout << prefix << "  center: none" << std::endl;
+    std::cout << prefix << "  center: none" << '\n';
   }
 
   if (circular_filament.has_normal()) {
     const Vector3d& normal = circular_filament.normal();
     std::cout << prefix << "  normal: [" << normal.x() << ", " << normal.y()
-              << ", " << normal.z() << "]" << std::endl;
+              << ", " << normal.z() << "]" << '\n';
   } else {
-    std::cout << prefix << "  normal: none" << std::endl;
+    std::cout << prefix << "  normal: none" << '\n';
   }
 
   if (circular_filament.has_radius()) {
     const double radius = circular_filament.radius();
-    std::cout << prefix << "  radius: " << radius << std::endl;
+    std::cout << prefix << "  radius: " << radius << '\n';
   } else {
-    std::cout << prefix << "  radius: none" << std::endl;
+    std::cout << prefix << "  radius: none" << '\n';
   }
 
-  std::cout << prefix << "}" << std::endl;
+  std::cout << prefix << "}" << '\n';
 }  // PrintCircularFilament
 
 void PrintPolygonFilament(const PolygonFilament& polygon_filament,
@@ -646,23 +646,23 @@ void PrintPolygonFilament(const PolygonFilament& polygon_filament,
     prefix += " ";
   }
 
-  std::cout << prefix << "PolygonFilament {" << std::endl;
+  std::cout << prefix << "PolygonFilament {" << '\n';
 
   if (polygon_filament.has_name()) {
     std::cout << prefix << "  name: '" << polygon_filament.name() << "'"
-              << std::endl;
+              << '\n';
   } else {
-    std::cout << prefix << "  name: none" << std::endl;
+    std::cout << prefix << "  name: none" << '\n';
   }
 
   if (polygon_filament.vertices_size() > 0) {
     std::cout << prefix << "  vertices: [" << polygon_filament.vertices_size()
-              << "]" << std::endl;
+              << "]" << '\n';
   } else {
-    std::cout << prefix << "  vertices: none" << std::endl;
+    std::cout << prefix << "  vertices: none" << '\n';
   }
 
-  std::cout << prefix << "}" << std::endl;
+  std::cout << prefix << "}" << '\n';
 }  // PrintPolygonFilament
 
 void PrintCurrentCarrier(const CurrentCarrier& current_carrier,
@@ -672,7 +672,7 @@ void PrintCurrentCarrier(const CurrentCarrier& current_carrier,
     prefix += " ";
   }
 
-  std::cout << prefix << "CurrentCarrier {" << std::endl;
+  std::cout << prefix << "CurrentCarrier {" << '\n';
 
   switch (current_carrier.type_case()) {
     case CurrentCarrier::TypeCase::kInfiniteStraightFilament:
@@ -697,7 +697,7 @@ void PrintCurrentCarrier(const CurrentCarrier& current_carrier,
       LOG(FATAL) << error_message.str();
   }
 
-  std::cout << prefix << "}" << std::endl;
+  std::cout << prefix << "}" << '\n';
 }  // PrintCurrentCarrier
 
 void PrintCoil(const Coil& coil, int indentation) {
@@ -706,26 +706,26 @@ void PrintCoil(const Coil& coil, int indentation) {
     prefix += " ";
   }
 
-  std::cout << prefix << "Coil {" << std::endl;
+  std::cout << prefix << "Coil {" << '\n';
 
   if (coil.has_name()) {
-    std::cout << prefix << "  name: '" << coil.name() << "'" << std::endl;
+    std::cout << prefix << "  name: '" << coil.name() << "'" << '\n';
   } else {
-    std::cout << prefix << "  name: none" << std::endl;
+    std::cout << prefix << "  name: none" << '\n';
   }
 
   if (coil.has_num_windings()) {
     std::cout << prefix << "  num_windings: " << coil.num_windings()
-              << std::endl;
+              << '\n';
   } else {
-    std::cout << prefix << "  num_windings: none" << std::endl;
+    std::cout << prefix << "  num_windings: none" << '\n';
   }
 
   for (const CurrentCarrier& current_carrier : coil.current_carriers()) {
     PrintCurrentCarrier(current_carrier, indentation + 2);
   }
 
-  std::cout << prefix << "}" << std::endl;
+  std::cout << prefix << "}" << '\n';
 }  // PrintCoil
 
 void PrintSerialCircuit(const SerialCircuit& serial_circuit, int indentation) {
@@ -734,27 +734,27 @@ void PrintSerialCircuit(const SerialCircuit& serial_circuit, int indentation) {
     prefix += " ";
   }
 
-  std::cout << prefix << "SerialCircuit {" << std::endl;
+  std::cout << prefix << "SerialCircuit {" << '\n';
 
   if (serial_circuit.has_name()) {
     std::cout << prefix << "  name: '" << serial_circuit.name() << "'"
-              << std::endl;
+              << '\n';
   } else {
-    std::cout << prefix << "  name: none" << std::endl;
+    std::cout << prefix << "  name: none" << '\n';
   }
 
   if (serial_circuit.has_current()) {
     std::cout << prefix << "  current: " << serial_circuit.current()
-              << std::endl;
+              << '\n';
   } else {
-    std::cout << prefix << "  current: none" << std::endl;
+    std::cout << prefix << "  current: none" << '\n';
   }
 
   for (const Coil& coil : serial_circuit.coils()) {
     PrintCoil(coil, indentation + 2);
   }
 
-  std::cout << prefix << "}" << std::endl;
+  std::cout << prefix << "}" << '\n';
 }  // PrintSerialCircuit
 
 void PrintMagneticConfiguration(
@@ -764,20 +764,20 @@ void PrintMagneticConfiguration(
     prefix += " ";
   }
 
-  std::cout << prefix << "MagneticConfiguration {" << std::endl;
+  std::cout << prefix << "MagneticConfiguration {" << '\n';
 
   if (magnetic_configuration.has_name()) {
     std::cout << prefix << "  name: '" << magnetic_configuration.name() << "'"
-              << std::endl;
+              << '\n';
   } else {
-    std::cout << prefix << "  name: none" << std::endl;
+    std::cout << prefix << "  name: none" << '\n';
   }
 
   if (magnetic_configuration.has_num_field_periods()) {
     std::cout << prefix << "  num_field_periods: "
-              << magnetic_configuration.num_field_periods() << std::endl;
+              << magnetic_configuration.num_field_periods() << '\n';
   } else {
-    std::cout << prefix << "  num_field_periods: none" << std::endl;
+    std::cout << prefix << "  num_field_periods: none" << '\n';
   }
 
   for (const SerialCircuit& serial_circuit :
@@ -785,7 +785,7 @@ void PrintMagneticConfiguration(
     PrintSerialCircuit(serial_circuit, indentation + 2);
   }
 
-  std::cout << prefix << "}" << std::endl;
+  std::cout << prefix << "}" << '\n';
 }  // PrintMagneticConfiguration
 
 }  // namespace magnetics

--- a/src/vmecpp/cpp/vmecpp/common/util/util.h
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.h
@@ -72,7 +72,7 @@ inline vmecpp::RowMatrixXd ToEigenMatrix(
   return m;
 }
 
-enum class VmecCheckpoint {
+enum class VmecCheckpoint : std::uint8_t {
   NONE = 0,
 
   // ------ initial guess and static members
@@ -145,7 +145,7 @@ enum class VmecCheckpoint {
   THREED1_SHAFRANOV_INTEGRALS
 };
 
-enum class VmecStatus {
+enum class VmecStatus : std::uint8_t {
   // no fatal error but convergence was not reached
   NORMAL_TERMINATION = 0,
   BAD_JACOBIAN = 1,
@@ -195,8 +195,8 @@ int signum(int x);
 // c     contains the RHS on entry and the solution vectors on exit
 void TridiagonalSolveSerial(std::vector<double> &m_a, std::vector<double> &m_d,
                             std::vector<double> &m_b,
-                            std::vector<std::vector<double>> &m_c,
-                            int jMin, int jMax, int nRHS);
+                            std::vector<std::vector<double>> &m_c, int jMin,
+                            int jMax, int nRHS);
 
 // OpenMP-enabled tri-diagonal solver
 //

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
@@ -22,7 +22,7 @@ static constexpr double kFTolDefault = 1.0e-10;
 // default maximum number of iterations
 static constexpr int kNIterDefault = 100;
 
-enum class FreeBoundaryMethod {
+enum class FreeBoundaryMethod : std::uint8_t {
   // use the NEumann Solver for TORoidal systems
   // for the free-boundary force contribution
   NESTOR,
@@ -40,7 +40,7 @@ std::string ToString(FreeBoundaryMethod free_boundary_method);
 // Use this to switch the overall program flow/iteration style
 // between VMEC 8.52 (Golden Reference for V&V, and what educational_VMEC is
 // based on) and PARVMEC (~same as hiddenSymmetries/VMEC2000) - version 9.0.
-enum class IterationStyle {
+enum class IterationStyle : std::uint8_t {
   // VMEC 8.52 (Golden Reference for V&V, and what educational_VMEC is based on)
   VMEC_8_52,
 

--- a/src/vmecpp/cpp/vmecpp/free_boundary/tangential_partitioning/tangential_partitioning.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/tangential_partitioning/tangential_partitioning.cc
@@ -30,6 +30,6 @@ void TangentialPartitioning::adjustPartitioning(int nZnT) {
   }
 }
 
-int TangentialPartitioning::get_thread_id() { return thread_id_; }
+int TangentialPartitioning::get_thread_id() const { return thread_id_; }
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/free_boundary/tangential_partitioning/tangential_partitioning.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/tangential_partitioning/tangential_partitioning.h
@@ -14,7 +14,7 @@ class TangentialPartitioning {
                                   int thread_id = 0);
 
   void adjustPartitioning(int nZnT);
-  int get_thread_id();
+  int get_thread_id() const;
 
   int ztMin;
   int ztMax;

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <span>
 #include <vector>
+#include <numbers>
 
 #include "absl/algorithm/container.h"
 #include "absl/log/check.h"
@@ -1046,7 +1047,7 @@ absl::StatusOr<bool> IdealMhdModel::update(
 
   // re-establish m=1 constraint
   // TODO(jons): why 1/sqrt(2) and not 1/2 ?
-  m_decomposed_f.m1Constraint(1.0 / sqrt(2));
+  m_decomposed_f.m1Constraint(1.0 / std::numbers::sqrt2);
 
   // v8.50: ADD iter2<2 so reset=<WOUT_FILE> works
   if (m_fc.fsqz < 1.0e-6 || iter2 < 2) {

--- a/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.cc
@@ -18,7 +18,7 @@ ProfileParameterizationData::ProfileParameterizationData(
 
 const std::string& ProfileParameterizationData::Name() { return name_; }
 
-bool ProfileParameterizationData::NeedsSplineData() { return needsSplineData_; }
+bool ProfileParameterizationData::NeedsSplineData() const { return needsSplineData_; }
 
 AllowedFor ProfileParameterizationData::IsAllowedFor() { return allowedFor_; }
 

--- a/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.h
@@ -4,6 +4,7 @@
 #ifndef VMECPP_VMEC_PROFILE_PARAMETERIZATION_DATA_PROFILE_PARAMETERIZATION_DATA_H_
 #define VMECPP_VMEC_PROFILE_PARAMETERIZATION_DATA_PROFILE_PARAMETERIZATION_DATA_H_
 
+#include <cstdint>
 #include <cstdlib>
 #include <string>
 
@@ -12,7 +13,7 @@ namespace vmecpp {
 // number of profile parameterizations
 #define NUM_PARAM 23
 
-enum class ProfileType { PRESSURE, CURRENT, IOTA };
+enum class ProfileType : std::uint8_t { PRESSURE, CURRENT, IOTA };
 
 struct AllowedFor {
   bool pres;
@@ -27,7 +28,7 @@ class ProfileParameterizationData {
                               bool needsSplineData);
 
   const std::string& Name();
-  bool NeedsSplineData();
+  bool NeedsSplineData() const;
   AllowedFor IsAllowedFor();
 
  private:
@@ -36,7 +37,7 @@ class ProfileParameterizationData {
   AllowedFor allowedFor_;
 };
 
-enum class ProfileParameterization {
+enum class ProfileParameterization : std::uint8_t {
   INVALID_PARAM = 0,
   POWER_SERIES = 1,
   POWER_SERIES_I = 2,

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -94,9 +94,9 @@ makegrid::MagneticFieldResponseTable MakeMagneticFieldResponseTable(
 }
 
 vmecpp::HotRestartState MakeHotRestartState(
-    vmecpp::WOutFileContents wout, vmecpp::VmecINDATAPyWrapper indata) {
+    vmecpp::WOutFileContents wout, const vmecpp::VmecINDATAPyWrapper& indata) {
   return vmecpp::HotRestartState(std::move(wout),
-                                 vmecpp::VmecINDATA(std::move(indata)));
+                                 vmecpp::VmecINDATA(indata));
 }
 
 }  // anonymous namespace

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
@@ -206,7 +206,7 @@ ProfileParameterization RadialProfiles::findParameterization(
         default:
           std::cerr << absl::StrFormat("unknown profile: %s",
                                        profileTypeToString(intendedType))
-                    << std::endl;
+                    << '\n';
           break;
       }
 
@@ -215,7 +215,7 @@ ProfileParameterization RadialProfiles::findParameterization(
                          "profile name '%s' is not applicable for %s profile",
                          ALL_PARAMS[i].Name(),
                          profileTypeToString(intendedType))
-                  << std::endl;
+                  << '\n';
         return ProfileParameterization::INVALID_PARAM;
       }
 

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -1141,7 +1141,7 @@ void Vmec::performTimeStep(const Sizes& s, const FlowControl& fc,
                            FourierGeometry& m_decomposed_x,
                            FourierVelocity& m_decomposed_v,
                            const FourierForces& decomposed_f,
-                           HandoverStorage& m_h_) {
+                           HandoverStorage& m_h_) const {
   // THIS IS THE TIME-STEP ALGORITHM. IT IS ESSENTIALLY A CONJUGATE
   // GRADIENT METHOD, WITHOUT THE LINE SEARCHES (FLETCHER-REEVES),
   // BASED ON A METHOD GIVEN BY P. GARABEDIAN

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
@@ -129,7 +129,7 @@ class Vmec {
                        FourierGeometry& m_decomposed_x,
                        FourierVelocity& m_decomposed_v,
                        const FourierForces& decomposed_f,
-                       HandoverStorage& m_h_);
+                       HandoverStorage& m_h_) const;
 
   int get_ivac() const { return ivac_; }
   int get_num_eqsolve_retries() const { return num_eqsolve_retries_; }
@@ -180,7 +180,7 @@ class Vmec {
   std::vector<double> bvecShare;
 
  private:
-  enum class SolveEqLoopStatus {
+  enum class SolveEqLoopStatus : std::uint8_t {
     NORMAL_TERMINATION,
     CHECKPOINT_REACHED,
     MUST_RETRY


### PR DESCRIPTION
### TL;DR
Modernizes C++ code by adopting standard math constants, using uint8_t for enums, and improving const correctness.

### What changed?
- Replaced manual calculations of mathematical constants with std::numbers (sqrt2, sqrt3, etc.)
- Added explicit uint8_t type to enum classes for memory optimization
- Made member functions const where appropriate
- Changed std::endl to '\n' according to cppcoreguidelines
- Fixed parameter passing to use const references where possible
