### PR TITLE
Removed unused field from IdealMhdModel

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -462,14 +462,13 @@ namespace vmecpp {
 
 IdealMhdModel::IdealMhdModel(
     FlowControl* m_fc, const Sizes* s, const FourierBasisFastPoloidal* t,
-    RadialProfiles* m_p, const Boundaries* b, const VmecConstants* constants,
+    RadialProfiles* m_p, const VmecConstants* constants,
     ThreadLocalStorage* m_ls, HandoverStorage* m_h, const RadialPartitioning* r,
     FreeBoundaryBase* m_fb, int signOfJacobian, int nvacskip, int* m_ivac)
     : m_fc_(*m_fc),
       s_(*s),
       t_(*t),
       m_p_(*m_p),
-      b_(*b),
       constants_(*constants),
       m_ls_(*m_ls),
       m_h_(*m_h),

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
@@ -64,7 +64,7 @@ class IdealMhdModel {
  public:
   IdealMhdModel(FlowControl* m_fc, const Sizes* s,
                 const FourierBasisFastPoloidal* t, RadialProfiles* m_p,
-                const Boundaries* b, const VmecConstants* constants,
+                const VmecConstants* constants,
                 ThreadLocalStorage* m_ls, HandoverStorage* m_h,
                 const RadialPartitioning* r, FreeBoundaryBase* m_fb,
                 int signOfJacobian, int nvacskip, int* m_ivac);
@@ -415,7 +415,6 @@ class IdealMhdModel {
   const Sizes& s_;
   const FourierBasisFastPoloidal& t_;
   RadialProfiles& m_p_;
-  const Boundaries& b_;
   const VmecConstants& constants_;
   ThreadLocalStorage& m_ls_;
   HandoverStorage& m_h_;

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -451,7 +451,7 @@ bool Vmec::InitializeRadial(
 
       // setup MHD model
       m_[thread_id] = std::make_unique<IdealMhdModel>(
-          &fc_, &s_, &t_, p_[thread_id].get(), &b_, &constants_,
+          &fc_, &s_, &t_, p_[thread_id].get(), &constants_,
           ls_[thread_id].get(), &h_, r_[thread_id].get(), fb_[thread_id].get(),
           kSignOfJacobian, indata_.nvacskip, &ivac_);
       m_[thread_id]->setFromINDATA(indata_.ncurr, indata_.gamma, indata_.tcon0);


### PR DESCRIPTION
It is not clear to me, why the boundaries object had to be passed to `IdealMhdModel`, if there is a reason feel free to close.