### PR TITLE
Print version info with help message

### DIFF
--- a/src/vmecpp/__main__.py
+++ b/src/vmecpp/__main__.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 import argparse
+import importlib.metadata
 from pathlib import Path
 
 import vmecpp
@@ -27,6 +28,13 @@ def parse_arguments() -> argparse.Namespace:
         "--quiet",
         help="If present, silences the printing of VMEC++ logs to standard output.",
         action="store_true",
+    )
+    p.add_argument(
+        "-v",
+        "--version",
+        help="Print VMEC++ version information and exit.",
+        action="version",
+        version=f"vmecpp v{importlib.metadata.version('vmecpp')}",
     )
     return p.parse_args()
 


### PR DESCRIPTION
Tiny quality of life improvement imho, if you don't like it feel free too close.

## How to test
`python src/vmecpp/__main__.py -h`

```log
usage: __main__.py [-h] [-t MAX_THREADS] [-q] [-v] input_file

VMEC++ is a free-boundary ideal-MHD equilibrium solver for stellarators and tokamaks.

positional arguments:
  input_file            A VMEC input file either in the classic Fortran 'indata' format or in VMEC++'s JSON format.

options:
  -h, --help            show this help message and exit
  -t MAX_THREADS, --max-threads MAX_THREADS
                        Maximum number of threads that VMEC++ should spawn. The actual number might still be lower that this in case there are too few flux
                        surfaces to keep these many threads busy.
  -q, --quiet           If present, silences the printing of VMEC++ logs to standard output.
  -v, --version         Print VMEC++ version information and exit.

```

`python src/vmecpp/__main__.py -v`
```log
vmecpp v0.2.1
```