### PR TITLE
Default initializer for VmecInput (reads values from VmecINDATAPyWrapper)

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -338,6 +338,12 @@ class VmecInput(pydantic.BaseModel):
             }
         )
 
+    @staticmethod
+    def default():
+        """Construct a VmecInput with the same default settings as VMEC2000."""
+        cpp_defaults = _vmecpp.VmecINDATAPyWrapper()
+        return VmecInput._from_cpp_vmecindatapywrapper(cpp_defaults)
+
     def _to_cpp_vmecindatapywrapper(self) -> _vmecpp.VmecINDATAPyWrapper:
         cpp_indata = _vmecpp.VmecINDATAPyWrapper()
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -380,3 +380,13 @@ def test_aux_arrays_from_cpp_wout():
         assert_aux_defaults(wout)
     np.testing.assert_almost_equal(wout.am_aux_s[:2], np.array([2.0, 3.0]))
     np.testing.assert_almost_equal(wout.am_aux_f[:2], np.array([2.0, 3.0]))
+
+
+def test_default_preset():
+    # Default construction doesn't throw an exception
+    default_preset = vmecpp.VmecInput.default()
+    # Sample a few of the default values that should be set
+    assert default_preset.nfp == 1
+    assert default_preset.mpol == 6
+    assert not default_preset.lasym
+    assert default_preset.ns_array == np.array([31])


### PR DESCRIPTION
### What changed?

- Added a custom `__init__` method to `VmecInput` class that initializes default values from the C++ `VmecINDATAPyWrapper` class when no arguments are provided

### Why make this change?
**Pro:** 
- Enables a "pure Python workflow", where the user doesn't have to load any input file. `VmecInput` can be comfortably constructed in a script, without providing explicit defaults for **all quantities**. 

**Con:** 
- Defaults aren't clearly visible for Python users without constructing and inspecting the object.
- only passing a few arguments and defaulting the rest isn't supported, which may be desirable too. 

Alternative: Explicitly default all fields to the same as VmecINDATAPyWrapper 