### PR TITLE
Make the stellarator asymetric fields optional in the datamodel

### DIFF
--- a/examples/python_api.py
+++ b/examples/python_api.py
@@ -7,18 +7,13 @@ from pathlib import Path
 
 import vmecpp
 
-# NOTE: This resolves to src/vmecpp/cpp/vmecpp/test_data in the repo.
-TEST_DATA_DIR = (
-    Path(__file__).parent.parent / "src" / "vmecpp" / "cpp" / "vmecpp" / "test_data"
-)
-
 
 def run_vmecpp():
     # We need a VmecInput, a Python object that corresponds
     # to the classic "input.*" files.
     # We can construct it from such a classic VMEC input file
     # (Fortran namelist called INDATA):
-    input_file = TEST_DATA_DIR / "input.solovev"
+    input_file = Path(__file__).parent / "data" / "input.solovev"
     input = vmecpp.VmecInput.from_file(input_file)
 
     # Now we can run VMEC++:

--- a/examples/python_api_input.py
+++ b/examples/python_api_input.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+"""How to modify a VmecInput object via the Python API."""
+
+from pathlib import Path
+
+import vmecpp
+
+
+def modify_input_and_run():
+    input_file = Path(__file__).parent / "data" / "input.solovev"
+    input = vmecpp.VmecInput.from_file(input_file)
+
+    # Since VmecInput is a Python object, we can easily
+    # interact with it, e.g. by modifying the coefficients:
+    input.rbc *= 1.1
+    input.zbs *= 1.1
+
+    # Note that the shapes of input arrays are validated and handled strictly,
+    # so data isn't implicitly ignored or padded. In this example VmecInput
+    # fails validation, because rbc has the wrong shape (2,1) when a configuration
+    # with mpol=6 requires rbc.shape == (6,1):
+    input.rbc = [[4.4], [1.13]]
+    try:
+        vmecpp.run(input)
+    except ValueError as e:
+        print(f"As expected: passing invalid shape arrays triggers the exception:\n{e}")
+
+    # There are helper methods for explicitly resizing coefficient arrays to the correct shape
+    input.rbc = vmecpp.VmecInput.resize_2d_coeff(input.rbc, input.mpol, input.ntor)
+    vmecpp.run(input)
+
+
+if __name__ == "__main__":
+    modify_input_and_run()

--- a/examples/simsopt_integration.py
+++ b/examples/simsopt_integration.py
@@ -7,14 +7,9 @@ from pathlib import Path
 
 import vmecpp.simsopt_compat
 
-# NOTE: This resolves to src/vmecpp/cpp/vmecpp/test_data in the repo.
-TEST_DATA_DIR = (
-    Path(__file__).parent.parent / "src" / "vmecpp" / "cpp" / "vmecpp" / "test_data"
-)
-
 
 def run_vmecpp_with_simsopt():
-    input_file = TEST_DATA_DIR / "input.solovev"
+    input_file = Path(__file__).parent / "data" / "input.solovev"
     vmec = vmecpp.simsopt_compat.Vmec(input_file)
     print(f"Computed plasma volume: {vmec.volume()}")
 

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
@@ -220,10 +220,12 @@ class VmecINDATA {
 
   // [ntor+1] magnetic axis coefficients for R ~ sin(n*v);
   // non-stellarator-symmetric
+  // TODO(jurasic) make theses optional after the Eigen3 refactor
   std::vector<double> raxis_s;
 
   // [ntor+1] magnetic axis coefficients for Z ~ cos(n*v);
   // non-stellarator-symmetric
+  // TODO(jurasic) make theses optional after the Eigen3 refactor
   std::vector<double> zaxis_c;
 
   // ---------------------------------
@@ -239,10 +241,12 @@ class VmecINDATA {
 
   // [mpol*(2*ntor+1)] boundary coefficients for R ~ sin(m*u - n*v);
   // non-stellarator-symmetric
+  // TODO(jurasic) make theses optional after the Eigen3 refactor
   std::vector<double> rbs;
 
   // [mpol*(2*ntor+1)] boundary coefficients for Z ~ cos(m*u - n*v);
   // non-stellarator-symmetric
+  // TODO(jurasic) make theses optional after the Eigen3 refactor
   std::vector<double> zbc;
 
   // Construct a VmecINDATA instance with default values, except for profile

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -197,10 +197,14 @@ PYBIND11_MODULE(_vmecpp, m) {
           [](VmecINDATAPyWrapper &w) -> VectorXd & { return w.zaxis_s; })
       .def_property_readonly(
           "raxis_s",
-          [](VmecINDATAPyWrapper &w) -> VectorXd & { return w.raxis_s; })
+          [](VmecINDATAPyWrapper &w) -> std::optional<VectorXd> & {
+            return w.raxis_s;
+        })
       .def_property_readonly(
           "zaxis_c",
-          [](VmecINDATAPyWrapper &w) -> VectorXd & { return w.zaxis_c; })
+          [](VmecINDATAPyWrapper &w) -> std::optional<VectorXd> & {
+            return w.zaxis_c;
+        })
 
       // (initial guess for) boundary shape
       // disallow re-assignment of the whole matrix (to preserve shapes
@@ -213,9 +217,12 @@ PYBIND11_MODULE(_vmecpp, m) {
           [](VmecINDATAPyWrapper &w) -> vmecpp::RowMatrixXd & { return w.zbs; })
       .def_property_readonly(
           "rbs",
-          [](VmecINDATAPyWrapper &w) -> vmecpp::RowMatrixXd & { return w.rbs; })
+          [](VmecINDATAPyWrapper &w) -> std::optional<vmecpp::RowMatrixXd> & {
+            return w.rbs;
+        })
       .def_property_readonly(
-          "zbc", [](VmecINDATAPyWrapper &w) -> vmecpp::RowMatrixXd & {
+          "zbc",
+          [](VmecINDATAPyWrapper &w) -> std::optional<vmecpp::RowMatrixXd> & {
             return w.zbc;
           });
 

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/vmec_indata_pywrapper.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/vmec_indata_pywrapper.cc
@@ -119,18 +119,25 @@ VmecINDATAPyWrapper::operator VmecINDATA() const {
   indata.return_outputs_even_if_not_converged = return_outputs_even_if_not_converged;
   indata.raxis_c.assign(raxis_c.begin(), raxis_c.end());
   indata.zaxis_s.assign(zaxis_s.begin(), zaxis_s.end());
-  indata.raxis_s.assign(raxis_s.begin(), raxis_s.end());
-  indata.zaxis_c.assign(zaxis_c.begin(), zaxis_c.end());
+  if(raxis_s.has_value()){
+    indata.raxis_s.assign(raxis_s.value().begin(), raxis_s.value().end());
+  }
+  if(zaxis_c.has_value()){
+    indata.zaxis_c.assign(zaxis_c.value().begin(), zaxis_c.value().end());
+  }
 
   const auto rbc_flat = rbc.reshaped<Eigen::RowMajor>();
   indata.rbc.assign(rbc_flat.begin(), rbc_flat.end());
   const auto zbs_flat = zbs.reshaped<Eigen::RowMajor>();
   indata.zbs.assign(zbs_flat.begin(), zbs_flat.end());
-  const auto rbs_flat = rbs.reshaped<Eigen::RowMajor>();
-  indata.rbs.assign(rbs_flat.begin(), rbs_flat.end());
-  const auto zbc_flat = zbc.reshaped<Eigen::RowMajor>();
-  indata.zbc.assign(zbc_flat.begin(), zbc_flat.end());
-
+  if(rbs.has_value()){
+    const auto rbs_flat = rbs.value().reshaped<Eigen::RowMajor>();
+    indata.rbs.assign(rbs_flat.begin(), rbs_flat.end());
+  }
+  if(zbc.has_value()){
+    const auto zbc_flat = zbc.value().reshaped<Eigen::RowMajor>();
+    indata.zbc.assign(zbc_flat.begin(), zbc_flat.end());
+  }
   return indata;
 }
 
@@ -154,13 +161,13 @@ void VmecINDATAPyWrapper::SetMpolNtor(int new_mpol, int new_ntor) {
   zaxis_s(shortest_range) = old_axis_fc(shortest_range);
 
   if (lasym) {
-    old_axis_fc = raxis_s;
+    old_axis_fc = raxis_s.value();
     raxis_s = VectorXd::Zero(new_ntor + 1);
-    raxis_s(shortest_range) = old_axis_fc(shortest_range);
+    (*raxis_s)(shortest_range) = old_axis_fc(shortest_range);
 
-    old_axis_fc = zaxis_c;
+    old_axis_fc = zaxis_c.value();
     zaxis_c = VectorXd::Zero(new_ntor + 1);
-    zaxis_c(shortest_range) = old_axis_fc(shortest_range);
+    (*zaxis_c)(shortest_range) = old_axis_fc(shortest_range);
   }
 
   auto resized_2d_coeff = [this, new_mpol, new_ntor](const auto& coeff) {
@@ -182,8 +189,8 @@ void VmecINDATAPyWrapper::SetMpolNtor(int new_mpol, int new_ntor) {
   rbc = resized_2d_coeff(rbc);
   zbs = resized_2d_coeff(zbs);
   if (lasym) {
-    rbs = resized_2d_coeff(rbs);
-    zbc = resized_2d_coeff(zbc);
+    rbs = resized_2d_coeff(rbs.value());
+    zbc = resized_2d_coeff(zbc.value());
   }
 
   mpol = new_mpol;

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/vmec_indata_pywrapper.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/vmec_indata_pywrapper.h
@@ -7,6 +7,7 @@
 #include <Eigen/Dense>
 #include <filesystem>
 #include <string>
+#include <optional>
 
 #include "vmecpp/common/util/util.h"  // RowMatrixXd, ToEigenVector, ToEigenMatrix
 #include "vmecpp/common/vmec_indata/vmec_indata.h"
@@ -65,12 +66,12 @@ class VmecINDATAPyWrapper {
   bool return_outputs_even_if_not_converged;
   Eigen::VectorXd raxis_c;
   Eigen::VectorXd zaxis_s;
-  Eigen::VectorXd raxis_s;
-  Eigen::VectorXd zaxis_c;
+  std::optional<Eigen::VectorXd> raxis_s;
+  std::optional<Eigen::VectorXd> zaxis_c;
   RowMatrixXd rbc;
   RowMatrixXd zbs;
-  RowMatrixXd rbs;
-  RowMatrixXd zbc;
+  std::optional<RowMatrixXd> rbs;
+  std::optional<RowMatrixXd> zbc;
 
   VmecINDATAPyWrapper();
   explicit VmecINDATAPyWrapper(const VmecINDATA& indata);

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/vmec_indata_pywrapper_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/vmec_indata_pywrapper_test.cc
@@ -61,17 +61,35 @@ void CheckEquality(const vmecpp::VmecINDATAPyWrapper &wrapper,
   EXPECT_EQ(wrapper.lforbal, indata.lforbal);
   EXPECT_THAT(wrapper.raxis_c, ElementsAreArray(indata.raxis_c));
   EXPECT_THAT(wrapper.zaxis_s, ElementsAreArray(indata.zaxis_s));
-  EXPECT_THAT(wrapper.raxis_s, ElementsAreArray(indata.raxis_s));
-  EXPECT_THAT(wrapper.zaxis_c, ElementsAreArray(indata.zaxis_c));
-
+  if(indata.lasym){
+    EXPECT_THAT(wrapper.raxis_s.value(), ElementsAreArray(indata.raxis_s));
+    EXPECT_THAT(wrapper.zaxis_c.value(), ElementsAreArray(indata.zaxis_c));
+  }else{
+    // For now, when stellaratory symmetric, VmecINDATA sets the asymmetric elements to
+    // an empty array and VmecINDATAPyWrapper uses std::nullopt. TODO(jurasic): reconcile the two
+    EXPECT_EQ(indata.raxis_s.size(), 0);
+    EXPECT_TRUE(!wrapper.raxis_s.has_value());
+    EXPECT_EQ(indata.zaxis_c.size(), 0);
+    EXPECT_TRUE(!wrapper.zaxis_c.has_value());
+  }
   const auto flat_rbc = wrapper.rbc.reshaped<Eigen::RowMajor>();
   EXPECT_THAT(flat_rbc, ElementsAreArray(indata.rbc));
   const auto flat_zbs = wrapper.zbs.reshaped<Eigen::RowMajor>();
   EXPECT_THAT(flat_zbs, ElementsAreArray(indata.zbs));
-  const auto flat_rbs = wrapper.rbs.reshaped<Eigen::RowMajor>();
-  EXPECT_THAT(flat_rbs, ElementsAreArray(indata.rbs));
-  const auto flat_zbc = wrapper.zbc.reshaped<Eigen::RowMajor>();
-  EXPECT_THAT(flat_zbc, ElementsAreArray(indata.zbc));
+
+  if(indata.lasym){
+    const auto flat_rbs = wrapper.rbs.value().reshaped<Eigen::RowMajor>();
+    EXPECT_THAT(flat_rbs, ElementsAreArray(indata.rbs));
+    const auto flat_zbc = wrapper.zbc.value().reshaped<Eigen::RowMajor>();
+    EXPECT_THAT(flat_zbc, ElementsAreArray(indata.zbc));
+  }else{
+    // For now, when stellaratory symmetric, VmecINDATA sets the asymmetric elements to
+    // an empty array and VmecINDATAPyWrapper uses std::nullopt. TODO(jurasic): reconcile the two
+    EXPECT_EQ(indata.rbs.size(), 0);
+    EXPECT_TRUE(!wrapper.rbs.has_value());
+    EXPECT_EQ(indata.zbc.size(), 0);
+    EXPECT_TRUE(!wrapper.zbc.has_value());
+  }
 }
 }  // namespace
 


### PR DESCRIPTION
Made lasym specific terms std::optional and Optional in Python
### As discussed in 
https://github.com/proximafusion/vmecpp/pull/198#discussion_r2024553225

> it's a bit weird to say `if not self.lasym`, we don't care about "rbs" and "zbc".
> should we rather say `if self.lasym: # check shapes`, else `# check rbs and zbc are None`?


> At the moment the fields are populated by an empty list when stellarator symmetric! 
> I agree `| None` would be a clearer API, but constitutes a potentially breaking change. 
