### PR TITLE
MPI optional

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,6 +56,6 @@ jobs:
           # on Ubuntu we would not need this, but on MacOS we need to point CMake to gfortran-14 and gcc-14
           export FC=$(which gfortran-14 || which gfortran)
           export CC=$(which gcc-14 || which gcc)
-          python -m pip install -v .[test]
+          python -m pip install -v .[test,MPI]
       - name: Test package
         run: python -m pytest tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
 dependencies = [
   "beartype",
   "jaxtyping",
-  "mpi4py",
   "netCDF4",
   "numpy",
   "pydantic",

--- a/src/vmecpp/simsopt_compat.py
+++ b/src/vmecpp/simsopt_compat.py
@@ -14,7 +14,6 @@ from typing import Any, Optional, cast
 
 import numpy as np
 from jaxtyping import Bool, Float
-from mpi4py import MPI
 from numpy.typing import NDArray
 from scipy.io import netcdf_file
 from simsopt._core.optimizable import Optimizable
@@ -38,7 +37,12 @@ logger = logging.getLogger(__name__)
 #
 # Creating an MpiPartition hogs memory until process exit, so we do it here once at
 # module scope rather than every time Vmec.__init__ is called.
-MPI_PARTITION = MpiPartition(ngroups=1)
+try:
+    from mpi4py import MPI
+
+    MPI_PARTITION = MpiPartition(ngroups=1)
+except ImportError:
+    MPI = None
 
 
 class Vmec(Optimizable):


### PR DESCRIPTION
Split the PR https://github.com/proximafusion/vmecpp/pull/143 into smaller contributions.


MPI is an optional dependency in simsopt, and we only include it _because of_ simsopt, so it should match the optional behavior.