### PR TITLE
Updated Python and OS versions for packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "netCDF4",
   "numpy",
   "pydantic",
+  "jax<=0.5.0",
   "simsopt>=1.8.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,15 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Operating System :: POSIX :: Linux",
+  "Operating System :: MacOS :: MacOS X",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python",
+  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [


### PR DESCRIPTION
- Syncronize  the versions we build wheels for with the versions in .toml
- Add MAC support
- Jax >0.5.0 causes a circular dependency on some systems. Pin for now