### PR TITLE
simsopt_compat.Vmec should to use Python API instead of CPP API

### DIFF
--- a/tests/cpp/vmecpp/vmec/pybind11/test_pybind_vmec.py
+++ b/tests/cpp/vmecpp/vmec/pybind11/test_pybind_vmec.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 """Tests for VMEC++ pybind11 Python bindings."""
 
+import tempfile
 from pathlib import Path
 
 import numpy as np
@@ -586,3 +587,16 @@ def test_magneticfieldresponsetable_constructor():
     np.testing.assert_allclose(
         magnetic_field_response_table.b_z, magnetic_field_component
     )
+
+
+def test_file_write():
+    indata = vmec.VmecINDATAPyWrapper.from_file(TEST_DATA_DIR / "cma.json")
+    output_quantities = vmec.run(indata)
+    assert output_quantities is not None
+    # Works with both Path and string call signature
+    for path_type in [Path, str]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "h5test.h5"
+            assert not path.exists()
+            output_quantities.save(path_type(path))
+            assert path.exists()

--- a/tests/test_simsopt_compat.py
+++ b/tests/test_simsopt_compat.py
@@ -4,7 +4,6 @@
 """Tests for VMEC++'s'SIMSOPT compatibility layer."""
 
 import math
-import tempfile
 from pathlib import Path
 
 import netCDF4
@@ -55,17 +54,6 @@ def test_aspect(vmec, reference_wout):
     aspect = vmec.aspect()
     expected_aspect = reference_wout.variables["aspect"][()]
     np.testing.assert_allclose(aspect, expected_aspect, rtol=1e-11, atol=0.0)
-
-
-def test_file_write(vmec):
-    assert vmec.output_quantities is not None
-    # Works with both Path and string call signature
-    for path_type in [Path, str]:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            path = Path(tmpdir) / "h5test.h5"
-            assert not path.exists()
-            vmec.output_quantities.save(path_type(path))
-            assert path.exists()
 
 
 def test_volume(vmec, reference_wout):


### PR DESCRIPTION
### TL;DR

Refactored the SIMSOPT compatibility layer to use the new Pydantic-based `VmecInput` and `VmecOutput` classes instead of the C++ wrapper classes.


> [!NOTE]
> @eguiraud-pf Does the `vmecpp.VmecWOut` object satisfy all requirements for `Vmec.wout`, or should it be wrapped in the `FortranWOutAdapter`?

### Why make this change?

This change aligns the SIMSOPT compatibility layer with the vmecpp.run signature.

### What changed?

- Replaced `vmec.VmecINDATAPyWrapper` with `vmecpp.VmecInput` throughout the code
- Updated the `FortranWOutAdapter` usage to directly use `vmecpp.VmecWOut` 
- Modified the `run()` method to accept a `restart_from` parameter instead of `initial_state`
- Updated the parameter types in function signatures to be more explicit
- Fixed the `set_mpol_ntor` method to work with the new Pydantic model by converting to and from the C++ wrapper
- Changed a logging call from `logging.warning` to `logger.warning` for consistency