### PR TITLE
Replaced remaining lapacke references with lapack

### DIFF
--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -23,7 +23,7 @@ jobs:
           lfs: true  # for the mgrid test data
       - name: Install required system packages for Ubuntu
         run: |
-          sudo apt-get update && sudo apt-get install -y build-essential cmake gcc g++ libeigen3-dev libhdf5-dev liblapacke-dev libnetcdf-dev libopenmpi-dev nlohmann-json3-dev python3-pip python-is-python3
+          sudo apt-get update && sudo apt-get install -y build-essential cmake gcc g++ libeigen3-dev libhdf5-dev liblapack-dev libnetcdf-dev libopenmpi-dev nlohmann-json3-dev python3-pip python-is-python3
       - name: Build VMEC++ via bazel
         run: |
           cd src/vmecpp/cpp

--- a/.github/workflows/clang_tidy.yaml
+++ b/.github/workflows/clang_tidy.yaml
@@ -33,7 +33,7 @@ jobs:
           lfs: true  # for the mgrid test data
       - name: Install required system packages for Ubuntu
         run: |
-          sudo apt-get update && sudo apt-get install -y build-essential cmake gcc g++ libeigen3-dev libhdf5-dev liblapacke-dev libnetcdf-dev libopenmpi-dev nlohmann-json3-dev python3-pip python-is-python3
+          sudo apt-get update && sudo apt-get install -y build-essential cmake gcc g++ libeigen3-dev libhdf5-dev liblapack-dev libnetcdf-dev libopenmpi-dev nlohmann-json3-dev python3-pip python-is-python3
       - name: Generate compile_commands.json for clang-tidy
         run: |
           cmake -DCMAKE_EXPORT_COMPILE_COMMANDS:STRING=ON .

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -32,7 +32,7 @@ jobs:
           python-version: "3.10"
       - name: Build docs
         run: |
-          sudo apt-get install libnetcdf-dev liblapacke-dev libopenmpi-dev libeigen3-dev nlohmann-json3-dev libhdf5-dev
+          sudo apt-get install libnetcdf-dev liblapack-dev libopenmpi-dev libeigen3-dev nlohmann-json3-dev libhdf5-dev
           # must actually install the package otherwise sphinx can't autogenerate the API reference
           python -m pip install -vvv .[docs]
           sphinx-apidoc --module-first --no-toc --force --separate -o docs/api src/vmecpp/ && sphinx-build docs html_docs

--- a/.github/workflows/test_bazel.yaml
+++ b/.github/workflows/test_bazel.yaml
@@ -23,7 +23,7 @@ jobs:
           lfs: true  # for the mgrid test data
       - name: Install required system packages for Ubuntu
         run: |
-          sudo apt-get update && sudo apt-get install -y build-essential cmake gcc g++ libeigen3-dev libhdf5-dev liblapacke-dev libnetcdf-dev libopenmpi-dev nlohmann-json3-dev python3-pip python-is-python3
+          sudo apt-get update && sudo apt-get install -y build-essential cmake gcc g++ libeigen3-dev libhdf5-dev liblapack-dev libnetcdf-dev libopenmpi-dev nlohmann-json3-dev python3-pip python-is-python3
       - name: Build VMEC++ via bazel
         run: |
           cd src/vmecpp/cpp

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,7 +44,7 @@ jobs:
         if: ${{ contains(matrix.os, 'ubuntu') }}
         run: |
           # install VMEC++ deps as well as VMEC2000 deps (we need to import VMEC2000 in a test)
-          sudo apt-get update && sudo apt-get install libnetcdf-dev liblapacke-dev libopenmpi-dev libeigen3-dev nlohmann-json3-dev libhdf5-dev libnetcdff-dev libscalapack-openmpi-dev libopenblas-dev
+          sudo apt-get update && sudo apt-get install libnetcdf-dev liblapack-dev libopenmpi-dev libeigen3-dev nlohmann-json3-dev libhdf5-dev libnetcdff-dev libscalapack-openmpi-dev libopenblas-dev
       - name: Also install VMEC2000 (only on Ubuntu 22.04)
         if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: |

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Ubuntu 22.04 and 24.04 are both supported.
 
 1. Install required system packages:
 ```shell
-sudo apt-get install build-essential cmake libnetcdf-dev liblapacke-dev libopenmpi-dev libeigen3-dev nlohmann-json3-dev libhdf5-dev
+sudo apt-get install build-essential cmake libnetcdf-dev liblapack-dev libopenmpi-dev libeigen3-dev nlohmann-json3-dev libhdf5-dev
 ```
 
 2. Install VMEC++ as a Python package (possibly after creating a dedicated virtual environment):

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 FROM ubuntu:22.04
 
 RUN apt-get -q update && \
-    apt-get -q -y install build-essential libnetcdf-dev liblapacke-dev libopenmpi-dev python3-pip python-is-python3 git wget ninja-build libeigen3-dev nlohmann-json3-dev
+    apt-get -q -y install build-essential libnetcdf-dev liblapack-dev libopenmpi-dev python3-pip python-is-python3 git wget ninja-build libeigen3-dev nlohmann-json3-dev
 RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.24.1/bazelisk-linux-amd64 \
     && mv bazelisk-linux-amd64 /usr/local/bin/bazel \
     && chmod u+x /usr/local/bin/bazel

--- a/environment.yml
+++ b/environment.yml
@@ -51,7 +51,6 @@ dependencies:
   - libiconv=1.17=hd590300_2
   - libjpeg-turbo=3.0.0=hd590300_1
   - liblapack=3.9.0=6_ha36c22a_netlib
-  - liblapacke=3.9.0=0_h6e990d7_netlib
   - liblzma=5.6.3=hb9d3cd8_1
   - libnetcdf=4.9.2=nompi_h00e09a9_116
   - libnghttp2=1.64.0=h161d5f1_0


### PR DESCRIPTION
Replaces all remaining references, to lapacke as it is not available on all systems and vmecpp only depends on lapack after the helpful PR https://github.com/proximafusion/vmecpp/pull/113