### PR TITLE
isvmec2000 supports fortran comments and blank lines

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -1202,11 +1202,15 @@ def run(
 
 def is_vmec2000_input(input_file: Path) -> bool:
     """Returns true if the input file looks like a Fortran VMEC/VMEC2000 INDATA file."""
-    # we peek at the first few characters in the file: if they are "&INDATA",
-    # this is an INDATA file
+    # we peek at the first few non-blank, non-comment lines in the file:
+    # if one of them is "&INDATA", then this is an INDATA file
     with open(input_file) as f:
-        first_line = f.readline().strip()
-    return first_line == "&INDATA"
+        for line in f:
+            stripped_line = line.strip()
+            if not stripped_line or stripped_line.startswith("!"):
+                continue
+            return stripped_line == "&INDATA"
+    return False
 
 
 @contextlib.contextmanager

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -248,6 +248,12 @@ def test_is_vmec2000_input():
     assert not vmecpp.is_vmec2000_input(vmecpp_input_file)
 
 
+# Regression test #232
+def test_is_vmec2000_input_with_comment():
+    vmec2000_input_file = TEST_DATA_DIR / "input.solovev_analytical"
+    assert vmecpp.is_vmec2000_input(vmec2000_input_file)
+
+
 def test_ensure_vmec2000_input_noop():
     vmec2000_input_file = TEST_DATA_DIR / "input.cma"
 


### PR DESCRIPTION
### What changed?

Modified the `is_vmec2000_input()` function to properly detect VMEC2000 input files by:
- Skipping blank lines and lines that start with `!` (comments)

Added a regression test using the `input.solovev_analytical` file to verify the fix works with files that have comments before the `&INDATA` marker.

### Why make this change?

Fixes issue #232 where VMEC2000 input files with comments or blank lines before the `&INDATA` marker were not being correctly identified, causing them to be processed incorrectly.