### PR TITLE
Test wheels on all kinds of linux distros

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -59,10 +59,108 @@ jobs:
         name: vmecpp-sdist
         path: ./wheelhouse/*.tar.gz
 
+  test-on-different-distros:
+    name: Test Linux distros
+    needs: main
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          [
+            "ubuntu:24.04",
+            "ubuntu:22.04",
+            "archlinux/archlinux",
+            "debian:12",
+            "debian:testing-20250224",
+            "fedora:41",
+          ]
+        test-mpi: [ true, false ]
+    runs-on: ubuntu-24.04
+    container: ${{ matrix.distro }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Python (Distro-Specific)
+        run: |
+          case ${{ matrix.distro }} in
+            ubuntu*|debian*)
+              apt update
+              apt install -y python3-venv
+              ;;
+            fedora*)
+              dnf -y update && dnf clean all
+              dnf -y install python-pip
+              ;;
+            archlinux*)
+              pacman -Sy --noconfirm python-pip
+              ;;
+            *)
+              echo "Unsupported distribution: ${{ matrix.distro }}"
+              exit 1
+              ;;
+          esac
+
+          python3 -m venv venv
+
+      - name: Install OpenMPI (Distro-Specific)
+        if: matrix.test-mpi
+        # mpi4py is a dependency of simsopt and needs a system-wide MPI installation to compile.
+        # This requires both a working OpenMPI installation and Python.h headers.
+        run: |
+          case ${{ matrix.distro }} in
+            ubuntu*|debian*)
+              apt install -y openmpi-bin libopenmpi-dev python3-dev
+              ;;
+            fedora*)
+              dnf install -y openmpi openmpi-devel python-devel
+              ;;
+            archlinux*)
+              pacman -Sy --noconfirm gcc openmpi
+              ;;
+            *)
+              echo "Unsupported distribution: ${{ matrix.distro }}"
+              exit 1
+              ;;
+          esac
+      - name: Download wheels artifact
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: ./wheelhouse/
+      - name: Install wheel
+        # Install the appropriate file for vmecpp from the wheelhouse directory.
+        # --no-index prevents installing from PyPi, so we don't accidentally install
+        # a published version instead of the newly built ones. At the same time it prevents
+        # loading dependencies from PyPi, so the first installation fails. We only use the console output
+        # from this command to get the appropriate .whl file for this platform and environment.
+        run: |
+          ls wheelhouse/
+
+          . venv/bin/activate
+          wheel_filename=$(find wheelhouse/$(python --version | awk '{print $2}' | awk -F. '{printf "vmecpp*-cp%s%s-*manylinux*.whl", $1, $2}'))
+          echo "Found matching wheel: $wheel_filename"
+          if [ ${{ matrix.test-mpi }} = true ]; then
+            # Fedora linux needs to source openmpi in every new shell
+            if [[ ${{ matrix.distro }} = fedora* ]]; then
+              . /etc/profile.d/modules.sh
+              module load mpi/openmpi-x86_64
+            fi
+
+            pip install mpi4py
+          fi
+          pip install $wheel_filename
+
+          pip install pytest
+          python -m pytest tests/
+
+
   pypi-publish:
     name: Publish wheels to PyPI
     if: github.event_name == 'release'
-    needs: [main, make-sdist]
+    needs: [main, make-sdist, test-on-different-distros]
     runs-on: ubuntu-24.04
     environment:
         name: pypi
@@ -71,7 +169,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          path: wheelhouse
+          path: dist/
           merge-multiple: true
 
       - name: Publish package distributions to PyPI

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
         matrix:
-            os: [ubuntu-22.04, ubuntu-24.04, macos-latest]
+            os: [ubuntu-22.04, ubuntu-24.04, macos-14]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ See [below](#differences-with-respect-to-parvmecvmec2000) for more details.
   - [As a command line tool](#as-a-command-line-tool)
   - [As a Docker image](#as-a-docker-image)
 - [Installation](#installation)
-  - [Ubuntu](#ubuntu)
+  - [Ubuntu](#ubuntudebian)
+  - [Arch](#arch-linux)
+  - [Fedora](#fedora)
   - [MacOS](#macos)
   - [As part of a conda environment](#as-part-of-a-conda-environment)
   - [C++ build from source](#c-build-from-source)
@@ -130,11 +132,11 @@ pip install vmecpp
 
 For usage as part of MPI-parallelized SIMSOPT applications, you might want to also install MPI on your machine and `pip install mpi4py`.
 
-Alternatively you can build the latest `vmecpp` directly from source according to the instructions below.
+Alternatively you can build the latest `vmecpp` directly from source according to the appropriate instructions below.
 
-### Ubuntu
+### Ubuntu/Debian
 
-Ubuntu 22.04 and 24.04 are both supported.
+Ubuntu 22.04 and 24.04, as well as Debian 12 are officially supported.
 
 1. Install required system packages:
 ```shell
@@ -152,6 +154,40 @@ The procedure will take a few minutes as it will build VMEC++ and some dependenc
 A common issue on Ubuntu is a build failure due to no `python` executable being available in PATH, since on Ubuntu the executable is called `python3`.
 When installing in a virtual environment (which is always a good idea anyways) `python` will be present.
 Otherwise the Ubuntu package `python-is-python3` provides the `python` alias.
+
+### Arch Linux
+
+1. Install required system packages:
+
+```shell
+pacman -Sy --noconfirm python-pip gcc gcc-fortran openmpi hdf5 netcdf lapack
+```
+
+2. Install VMEC++ as a Python package (possibly after creating a virtual environment):
+
+```shell
+python -m pip install git+https://github.com/proximafusion/vmecpp
+```
+
+### Fedora
+
+[Fedora 41](https://docs.fedoraproject.org/en-US/fedora/f41/release-notes/) is officially supported.
+
+1. Install required system packages:
+
+```shell
+dnf install -y python3.10-devel cmake g++ gfortran openmpi-devel hdf5-devel netcdf-devel lapack-devel
+```
+
+2. Install VMEC++ as a Python package (possibly after creating a virtual environment):
+
+```shell
+# If you are installing with MPI support, remember to source the mpi compiler first
+. /etc/profile.d/modules.sh
+module load mpi/openmpi-x86_64
+python3.10 -m pip install git+https://github.com/proximafusion/vmecpp
+```
+
 
 ### MacOS
 
@@ -298,8 +334,9 @@ Some of the things we are planning for VMEC++'s future:
 - [ ] VMEC++ usable as a C++ bazel module
 
 Some items we do not plan to work on, but where community ownership is welcome:
-- [ ] packaging VMEC++ for other platforms or package managers (e.g. conda, homebrew, ...)
+- [ ] packaging VMEC++ for other platforms or package managers other than pip (e.g. conda, homebrew, ...)
 - [ ] native Windows support
+- [ ] ARM support
 - [ ] 2D preconditioner using [`bcyclic_plus_plus`](https://code.ornl.gov/m4c/bcyclic_plus_plus)
 
 ## Related repositories


### PR DESCRIPTION
### TL;DR
Added comprehensive Linux distribution testing to the PyPI publishing workflow.

### What changed?
Added a new job `test-on-different-distros` that tests the built wheels across multiple Linux distributions including the two newest Ubuntu versions, Arch Linux, Debian, Debian:testing and Fedora (the linux distros we discussed). Each distribution is tested both with and without MPI support.

We could add Fedora and Arch installation instructions, since they are tested in CI anyway
https://github.com/proximafusion/vmecpp/actions/runs/13749659177
