### PR TITLE
mgrid file loading with absl::Status

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -1258,8 +1258,6 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
   // nothing to check here: lfreeb can be true or false and both are valid...
   if (vmec_indata.lfreeb) {
     // mgrid_file
-    // TODO(jons): check that mgrid file exists and can be opened
-    // TODO(jons): try to read it ? only metadata ?
     // TODO(jons): if mgrid read, check for consistent nzeta
 
     // extcur

--- a/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
@@ -43,7 +43,7 @@ MGridProvider::MGridProvider() {
 
   nextcur = -1;
 
-  hasMgridLoaded = false;
+  has_mgrid_loaded_ = false;
 
   has_fixed_field_ = false;
 
@@ -143,7 +143,7 @@ absl::Status MGridProvider::LoadFile(const std::filesystem::path& filename,
     return absl::InternalError("Failed to close NetCDF file.");
   }
 
-  hasMgridLoaded = true;
+  has_mgrid_loaded_ = true;
   has_fixed_field_ = false;
 
   return absl::Status();
@@ -200,7 +200,7 @@ absl::Status MGridProvider::LoadFields(
     }  // linear_index
   }  // nextcur
 
-  hasMgridLoaded = true;
+  has_mgrid_loaded_ = true;
   has_fixed_field_ = false;
 
   return absl::OkStatus();
@@ -214,7 +214,7 @@ void MGridProvider::SetFixedMagneticField(const std::vector<double>& fixed_br,
   fixed_bp_ = fixed_bp;
   fixed_bz_ = fixed_bz;
 
-  hasMgridLoaded = true;
+  has_mgrid_loaded_ = true;
   has_fixed_field_ = true;
 }  // SetFixedMagneticField
 
@@ -225,7 +225,7 @@ void MGridProvider::interpolate(int ztMin, int ztMax, int nZeta,
                                 std::vector<double>& m_interpBr,
                                 std::vector<double>& m_interpBp,
                                 std::vector<double>& m_interpBz) const {
-  CHECK(hasMgridLoaded) << "no mgrid loaded";
+  CHECK(has_mgrid_loaded_) << "no mgrid loaded";
 
   if (has_fixed_field_) {
     // quick return: just copy into target storage

--- a/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.h
@@ -61,8 +61,10 @@ class MGridProvider {
 
   std::string mgrid_mode;
 
+  bool IsLoaded() const { return has_mgrid_loaded_; }
+
  private:
-  bool hasMgridLoaded;
+  bool has_mgrid_loaded_;
   bool has_fixed_field_;
 
   std::vector<double> fixed_br_;

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
@@ -73,13 +73,20 @@ class Vmec {
   // scaling factor for blending between two different ways to compute B^zeta
   static constexpr double kPDamp = 0.05;
 
+  // VMEC++ constructor is only valid for fixed-boundary input files.
+  // Free-boundary runs will complete initialization by loading the mgrid
+  // contents when run is called, to have graceful error handling with absl.
   explicit Vmec(const VmecINDATA& indata,
                 std::optional<int> max_threads = std::nullopt,
                 bool verbose = true);
 
-  Vmec(const VmecINDATA& indata,
-       const makegrid::MagneticFieldResponseTable* magnetic_response_table,
-       std::optional<int> max_threads = std::nullopt, bool verbose = true);
+  // Mgrid loading for free-boundary VMEC++ from a precomputed response-table is
+  // done outside of the Vmec constructor for improved exception handling
+  absl::Status LoadMGrid(
+      const makegrid::MagneticFieldResponseTable& magnetic_response_table);
+  // Mgrid loading for free-boundary VMEC++ from the indata_.mgrid_file path is
+  // done outside of the Vmec constructor for improved exception handling
+  absl::Status LoadMGrid();
 
   absl::StatusOr<bool> run(
       const VmecCheckpoint& checkpoint = VmecCheckpoint::NONE,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -28,6 +28,22 @@ TEST_DATA_DIR = REPO_ROOT / "src" / "vmecpp" / "cpp" / "vmecpp" / "test_data"
 
 
 @pytest.mark.parametrize(
+    ("mgrid_path", "expected_exception"),
+    [
+        ("cma.json", RuntimeError),
+        ("does_not_exist", RuntimeError),
+        #  ("wout_cma.nc", RuntimeError),  # This crashes because netcdf_io doesn't use absl::status yet
+    ],
+)
+def test_raise_invalid_mgrid(mgrid_path: str, expected_exception):
+    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cma.json")
+    vmec_input.lfreeb = True
+    vmec_input.mgrid_file = str(TEST_DATA_DIR / mgrid_path)
+    with pytest.raises(expected_exception):
+        vmecpp.run(vmec_input, max_threads=1)
+
+
+@pytest.mark.parametrize(
     ("max_threads", "input_file", "verbose"),
     [(None, "cma.json", True), (1, "input.cma", False)],
 )


### PR DESCRIPTION
## Issue
The Vmec constructor had absl::CHECK calls in the constructor, which terminated not just the vmecpp execution but also the python wrapper process when mgrid file loading failed, without an Exception or error message that the user could handle. 

## Proposed solution
### TLDR 
Init method for mgrid loading

### Long version
The PR refactors the `Vmec` constructor to do pure, exception free initialization (Ignoring the possibility of a memory allocation error from std::vector) and moves all sources of exceptions to places where we can report an `absl::Status`. It removes the magnetic response table constructor of Vmec, and all mgrid related initialization is instead handled in `InitMgrid`, a new method that returns the completion status.


**The downside** is, that `Vmec(indata)` does no longer produce a valid object for free-boundary input files. Instead, the mgrid load is finalized during the first call to `run()` if any file IO is required.

**Positive** is that the error handling is now correct for missing, invalid mgrid files, wrong resolutions etc. and returns error codes/Python exceptions instead of terminating.

A long term better API would be: https://github.com/proximafusion/vmecpp/pull/244