### PR TITLE
Eigen3.4 version issue with hash in Bazel Central Registry

### DIFF
--- a/src/vmecpp/cpp/MODULE.bazel
+++ b/src/vmecpp/cpp/MODULE.bazel
@@ -4,7 +4,7 @@
 module(name = "vmecpp", version = "0.3.0")
 
 bazel_dep(name = "abseil-cpp", version = "20230802.0.bcr.1")
-bazel_dep(name = "eigen", version = "3.4.0")
+bazel_dep(name = "eigen", version = "3.4.0.bcr.3")
 bazel_dep(name = "google_benchmark", version = "1.8.2")
 bazel_dep(name = "googletest", version = "1.14.0")
 


### PR DESCRIPTION
The BCR version of Eigen was bumped...
https://registry.bazel.build/modules/eigen/4.0.0-20241125.bcr.1

## Underlying issue
Apparently Eigen archives on GirLab aren't stable?
https://gitlab.com/libeigen/eigen/-/issues/2919

Current theory by Eigen3 maintainers, is that it is a bug on GitLab side, which caused a bad archive to be cached somewhere...