### PR TITLE
Match bazel version of pybind11 to version in CMakeLists.txt

### DIFF
--- a/src/vmecpp/cpp/MODULE.bazel
+++ b/src/vmecpp/cpp/MODULE.bazel
@@ -11,9 +11,21 @@ bazel_dep(name = "googletest", version = "1.14.0")
 bazel_dep(name = "nlohmann_json", version = "3.11.3")
 
 # Pybind11: see https://github.com/pybind/pybind11_bazel#bzlmod
-bazel_dep(name = "pybind11_bazel", version = "2.11.1")
+bazel_dep(name = "pybind11_bazel", version = "2.13.6")
+
 python_configure = use_extension("@pybind11_bazel//:python_configure.bzl", "extension")
 use_repo(python_configure, "local_config_python", "pybind11")
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "rules_foreign_cc", version = "0.12.0")
+
+
+bazel_dep(name = "rules_python", version = "0.34.0")
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    configure_coverage_tool = True,
+    # Only set when you have multiple toolchain versions.
+    is_default = True,
+    python_version = "3.10",
+    ignore_root_user_error = True,
+)


### PR DESCRIPTION
This is part of the effort of migrating all remaining changes from repo to the open source vmecpp

This migrates:
https://github.com/proximafusion/repo/commit/e77cae36f918a0a72315e0b98a5501b7ee7aca00