### PR TITLE
MagneticFieldResponseTable to use Eigen Matrices

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/makegrid_lib/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/common/makegrid_lib/BUILD.bazel
@@ -14,6 +14,7 @@ cc_library(
         "//vmecpp/common/composed_types_lib",
         "//vmecpp/common/magnetic_configuration_lib",
         "//vmecpp/common/magnetic_field_provider:magnetic_field_provider_lib",
+        "//vmecpp/common/util:util",
     ],
     linkopts = [
         "-lnetcdf",

--- a/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib.h
+++ b/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib.h
@@ -11,10 +11,14 @@
 
 #include "absl/status/statusor.h"
 #include "vmecpp/common/magnetic_configuration_lib/magnetic_configuration_lib.h"
+#include "vmecpp/common/util/util.h"
 
 namespace makegrid {
 
 using magnetics::MagneticConfiguration;
+
+using vmecpp::RowMatrixXd;
+using RowMatrix3Xd = Eigen::Matrix<double, 3, Eigen::Dynamic, Eigen::RowMajor>;
 
 struct MakegridParameters {
   // If true, normalize the magnetic field to the coil currents and number of
@@ -60,17 +64,17 @@ struct MagneticFieldResponseTable {
   // cylindrical R components of magnetic field
   // [number_of_serial_circuits][number_of_phi_grid_points *
   // number_of_z_grid_points * number_of_r_grid_points]
-  std::vector<std::vector<double>> b_r;
+  RowMatrixXd b_r;
 
   // cylindrical phi components of magnetic field
   // [number_of_serial_circuits][number_of_phi_grid_points *
   // number_of_z_grid_points * number_of_r_grid_points]
-  std::vector<std::vector<double>> b_p;
+  RowMatrixXd b_p;
 
   // cylindrical Z components of magnetic field
   // [number_of_serial_circuits][number_of_phi_grid_points *
   // number_of_z_grid_points * number_of_r_grid_points]
-  std::vector<std::vector<double>> b_z;
+  RowMatrixXd b_z;
 };  // MagneticFieldResponseTable
 
 struct MakegridCachedVectorPotential {
@@ -80,17 +84,17 @@ struct MakegridCachedVectorPotential {
   // cylindrical R components of vector potential
   // [number_of_serial_circuits][number_of_phi_grid_points *
   // number_of_z_grid_points * number_of_r_grid_points]
-  std::vector<std::vector<double>> a_r;
+  RowMatrixXd a_r;
 
   // cylindrical phi components of vector potential
   // [number_of_serial_circuits][number_of_phi_grid_points *
   // number_of_z_grid_points * number_of_r_grid_points]
-  std::vector<std::vector<double>> a_p;
+  RowMatrixXd a_p;
 
   // cylindrical Z components of vector potential
   // [number_of_serial_circuits][number_of_phi_grid_points *
   // number_of_z_grid_points * number_of_r_grid_points]
-  std::vector<std::vector<double>> a_z;
+  RowMatrixXd a_z;
 };  // MakegridCachedVectorPotential
 
 // Check if the parameters in given MakegridParameters are valid.
@@ -113,7 +117,7 @@ absl::StatusOr<MakegridParameters> ImportMakegridParametersFromFile(
 //   * number_of_phi_grid_points (slowest)
 //   * number_of_z_grid_points
 //   * number_of_r_grid_points (fastest)
-absl::StatusOr<std::vector<std::vector<double>>> MakeCylindricalGrid(
+absl::StatusOr<RowMatrix3Xd> MakeCylindricalGrid(
     const MakegridParameters& makegrid_parameters);
 
 // Compute the (normalized) magnetic field components on the given grid

--- a/src/vmecpp/cpp/vmecpp/common/util/util.h
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.h
@@ -56,7 +56,7 @@ inline vmecpp::RowMatrixXd ToEigenMatrix(const std::vector<double> &v,
 inline vmecpp::RowMatrixXd ToEigenMatrix(
     const std::vector<std::vector<double>> &v) {
   const std::size_t outer_size = v.size();
-  CHECK_GT(outer_size, 0);
+  CHECK_GT(outer_size, 0u);
   const std::size_t inner_size = v[0].size();
   for (const auto &row : v) {
     CHECK_EQ(row.size(), inner_size);

--- a/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
@@ -153,11 +153,12 @@ absl::Status MGridProvider::LoadFields(
     const makegrid::MakegridParameters& mgrid_params,
     const makegrid::MagneticFieldResponseTable& magnetic_response_table,
     const std::vector<double>& coil_currents) {
-  if (coil_currents.size() != magnetic_response_table.b_p.size()) {
+  if (coil_currents.size() !=
+      static_cast<std::size_t>((magnetic_response_table.b_p.rows()))) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "Number of currents %d does not match number of coil fields in the "
         "response table %d.",
-        coil_currents.size(), magnetic_response_table.b_p.size()));
+        coil_currents.size(), magnetic_response_table.b_p.rows()));
   }
 
   nfp = mgrid_params.number_of_field_periods;
@@ -192,11 +193,11 @@ absl::Status MGridProvider::LoadFields(
   for (int i = 0; i < nextcur; ++i) {
     for (int linear_index = 0; linear_index < num_grid_points; ++linear_index) {
       bR[linear_index] +=
-          magnetic_response_table.b_r[i][linear_index] * coil_currents[i];
+          magnetic_response_table.b_r(i, linear_index) * coil_currents[i];
       bP[linear_index] +=
-          magnetic_response_table.b_p[i][linear_index] * coil_currents[i];
+          magnetic_response_table.b_p(i, linear_index) * coil_currents[i];
       bZ[linear_index] +=
-          magnetic_response_table.b_z[i][linear_index] * coil_currents[i];
+          magnetic_response_table.b_z(i, linear_index) * coil_currents[i];
     }  // linear_index
   }  // nextcur
 


### PR DESCRIPTION
Make it easier to work with the response table from Python by allowing readwrite and automatic numpy conversion.

## Why do we need this?
- Enables easy integration with Python/simsopt/JAX routines for computing the response table 
- Iterative transition away from stl::vector to Eigen3

Additionally: Move computation of a single coil to a separate function