### PR TITLE
Expose FB hot-restart in Python

### DIFF
--- a/examples/freeboundary_run_and_hot_restart.py
+++ b/examples/freeboundary_run_and_hot_restart.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+"""Hot-restart from a converged equilibrium."""
+
+from pathlib import Path
+
+import vmecpp
+
+# Load the VMEC++ JSON indata file.
+# Its keys have 1:1 correspondence with those in a classic Fortran INDATA file.
+TEST_DATA_DIR = Path("src") / "vmecpp" / "cpp" / "vmecpp" / "test_data"
+vmec_input_filename = TEST_DATA_DIR / "cth_like_free_bdy.json"
+coils_fname = TEST_DATA_DIR / "coils.cth_like"
+makegrid_params_fname = TEST_DATA_DIR / "makegrid_parameters_cth_like.json"
+
+vmec_input = vmecpp.VmecInput.from_file(vmec_input_filename)
+# We don't need an mgrid file, because we are passing the magnetic field as an object in memory
+vmec_input.mgrid_file = ""
+
+mgrid_params = vmecpp._vmecpp.MakegridParameters.from_file(makegrid_params_fname)
+magnetic_configuration = vmecpp._vmecpp.MagneticConfiguration.from_file(coils_fname)
+magnetic_response_table = vmecpp._vmecpp.compute_magnetic_field_response_table(
+    mgrid_params, magnetic_configuration
+)
+# Let's run VMEC++.
+# In case of errors or non-convergence, a RuntimeError is raised.
+# The OutputQuantities object returned has attributes corresponding
+# to the usual outputs: wout, jxbout, mercier, ...
+vmec_output = vmecpp.run(vmec_input, magnetic_field=magnetic_response_table)
+print("  initial volume:", vmec_output.wout.volume_p)
+
+# Now let's perturb the plasma boundary a little bit...
+vmec_input.rbc[0, 0] *= 0.8
+vmec_input.rbc[1, 0] *= 1.2
+
+# ...and run VMEC++ again, but using its "hot restart" feature:
+# passing the previously obtained output_quantities ensures that
+# the run starts already close to the equilibrium, so it will take
+# very few iterations to converge this time.
+perturbed_output = vmecpp.run(
+    vmec_input, magnetic_field=magnetic_response_table, restart_from=vmec_output
+)
+print("perturbed volume:", perturbed_output.wout.volume_p)
+print("Difference:      ", vmec_output.wout.volume_p - perturbed_output.wout.volume_p)

--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -1286,14 +1286,21 @@ class VmecOutput(pydantic.BaseModel):
 
 def run(
     input: VmecInput,
+    magnetic_field: _vmecpp.MagneticFieldResponseTable | None = None,
+    *,
     max_threads: int | None = None,
     verbose: bool = True,
     restart_from: VmecOutput | None = None,
 ) -> VmecOutput:
-    """Run VMEC++ using the provided input.
+    """Run VMEC++ using the provided input. This is the main entrypoint for both fixed-
+    and free-boundary calculations.
 
     Args:
         input: a VmecInput instance, corresponding to the contents of a classic VMEC input file
+        magnetic_field: if present, VMEC++ will pass the magnetic field object in memory instead of reading
+            it from an mgrid file (only relevant in free-boundary runs).
+
+    Keyword Args:
         max_threads: maximum number of threads that VMEC++ should spawn. The actual number might still
             be lower that this in case there are too few flux surfaces to keep these many threads
             busy. If None, a number of threads equal to the number of logical cores is used.
@@ -1301,6 +1308,14 @@ def run(
         restart_from: if present, VMEC++ is initialized using the converged equilibrium from the
             provided VmecOutput. This can dramatically decrease the number of iterations to
             convergence when running VMEC++ on a configuration that is very similar to the `restart_from` equilibrium.
+
+    Example:
+        >>> import vmecpp
+        >>> path = "examples/data/solovev.json"
+        >>> vmec_input = vmecpp.VmecInput.from_file(path)
+        >>> output = vmecpp.run(vmec_input, verbose=False, max_threads=1)
+        >>> round(output.wout.b0, 14) # Exact value may differ by C library
+        0.20333137113443
     """
     input = VmecInput.model_validate(input)
     cpp_indata = input._to_cpp_vmecindatapywrapper()
@@ -1320,12 +1335,24 @@ def run(
         )
         raise RuntimeError(msg)
 
-    cpp_output_quantities = _vmecpp.run(
-        cpp_indata,
-        initial_state=initial_state,
-        max_threads=max_threads,
-        verbose=verbose,
-    )
+    if magnetic_field is None:
+        cpp_output_quantities = _vmecpp.run(
+            cpp_indata,
+            initial_state=initial_state,
+            max_threads=max_threads,
+            verbose=verbose,
+        )
+    else:
+        # magnetic_response_table takes precedence anyway, but let's be explicit, to ensure
+        # we don't silently use the mgrid file in input, instead of the magnetic_response_table object.
+        cpp_indata.mgrid_file = ""
+        cpp_output_quantities = _vmecpp.run(
+            cpp_indata,
+            magnetic_response_table=magnetic_field,
+            initial_state=initial_state,
+            max_threads=max_threads,
+            verbose=verbose,
+        )
 
     cpp_wout = cpp_output_quantities.wout
     wout = VmecWOut._from_cpp_wout(cpp_wout)

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -765,8 +765,8 @@ PYBIND11_MODULE(_vmecpp, m) {
       "run",
       [](const VmecINDATAPyWrapper &indata,
          const makegrid::MagneticFieldResponseTable &magnetic_response_table,
-         std::optional<vmecpp::HotRestartState> initial_state = std::nullopt,
-         std::optional<int> max_threads = std::nullopt, bool verbose = true) {
+         std::optional<vmecpp::HotRestartState> initial_state,
+         std::optional<int> max_threads, bool verbose = true) {
         auto ret =
             vmecpp::run(vmecpp::VmecINDATA(indata), magnetic_response_table,
                         std::move(initial_state), max_threads, verbose);


### PR DESCRIPTION
The discussed API change for `vmecpp.run()` and a free boundary hot restart example. 

For now using the CPP API for the MagneticFieldResponseTable.