### PR TITLE
Fully support and test  editable installs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,6 +29,7 @@ jobs:
     strategy:
         matrix:
             os: [ubuntu-22.04, ubuntu-24.04, macos-14]
+            editable: [true, false]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -62,7 +63,11 @@ jobs:
           if [[ ${{ contains(matrix.os, 'macos') }} == true ]]; then
             export OpenMP_ROOT=$(brew --prefix)/opt/libomp
           fi
-          python -m pip install -v .[test]
+          if [[ ${{ matrix.editable }} == true ]]; then
+            python -m pip install -e .[test]
+          else
+            python -m pip install -v .[test]
+          fi
       - name: Test package
         run: python -m pytest tests/
       - name: Test docstring examples

--- a/src/vmecpp/_util.py
+++ b/src/vmecpp/_util.py
@@ -1,6 +1,7 @@
 """The usual hodgepodge of helper utilities without a better home."""
 
 import contextlib
+import importlib.metadata
 import logging
 import os
 import shutil
@@ -20,6 +21,7 @@ def package_root() -> Path:
     Useful e.g. to point tests to test files using paths relative to the repo root
     rather than paths relative to the test module.
     """
+
     return Path(__file__).parent
 
 
@@ -86,9 +88,16 @@ def indata_to_json(
         msg = f"{filename} does not exist."
         raise FileNotFoundError(msg)
 
-    indata_to_json_exe = Path(
-        package_root(), "cpp", "third_party", "indata2json", "indata2json"
+    # Get the path to the packaged indata2json executable.
+    # For virtual environments, package_root() points to the source files,
+    # but this method will return the correct install location e.g. in your virtual environment.
+    indata_package_path = next(
+        filter(
+            lambda path: path.stem == "indata2json", importlib.metadata.files("vmecpp")
+        )
     )
+    indata_to_json_exe = indata_package_path.locate()
+
     if not indata_to_json_exe.is_file():
         msg = f"{indata_to_json_exe} is not a file."
         raise FileNotFoundError(msg)

--- a/src/vmecpp/_util.py
+++ b/src/vmecpp/_util.py
@@ -21,8 +21,19 @@ def package_root() -> Path:
     Useful e.g. to point tests to test files using paths relative to the repo root
     rather than paths relative to the test module.
     """
-
     return Path(__file__).parent
+
+
+def distribution_root() -> Path:
+    """The path to the install location of this package. This may be the same as
+    package_root, but doesn't have to be.
+
+    The two differ in editable installations, where package_root() will point to the
+    source files, and distribution will point the /site-packages/vmecpp folder of your
+    python environment. It is the correct path to use for accessing shared libraries and
+    executables that come with vmecpp.
+    """
+    return importlib.metadata.distribution("vmecpp").locate_file("vmecpp")
 
 
 @contextlib.contextmanager
@@ -88,16 +99,9 @@ def indata_to_json(
         msg = f"{filename} does not exist."
         raise FileNotFoundError(msg)
 
-    # Get the path to the packaged indata2json executable.
-    # For virtual environments, package_root() points to the source files,
-    # but this method will return the correct install location e.g. in your virtual environment.
-    indata_package_path = next(
-        filter(
-            lambda path: path.stem == "indata2json", importlib.metadata.files("vmecpp")
-        )
+    indata_to_json_exe = (
+        distribution_root() / "cpp" / "third_party" / "indata2json" / "indata2json"
     )
-    indata_to_json_exe = indata_package_path.locate()
-
     if not indata_to_json_exe.is_file():
         msg = f"{indata_to_json_exe} is not a file."
         raise FileNotFoundError(msg)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -53,3 +53,14 @@ def test_indata_to_json_not_found_file():
 def test_package_root():
     # check we can find a file that should be there from the repo root
     assert Path(_util.package_root(), "_util.py").is_file()
+
+
+def test_distributino_root():
+    assert _util.distribution_root().is_dir()
+    assert (
+        _util.distribution_root()
+        / "cpp"
+        / "third_party"
+        / "indata2json"
+        / "indata2json"
+    ).is_file()


### PR DESCRIPTION
### TL;DR

Fix package resource discovery to support editable installs and add editable install testing to CI.

### What changed?

- Modified the GitHub Actions workflow to test both regular and editable installs by adding a conditional pip install command
- Improved `indata_to_json()` to find the executable using `importlib.metadata.files()` rather than assuming a fixed location relative to the source files, because repo_root broke on editable.

> [!NOTE]
> Required checks are not finishing because the CI test names include editable=true/false due to this change, so they don't match the required check names. Will adjust the required checks once approved.