### PR TITLE
Move from hatchling to scikit-build-core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 dist/
 wheelhouse/
 __pycache__
+src/vmecpp/__about__.py
 
 # bazel output directories
 bazel-*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling", "scikit-build-core~=0.10.0", "pybind11"]
-build-backend = "hatchling.build"
+requires = ["scikit-build-core~=0.11.0", "pybind11", "numpy"] # numpy is needed for some scikit-build-core features.
+build-backend = "scikit_build_core.build"
 
 [project]
 name = "vmecpp"
@@ -54,14 +54,25 @@ Documentation = "https://github.com/proximafusion/vmecpp#readme"
 Issues = "https://github.com/proximafusion/vmecpp/issues"
 Source = "https://github.com/proximafusion/vmecpp"
 
-[tool.hatch.version]
-path = "src/vmecpp/__about__.py"
+[tool.scikit-build]
+cmake.build-type = "Release"
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
+sdist.exclude = [
+    "src/vmecpp/cpp/vmecpp/test_data/",
+    "docs/",
+    ".github/",
+]
+cmake.verbose = true
+# Caching directory for wheel builds
+build-dir = "build"
+# When vmecpp is installed in editable mode
+# pip install -e .
+# it will check if the C++ sources have changed on each package import and rebuild individual files as needed
+editable.rebuild = true
 
-[tool.hatch.build.targets.wheel.hooks.scikit-build]
-experimental = true
+[tool.setuptools_scm]
+version_file = "src/vmecpp/__about__.py"
 
-[tool.hatch.build.targets.wheel.force-include]
-"src/vmecpp/cpp/vmecpp/simsopt_compat" = "vmecpp/cpp/vmecpp/simsopt_compat"
 
 [tool.cibuildwheel]
 archs = ["native"]
@@ -75,11 +86,6 @@ before-build = "yum install -y lapack-devel netcdf-devel hdf5-devel libomp-devel
 
 [tool.cibuildwheel.macos]
 before-build = "brew install gcc lapack netcdf hdf5 libomp"
-
-[tool.hatch.envs.test]
-dependencies = [
-  "pytest"
-]
 
 [tool.coverage.run]
 source_pkgs = ["vmecpp", "tests"]

--- a/src/vmecpp/__about__.py
+++ b/src/vmecpp/__about__.py
@@ -1,5 +1,0 @@
-# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
-#
-# SPDX-License-Identifier: MIT
-# NOTE: must also update src/vmecpp/cpp/MODULE.bazel
-__version__ = "0.2.1"


### PR DESCRIPTION
## Why do we need this?
- It was wrapping scikit-build-core anyway, now we have one less dependency
- Hatchling didn't allow editable installs, complicating local Python development without rebuilding the entire source
  - the lack of editable installs also caused issues installing `vmecpp` with `uv pip install` 
## Bonus improvement ✨ 
- Automatically get release version from git tag with `setuptools_scm`  https://setuptools-scm.readthedocs.io/en/stable/usage/