### PR TITLE
Add sdists, moved wheel build settings to .toml so it can be run locally

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -14,13 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            arch: manylinux_x86_64
-          - os: macos-13
-            arch: macosx_x86_64
-          - os: macos-14
-            arch: macosx_arm64
+        # ubuntu-24.04-arm not supported due to lack of netcdf-devel hdf5-devel
+        os: [ubuntu-24.04, macos-13, macos-14]
 
     steps:
       - name: Checkout repository
@@ -30,21 +25,13 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.0
+        # All the settings for cibuildwheel are in pyproject.toml
         env:
-          CIBW_BUILD: "cp*-${{ matrix.arch }}"
-          CIBW_ARCHS_LINUX: "x86_64"
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_34_x86_64
-          CIBW_ARCHS_MACOS: "native"
-          CIBW_BEFORE_BUILD_LINUX: |
-            dnf install -y libomp-devel eigen3-devel lapack-devel json-devel netcdf-devel hdf5-devel
-          CIBW_BEFORE_BUILD_MACOS: |
-            brew install gcc libomp eigen lapack nlohmann-json protobuf netcdf hdf5
           CIBW_ENVIRONMENT_MACOS: >
             MACOSX_DEPLOYMENT_TARGET=${{ matrix.os == 'macos-14' && '14.0' || '13.0' }}
             DYLD_LIBRARY_PATH=/usr/local/opt/gcc/lib/gcc/current/:$DYLD_LIBRARY_PATH
             FC=gfortran-14
             HDF5_ROOT=$(brew --prefix hdf5)
-          CIBW_BUILD_FRONTEND: "build"
         with:
           package-dir: .
           output-dir: wheelhouse
@@ -56,11 +43,31 @@ jobs:
           name: vmecpp-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
+  make-sdist:
+    name: Make SDist
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Build SDist
+      run: pipx run build --sdist
+
+    - name: Move Files
+      run: mv dist wheelhouse
+
+    - name: Upload SDist
+      uses: actions/upload-artifact@v4
+      with:
+        name: vmecpp-sdist
+        path: ./wheelhouse/*.tar.gz
+
   pypi-publish:
     name: Publish wheels to PyPI
     if: github.event_name == 'release'
-    needs: main
-    runs-on: ubuntu-latest
+    needs: [main, make-sdist]
+    runs-on: ubuntu-24.04
     environment:
         name: pypi
     permissions:
@@ -69,6 +76,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: wheelhouse
+          merge-multiple: true
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 
 # python build outputs
 dist/
+wheelhouse/
 __pycache__
 
 # bazel output directories

--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ more information and instructions on how to build a new image.
 
 ## Installation
 
+The easiest method for installing `vmecpp` is using pip:
+```shell
+pip install vmecpp
+```
+
+For usage as part of MPI-parallelized SIMSOPT applications, you might want to also install MPI on your machine and `pip install mpi4py`.
+
+Alternatively you can build the latest `vmecpp` directly from source according to the instructions below.
+
 ### Ubuntu
 
 Ubuntu 22.04 and 24.04 are both supported.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "scikit-build-core~=0.10.0"]
+requires = ["hatchling", "scikit-build-core~=0.10.0", "pybind11"]
 build-backend = "hatchling.build"
 
 [project]
@@ -33,7 +33,7 @@ dependencies = [
   "netCDF4",
   "numpy",
   "pydantic",
-  "jax<=0.5.0",
+  "jax<=0.5.0", # To prevent a circular import bug in jax on arch Linux
   "simsopt>=1.8.1",
 ]
 
@@ -63,6 +63,19 @@ experimental = true
 
 [tool.hatch.build.targets.wheel.force-include]
 "src/vmecpp/cpp/vmecpp/simsopt_compat" = "vmecpp/cpp/vmecpp/simsopt_compat"
+
+[tool.cibuildwheel]
+archs = ["native"]
+skip = ["pp*", "*-musllinux*"]
+build-frontend = "build"
+test-requires = "pytest"
+test-command = "pytest {package}/tests/test_simsopt_compat.py"
+
+[tool.cibuildwheel.linux]
+before-build = "yum install -y libgomp eigen3-devel lapack-devel json-devel netcdf-devel hdf5-devel"
+
+[tool.cibuildwheel.macos]
+before-build = "brew install gcc libomp eigen lapack nlohmann-json protobuf netcdf hdf5"
 
 [tool.hatch.envs.test]
 dependencies = [


### PR DESCRIPTION
Split the PR https://github.com/proximafusion/vmecpp/pull/143 into smaller contributions.

- Configured cibuildwheel settings in pyproject.toml instead of in the workflow script, so that running `cibuildwheel` locally is more easily reproducible
- Added SDist creation step to the publishing workflow
- Updated README with pip installation instructions
- Added wheelhouse to gitignore
