### PR TITLE
Terminate Fortran namelist files only with / not / and &END

### DIFF
--- a/src/vmecpp/_util.py
+++ b/src/vmecpp/_util.py
@@ -224,7 +224,7 @@ def vmecpp_json_to_indata(vmecpp_json: dict[str, Any]) -> str:
     indata += _fourier_coefficients_to_namelist("rbs", vmecpp_json)
     indata += _fourier_coefficients_to_namelist("zbc", vmecpp_json)
 
-    indata += "\n/\n&END\n"
+    indata += "\n/\n"
 
     return indata
 


### PR DESCRIPTION
&END is not part of the modern Fortran spec, apparently it is a leftover from some older Fortran compilers?

Some tools for parsing Fortran have difficulties with the termination syntax we use, e.g. f90nml which is used in simsopt.
## Minimal example
```python
import f90nml
f90nml.read("src/vmecpp/cpp/vmecpp/test_data/input.cth_like_free_bdy")
```
Terminates because the `INDATA` group was closed before. Either / or &END work, but not both. 

I suggest to use the more widespread / syntax for closing. LIBSTELL supports this, simsopt does, and it is standard compliant.

https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2024-2/namelist.html

https://jules-lsm.github.io/latest/namelists/intro.html

