### PR TITLE
Support string path in FortranWOutAdapter.save

### DIFF
--- a/src/vmecpp/cpp/vmecpp/simsopt_compat/_fortran_wout_adapter.py
+++ b/src/vmecpp/cpp/vmecpp/simsopt_compat/_fortran_wout_adapter.py
@@ -435,12 +435,13 @@ class FortranWOutAdapter(pydantic.BaseModel):
 
         return FortranWOutAdapter(**attrs)
 
-    def save(self, out_path: Path) -> None:
+    def save(self, out_path: str | Path) -> None:
         """Save contents in NetCDF3 format.
 
         This is the format used by Fortran VMEC implementations and the one expected by
         SIMSOPT.
         """
+        out_path = Path(out_path)
         # protect against possible confusion between the C++ WOutFileContents::Save
         # and this method
         if out_path.suffix == ".h5":


### PR DESCRIPTION
### TL;DR

Allow string paths in `FortranWOutAdapter.save()` method to improve API flexibility.

### What changed?

- Modified the `save()` method in `FortranWOutAdapter` to accept both string and Path objects as input
- Added internal conversion of string paths to Path objects
- Updated the method's type hint to reflect this change (`str | Path`)
- Added a parameterized test to verify both string and Path inputs work correctly

### Why make this change?
This was the only method that didn't accept strings as file paths. It's a common usecase when passing a path directly to write `save("test.h5")` without converting to a Path object before.