### PR TITLE
Keep isvmec and ensure_vmec methods around in simsopt_compat for backwards compatibility

### DIFF
--- a/src/vmecpp/simsopt_compat.py
+++ b/src/vmecpp/simsopt_compat.py
@@ -18,6 +18,11 @@ import vmecpp
 
 logger = logging.getLogger(__name__)
 
+# Expose specific functions from vmecpp for backwards compatibility
+is_vmec200_input = vmecpp.is_vmec2000_input
+ensure_vmec200_input = vmecpp.ensure_vmec2000_input
+ensure_vmecpp_input = vmecpp.ensure_vmecpp_input
+
 # NOTE: this will be needed to set Vmec.mpi.
 # VMEC++ does not use MPI, but Vmec.mpi must be set anyways to make tools like Boozer
 # happy: they expect to be able to extract the mpi controller from the Vmec object,

--- a/src/vmecpp/simsopt_compat.py
+++ b/src/vmecpp/simsopt_compat.py
@@ -16,12 +16,14 @@ from simsopt.util.mpi import MpiPartition
 
 import vmecpp
 
-logger = logging.getLogger(__name__)
+# Re-export specific functions from vmecpp for backwards compatibility
+from vmecpp import (  # noqa: F401
+    ensure_vmec2000_input,
+    ensure_vmecpp_input,
+    is_vmec2000_input,
+)
 
-# Expose specific functions from vmecpp for backwards compatibility
-is_vmec200_input = vmecpp.is_vmec2000_input
-ensure_vmec200_input = vmecpp.ensure_vmec2000_input
-ensure_vmecpp_input = vmecpp.ensure_vmecpp_input
+logger = logging.getLogger(__name__)
 
 # NOTE: this will be needed to set Vmec.mpi.
 # VMEC++ does not use MPI, but Vmec.mpi must be set anyways to make tools like Boozer


### PR DESCRIPTION
These methods were migrated to vmecpp so we can separate the imports. 
Since a lot of places in repo depend on the old import paths, it might be nice to still keep this around.