### PR TITLE
mgrid load, string to filesystem

### DIFF
--- a/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
@@ -11,7 +11,6 @@
 #include <cstdio>
 #include <fstream>
 #include <iostream>
-#include <string>
 #include <vector>
 
 #include "absl/log/check.h"
@@ -52,7 +51,7 @@ MGridProvider::MGridProvider() {
 }
 
 // return 0 if mgrid could be loaded, 1 otherwise
-int MGridProvider::LoadFile(const std::string& filename,
+int MGridProvider::LoadFile(const std::filesystem::path& filename,
                             const std::vector<double>& coilCurrents) {
   {  // try to open file in order to check if it is accessible
     std::ifstream fp(filename);

--- a/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.h
@@ -5,7 +5,7 @@
 #ifndef VMECPP_FREE_BOUNDARY_MGRID_PROVIDER_MGRID_PROVIDER_H_
 #define VMECPP_FREE_BOUNDARY_MGRID_PROVIDER_MGRID_PROVIDER_H_
 
-#include <string>
+#include <filesystem>
 #include <vector>
 
 #include "vmecpp/common/makegrid_lib/makegrid_lib.h"
@@ -17,7 +17,7 @@ class MGridProvider {
  public:
   MGridProvider();
 
-  int LoadFile(const std::string& filename,
+  int LoadFile(const std::filesystem::path& filename,
                const std::vector<double>& coilCurrents);
 
   absl::Status LoadFields(


### PR DESCRIPTION
## Minor cleanup
- string -> filesystem::path to be more expressive