### PR TITLE
BaseModelWithNumpy for numpy+pydantic serialization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "numpy",
   "pydantic",
   "numpydantic",
+  "jaxtyping",
   "jax<=0.5.0", # To prevent a circular import bug in jax on arch Linux
   "simsopt>=1.8.1",
 ]

--- a/src/vmecpp/_pydantic_numpy.py
+++ b/src/vmecpp/_pydantic_numpy.py
@@ -1,0 +1,399 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+import types
+import typing
+from collections.abc import Callable, Mapping
+from typing import Any, Literal, Union
+
+import jaxtyping as jt
+import numpy as np
+import pydantic
+
+
+class BaseModelWithNumpy(pydantic.BaseModel):
+    """A minimal layer on top of pydantic to help with serialization and de-
+    serialization of classes with numpy arrays, annotated with jaxtyping.
+
+    Does checks on the shape and type of arrays, may do casting if needed.
+    """
+
+    model_config = pydantic.ConfigDict(
+        arbitrary_types_allowed=True,
+        # Serialize NaN and infinite floats as strings in JSON output.
+        # See: https://docs.google.com/document/d/1fTvLrCl_tfjgud8SL7PVwhG28az0oy22gVa5wvqXSxY
+        # for why.
+        # Due to a bug in Pydantic, this setting is ignored by model_dump(mode="json"),
+        # so we override it below to also convert values to string there.
+        ser_json_inf_nan="strings",
+    )
+
+    @pydantic.field_serializer("*", mode="wrap", when_used="json")
+    def _dapper_serialize_field(
+        self,
+        value: typing.Any,
+        default_handler: pydantic.SerializerFunctionWrapHandler,
+        info: pydantic.FieldSerializationInfo,
+        # Note: Do NOT annotate return type with "-> Any" here, since that removes types
+        # from the JSON schema of all fields (in serialization mode).
+    ):
+        value = serialize_special_field(type(self), info.field_name, value)
+        return default_handler(value)
+
+    @pydantic.field_validator("*", mode="wrap")
+    @classmethod
+    def _dapper_validate_field(
+        cls,
+        value: typing.Any,
+        default_handler: pydantic.ValidatorFunctionWrapHandler,
+        info: pydantic.ValidationInfo,
+    ) -> typing.Any:
+        assert info.field_name is not None
+        # We consciously *ignore* info.mode_is_json() here to allow validating from
+        # JSON-like dicts without having to go through strings. This is consistent with
+        # Pydantic's default behavior: while serializers retain Python objects in
+        # model_dump, but convert them to JSON values in model_dump_json, validators
+        # are lenient and accept JSON values in both modes.
+        value = deserialize_special_field(cls, info.field_name, value)
+        return default_handler(value)
+
+    # This override is necessary to make also `model_dump(mode="json")` respect the
+    # ser_json_inf_nan="strings" setting in model_config. Without this fix, Pydantic
+    # would keep returning NaN/Inf as Python floats from this function, which leads to
+    # invalid JSON, e.g. when the output is used with `json.dumps`.
+    # This bug will probably only be fixed in Pydantic V3, since they consider it a
+    # breaking change.
+    # See: https://github.com/pydantic/pydantic/issues/10037#issuecomment-2314751795
+    # Hide the override from the type system to "pass through" docstring and parameter
+    # types and defaults.
+    if not typing.TYPE_CHECKING:
+
+        def model_dump(self, *, mode: str = "python", **kwargs: Any) -> dict[str, Any]:
+            output_dict = super().model_dump(mode=mode, **kwargs)
+            if mode == "json":
+                sanitize_floats_in_container(output_dict)
+            return output_dict
+
+
+"""This module handles special cases for serialization of DapperData types.
+
+Any data type that pydantic cannot natively handle can be supported by
+adding a case in this module.
+
+Only add special cases here if the type is not under your control (it comes from
+a third-party library) AND if it is of broad interest across the codebase.
+
+Before adding a special case to this module, consider one of these two alternatives:
+
+1) Wrap the type definition and add Pydantic serializers and validators directly:
+   `Annotated[<type>, pydantic.PlainSerializer(...), pydantic.BeforeValidator(...)]`
+   Example can be found here: dapper/examples/annotated_serialization.py
+
+2) Convert/wrap the unsupported class in a DapperData class and provide a
+   @pydantic.field_serializer and @pydantic.field_validator method on that class.
+   See: https://docs.pydantic.dev/latest/concepts/serialization/#custom-serializers
+
+The advantage of adding a special case to this module is solely so types can be
+declared in DapperData classes "as-is" without wrapping them with Annotated types.
+For example, you can declare `value: jt.Float[np.ndarray, ...]` instead of
+`value: dapper.NumpyArrayWrapper[...]`.
+
+----
+
+The mechanism for serialization is to convert "special" fields to JSON-serializable
+values and then let Pydantic take care of the rest.
+In practice:
+- If the field is "special", (e.g. `np.ndarray`) it is converted to either a primitive
+  list or a `dapper.Blob`, depending on the presence of a `dapper.Binary` annotation.
+- If the field is a generic/composed type such as a list, an optional or a union,
+  recurse and do the same for the inner types.
+- Otherwise just return the field as is.
+
+The mechanism for deserialization is the inverse: Pydantic provides the serialized field
+and we convert it back to the original type (e.g. `np.ndarray`) while returning
+the rest unchanged to Pydantic's deserialization logic.
+
+----
+
+JAX array handling works as follows:
+ - During serialization, JAX arrays are converted to numpy arrays and serialized with
+   the same rules.
+ - During validation, "jt.Array" annotations are NOT treated specially, thus only numpy
+   arrays can be produced by the deserialization process. To put JAX arrays into Dapper
+   types that should be serializable, they must be annotated with NpOrJaxArray!
+"""
+NpOrJaxArray = np.ndarray | jt.Array
+NpOrAbstractArray = np.ndarray | jt.AbstractArray
+
+AnyJsonValue = dict | list | str | int | float | bool | None
+"""Type alias for any value that can be part of a JSON object."""
+
+_NUMPY_ALLOWED_NONBINARY_DTYPES = (np.float64, np.int64, np.bool_)
+"""Allowed numpy dtypes for serialization without the `Binary` annotation."""
+
+
+def serialize_special_field(
+    cls: type[pydantic.BaseModel],
+    field_name: str,
+    value: Any,
+) -> Any:
+    """Preprocesses a field value, serializing special types while leaving others
+    unchanged."""
+    field_info = cls.model_fields.get(field_name, None)
+    if field_info is not None:
+        assert field_info.annotation is not None
+        field_type = field_info.annotation
+        field_metadata = field_info.metadata
+    else:
+        assert (
+            field_name in cls.model_computed_fields
+        ), f"Field {field_name} must be either a field or a computed field."
+        computed_field_info = cls.model_computed_fields[field_name]
+        field_type = computed_field_info.return_type
+        field_metadata = []  # Computed fields cannot use Annotated[...] for now.
+
+    try:
+        return _traverse_field_contents(
+            field_type, value, _serialize_value, field_metadata
+        )
+    except ValueError as e:
+        msg = f'At field "{field_name}" of type {type(value).__name__}: {e}'
+        raise ValueError(msg)  # noqa: B904
+
+
+def deserialize_special_field(
+    cls: type[pydantic.BaseModel],
+    field_name: str,
+    value: Any,
+) -> Any:
+    """Preprocesses a serialized field value, deserializing special types while leaving
+    others unchanged."""
+    # Note: Computed fields do not call field validators, so we do not need to consider
+    # them for deserialization.
+    field_info = cls.model_fields[field_name]
+    assert field_info.annotation is not None
+    return _traverse_field_contents(
+        field_info.annotation, value, _deserialize_value, field_info.metadata
+    )
+
+
+def _serialize_value(declared_type: type, value: Any, field_metadata: list[Any]) -> Any:  # noqa: ARG001
+    """Tests for the presence of a special type and converts it to a serializable value.
+
+    Args:
+        declared_type: The innermost declared type of the field. Unused, since for
+            serialization, the runtime type of the value is enough.
+        value: The scalar value to serialize, that potentially needs special handling.
+        field_metadata: The annotation metadata of the field, which may contain the
+            `dapper.Binary` annotation.
+
+    Returns:
+        Any value that can be serialized by Pydantic, for example a `dapper.Blob`,
+        a dict representation of the object, or a raw string.
+        Returns the unmodified value if no special handling applies.
+    """
+    del declared_type  # unused
+
+    if isinstance(value, NpOrJaxArray):
+        # Convert JAX arrays to numpy arrays for the purpose of serialization.
+        np_array = np.asarray(value)
+        if np_array.dtype in _NUMPY_ALLOWED_NONBINARY_DTYPES:
+            return np_array.tolist()
+        msg = (
+            f"Cannot serialize numpy array with dtype {np_array.dtype} to JSON. "
+            f"Please convert it to an allowed dtype: {_NUMPY_ALLOWED_NONBINARY_DTYPES}."
+        )
+        raise ValueError(msg)
+    return value
+
+
+def _deserialize_value(
+    declared_type: type, value: Any, field_metadata: list[Any]
+) -> Any:
+    """Tests for the presence of a special type and converts its serialized value back
+    to the original representation.
+
+    This function must gracefully handle values that are NOT valid for the declared
+    type, since deserialization is attempted for Union types where one of the options is
+    a special type, but the concrete value is not.
+
+    This function must also handle values while validating in "Python" mode using
+    "model_validate", since that function must support both raw JSON values and higher-
+    level Python values. Since these values already have the correct data type, they
+    should be returned unchanged.
+
+    Args:
+        declared_type: The innermost declared type of the field, after unwrapping
+            containers and unions from its declaration.
+        value: The serialized value, either in its JSON form or as a Python object.
+        field_metadata: The annotation metadata of the field.
+
+    Returns:
+        The deserialized value, or the unmodified value if it is not a special type.
+    """
+    del field_metadata  # unused
+
+    if issubclass(declared_type, NpOrAbstractArray) and isinstance(value, list):
+        fixed_list = _reconstruct_floats_for_numpy(value)
+        np_data = np.array(fixed_list)
+        # Only accept allowed dtypes, to avoid misinterpreting non-numpy lists.
+        if np_data.dtype in _NUMPY_ALLOWED_NONBINARY_DTYPES:
+            return np_data
+    return value
+
+
+def _traverse_field_contents(
+    field_type: type,
+    value: Any,
+    value_converter: Callable[[type, Any, list[Any]], Any],
+    field_metadata: list[Any],
+) -> Any:
+    """Traverses the insides of a field's declared type, recursively resolving nested
+    and collection types and returning the processed result.
+
+    This is called for both serialization and deserialization.
+    """
+    # Fields declared as Any are not processed, since their deserialization is under-
+    # specified. If we would allow applying transformations at serialization time, there
+    # would be no way to reverse it during deserialization without a "target" type hint.
+    if field_type is Any:
+        return value
+
+    outer_type = typing.get_origin(field_type)
+
+    # Performance note: The following code recurses into containers (lists, dicts, ...)
+    # looking for special values, independently of their declared value type.
+    # If this becomes a performance bottleneck, consider adding a check here to skip
+    # containers that are known to not contain special values (e.g. list[float]).
+
+    # Simple type.
+    if outer_type is None:
+        result = value_converter(field_type, value, field_metadata)
+
+    # Literal[X, Y, ...] cannot be used with issubclass and would fail the other checks,
+    # so we need to check it separately.
+    elif outer_type is Literal:
+        result = value
+
+    # - Union[T, TOther].
+    # - Optional[T] becomes Union[T, None].
+    # - Surprisingly, "int|str" becomes types.UnionType[int, str] instead of Union,
+    #   see: https://github.com/python/cpython/issues/105499
+    elif outer_type is Union or issubclass(outer_type, types.UnionType):
+        # Unions are complex to deserialize, since it must be deduced which of the
+        # declared types to deserialize to. For example, it is unclear how to handle
+        # a field `Union[np.ndarray, Blob]`, since both types share the same JSON
+        # structure.
+        # Pydantic has complex heuristics for this, but we haven't reimplemented them
+        # fully. See: https://docs.pydantic.dev/2.7/concepts/unions/
+        # Our approach is similar to Pydantic's "left-to-right" mode, but doesn't handle
+        # validation errors perfectly when multiple similar-looking Union types COULD
+        # match the given JSON data. If this becomes a problem and validation fails when
+        # it shouldn't, this logic should be revisited in the future.
+        # ----
+        # In serialization mode, the task is easier: The first time value_converter
+        # is called, it can directly decide whether or not it needs to handle a special
+        # case. This function still checks all options just to keep the code simpler.
+
+        result = value
+        inner_types = typing.get_args(field_type)
+        for value_type in inner_types:
+            result = _traverse_field_contents(
+                value_type, value, value_converter, field_metadata
+            )
+            # Stop at the first conversion that changed something, similar to Pydantic's
+            # "left-to-right" mode.
+            if result is not value:
+                break
+
+    # Dicts and similar.
+    elif issubclass(outer_type, Mapping) and isinstance(value, Mapping):
+        value_type = typing.get_args(field_type)[1]
+        result = outer_type(
+            {
+                key: _traverse_field_contents(
+                    value_type, item, value_converter, field_metadata
+                )
+                for key, item in value.items()
+            }  # type: ignore
+        )
+
+    # Tuples: They can be declared as tuple[T1, T2] or tuple[T, ...].
+    # During deserialization, `value` will however be a list!
+    elif issubclass(outer_type, tuple) and isinstance(value, tuple | list):
+        value_types = typing.get_args(field_type)
+        if len(value_types) == 2 and value_types[1] is Ellipsis:
+            value_types = [value_types[0]] * len(value)
+        result = outer_type(
+            _traverse_field_contents(item_type, item, value_converter, field_metadata)
+            for item_type, item in zip(value_types, value, strict=True)
+        )
+
+    # Lists and similar.
+    # Cannot use "Sequence" since that would also capture "str" and maybe others.
+    elif issubclass(outer_type, list | set | frozenset) and isinstance(
+        value, list | set | frozenset
+    ):
+        value_type = typing.get_args(field_type)[0]
+        result = outer_type(
+            _traverse_field_contents(value_type, item, value_converter, field_metadata)
+            for item in value
+        )
+
+    # Other generic type. We don't support these, just pass them through.
+    else:
+        result = value
+
+    return result
+
+
+def sanitize_floats_in_container(value: list | dict) -> None:
+    """Traverses a JSON container and converts unsupported float values to strings.
+
+    This function operates in-place to avoid creating a copy of the whole structure.
+    """
+    # Iterate through either (i, item) or (key, item) pairs.
+    tuple_iterator = enumerate(value) if isinstance(value, list) else value.items()
+    for key, item in tuple_iterator:
+        # Recurse into other containers.
+        if isinstance(item, list | dict):
+            sanitize_floats_in_container(item)
+        # In-place conversion for floats.
+        elif isinstance(item, float):
+            value[key] = _sanitize_float(item)
+
+
+# See: https://docs.google.com/document/d/1fTvLrCl_tfjgud8SL7PVwhG28az0oy22gVa5wvqXSxY
+# for the rationale behind representing these values as strings.
+def _sanitize_float(value: float) -> float | str:
+    if np.isnan(value):
+        return "NaN"
+    if np.isinf(value):
+        return "-Infinity" if value < 0 else "Infinity"
+    return value
+
+
+def _reconstruct_floats_for_numpy(value: list | float | str) -> list | float | str:
+    """Reconstructs floats in a (potentially nested) list so numpy can handle them.
+
+    While pydantic can coerce "NaN" and "Infinity" back to floats, our custom numpy
+    deserialization from a Python list cannot reuse this logic, so we need to check for
+    stringified values ourselves.
+
+    Only lists are supported as containers, since that's what we need for `np.array`.
+    """
+    if isinstance(value, list):
+        return [_reconstruct_floats_for_numpy(item) for item in value]
+    return _reconstruct_float(value)
+
+
+def _reconstruct_float(value: float | str) -> float | str:
+    # We handle some other spellings as well, to stay consistent with pydantic's
+    # built-in validation logic.
+    if value == "NaN" or value == "nan" or value is None:  # noqa: PLR1714
+        return np.nan
+    if value == "Infinity" or value == "inf":  # noqa: PLR1714
+        return np.inf
+    if value == "-Infinity" or value == "-inf":  # noqa: PLR1714
+        return -np.inf
+    return value

--- a/tests/test_pydantic_numpy.py
+++ b/tests/test_pydantic_numpy.py
@@ -1,0 +1,502 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MITimport datetime as dt
+import datetime as dt
+import json
+from collections.abc import Callable
+from typing import Literal
+
+import jax
+import jax.numpy as jnp
+import jaxtyping as jt
+import numpy as np
+import pydantic
+import pytest
+
+from vmecpp._pydantic_numpy import BaseModelWithNumpy, NpOrJaxArray
+
+jax.config.update("jax_enable_x64", True)
+
+
+class ModelPlainArray(BaseModelWithNumpy):
+    np_array: np.ndarray
+
+
+class ModelJaxtypingArray(BaseModelWithNumpy):
+    np_array: jt.Float[np.ndarray, " n_elements"] | jt.Int[np.ndarray, " n_elements"]
+
+
+class ModelOptionalArray(BaseModelWithNumpy):
+    np_array: np.ndarray | None
+
+
+class ModelUnion1Array(BaseModelWithNumpy):
+    np_array: str | np.ndarray | float
+
+
+class ModelUnion2Array(BaseModelWithNumpy):
+    np_array: str | np.ndarray | float
+
+
+@pytest.mark.parametrize(
+    "ModelClass",
+    [
+        ModelPlainArray,
+        ModelJaxtypingArray,
+        ModelOptionalArray,
+        ModelUnion1Array,
+        ModelUnion2Array,
+    ],
+)
+def test_serialize_numpy_plain(ModelClass: type):
+    np_data = np.array([1.0, 2.0, 3.0, 4.2])
+    model: BaseModelWithNumpy = ModelClass(np_array=np_data)
+
+    serialized = model.model_dump_json()
+
+    json_obj = json.loads(serialized)
+    assert isinstance(json_obj, dict)
+    assert "np_array" in json_obj
+    assert json_obj["np_array"] == [1.0, 2.0, 3.0, 4.2]
+
+    deserialized = ModelClass.model_validate_json(serialized)  # type: ignore
+
+    assert isinstance(deserialized.np_array, np.ndarray)
+    assert np.all(deserialized.np_array == np_data)
+
+
+def test_serialize_optional_none():
+    class Model(BaseModelWithNumpy):
+        np_array: np.ndarray | None
+
+    model = Model(np_array=None)
+
+    serialized = model.model_dump_json()
+
+    json_obj = json.loads(serialized)
+    assert json_obj["np_array"] is None
+
+    deserialized = Model.model_validate_json(serialized)
+
+    assert deserialized.np_array is None
+
+
+def test_serialize_union_value_before_array():
+    class ModelUnionBefore(BaseModelWithNumpy):
+        union_str: str | np.ndarray
+        union_float: float | np.ndarray
+        union_list: list[str] | np.ndarray
+
+    model = ModelUnionBefore(
+        union_str="foobar", union_float=42.42, union_list=["foo", "bar"]
+    )
+
+    serialized = model.model_dump_json()
+
+    json_obj = json.loads(serialized)
+    assert json_obj["union_str"] == "foobar"
+    assert json_obj["union_float"] == 42.42
+    assert json_obj["union_list"] == ["foo", "bar"]
+
+    deserialized = ModelUnionBefore.model_validate_json(serialized)
+
+    assert deserialized.union_str == "foobar"
+    assert deserialized.union_float == 42.42
+    assert deserialized.union_list == ["foo", "bar"]
+
+
+def test_serialize_union_value_after_array():
+    class ModelUnionAfter(BaseModelWithNumpy):
+        union_str: np.ndarray | str
+        union_float: np.ndarray | float
+        union_list: np.ndarray | list[str]
+
+    model = ModelUnionAfter(
+        union_str="foobar", union_float=42.42, union_list=["foo", "bar"]
+    )
+
+    serialized = model.model_dump_json()
+
+    json_obj = json.loads(serialized)
+    assert json_obj["union_str"] == "foobar"
+    assert json_obj["union_float"] == 42.42
+    assert json_obj["union_list"] == ["foo", "bar"]
+
+    deserialized = ModelUnionAfter.model_validate_json(serialized)
+
+    assert deserialized.union_str == "foobar"
+    assert deserialized.union_float == 42.42
+    assert deserialized.union_list == ["foo", "bar"]
+
+
+def test_serialize_numpy_lists():
+    class Model(BaseModelWithNumpy):
+        np_list: list[jt.Float[np.ndarray, " n_elements"]]
+        np_simple_tuple: tuple[np.ndarray, ...]
+        np_hard_tuple: tuple[int, np.ndarray, str]
+
+    np_data = np.array([1.0, 2.0, 3.0, 4.2])
+    model = Model(
+        np_list=[np_data, np_data, np_data],
+        np_simple_tuple=(np_data, np_data, np_data),
+        np_hard_tuple=(42, np_data, "foobar"),
+    )
+
+    serialized = model.model_dump_json()
+
+    json_obj = json.loads(serialized)
+    assert isinstance(json_obj["np_list"], list)
+    assert isinstance(json_obj["np_simple_tuple"], list)
+    assert isinstance(json_obj["np_hard_tuple"], list)
+    assert json_obj["np_list"][0] == [1.0, 2.0, 3.0, 4.2]
+    assert json_obj["np_simple_tuple"][0] == [1.0, 2.0, 3.0, 4.2]
+    assert json_obj["np_hard_tuple"][0] == 42
+    assert json_obj["np_hard_tuple"][1] == [1.0, 2.0, 3.0, 4.2]
+    assert json_obj["np_hard_tuple"][2] == "foobar"
+
+    deserialized = Model.model_validate_json(serialized)
+
+    assert isinstance(deserialized.np_list, list)
+    assert len(deserialized.np_list) == 3
+    assert np.all(deserialized.np_list[0] == np_data)
+    assert len(deserialized.np_simple_tuple) == 3
+    assert np.all(deserialized.np_simple_tuple[0] == np_data)
+    hard_int, hard_np, hard_str = deserialized.np_hard_tuple
+    assert hard_int == 42
+    assert np.all(hard_np == np_data)
+    assert hard_str == "foobar"
+
+
+def test_serialize_numpy_dict():
+    class Model(BaseModelWithNumpy):
+        # let's add optional just to make it harder
+        np_dict: dict[str, np.ndarray] | None
+
+    np_data = np.array([1.0, 2.0, 3.0, 4.2])
+    model = Model(np_dict={"foo": np_data, "bar": np_data})
+
+    serialized = model.model_dump_json()
+
+    json_obj = json.loads(serialized)
+    assert isinstance(json_obj["np_dict"], dict)
+    assert "foo" in json_obj["np_dict"]
+    assert "bar" in json_obj["np_dict"]
+    assert json_obj["np_dict"]["foo"] == [1.0, 2.0, 3.0, 4.2]
+    assert json_obj["np_dict"]["bar"] == [1.0, 2.0, 3.0, 4.2]
+
+    deserialized = Model.model_validate_json(serialized)
+
+    assert isinstance(deserialized.np_dict, dict)
+    assert "foo" in deserialized.np_dict
+    assert "bar" in deserialized.np_dict
+    assert np.all(deserialized.np_dict["foo"] == np_data)
+    assert np.all(deserialized.np_dict["bar"] == np_data)
+
+
+def test_serialize_deeply_nested():
+    class Model(BaseModelWithNumpy):
+        np_deep: dict[str, list[tuple[np.ndarray | dt.datetime, str]]] | None
+
+    other_data = dt.datetime(2024, 1, 1, 12, 34, 56)
+    np_data = np.array([1.0, 2.0, 3.0, 4.2])
+    model = Model(np_deep={"foo": [(other_data, "other"), (np_data, "np")]})
+
+    serialized = model.model_dump_json()
+
+    json_obj = json.loads(serialized)
+    assert isinstance(json_obj["np_deep"], dict)
+    assert "foo" in json_obj["np_deep"]
+    assert json_obj["np_deep"]["foo"][0] == ["2024-01-01T12:34:56", "other"]
+    assert json_obj["np_deep"]["foo"][1] == [[1.0, 2.0, 3.0, 4.2], "np"]
+
+    deserialized = Model.model_validate_json(serialized)
+
+    assert isinstance(deserialized.np_deep, dict)
+    assert "foo" in deserialized.np_deep
+    foo_list = deserialized.np_deep["foo"]
+    assert len(foo_list) == 2
+    assert isinstance(foo_list[0], tuple)
+    assert isinstance(foo_list[1], tuple)
+    first_data, first_str = foo_list[0]
+    second_data, second_str = foo_list[1]
+    assert first_data == other_data
+    assert first_str == "other"
+    assert isinstance(second_data, np.ndarray)
+    assert np.all(second_data == np_data)
+    assert second_str == "np"
+
+
+def test_serialize_computed_field():
+    class Model(BaseModelWithNumpy):
+        should_compute_nan: bool
+
+        @pydantic.computed_field
+        @property
+        def computed_float(self) -> float:
+            if self.should_compute_nan:
+                return np.nan
+            return 42.42
+
+        # In practice, this is kinda weird and should likely be a full field rather than
+        # a property, but it is a valid use case.
+        @pydantic.computed_field
+        @property
+        def computed_array(self) -> np.ndarray:
+            return np.array([1.0, 2.0, 3.0])
+
+    model1 = Model(should_compute_nan=False)
+    model2 = Model(should_compute_nan=True)
+
+    serialized1 = model1.model_dump_json()
+    serialized2 = model2.model_dump_json()
+
+    json_obj1 = json.loads(serialized1)
+    json_obj2 = json.loads(serialized2)
+    assert json_obj1["should_compute_nan"] is False
+    assert json_obj1["computed_float"] == 42.42
+    assert json_obj1["computed_array"] == [1.0, 2.0, 3.0]
+    assert json_obj2["should_compute_nan"] is True
+    assert json_obj2["computed_float"] == "NaN"
+    assert json_obj2["computed_array"] == [1.0, 2.0, 3.0]
+
+
+# Test serialization also in "python" mode.
+def test_model_dump_preserves_arrays():
+    class Model(BaseModelWithNumpy):
+        np_array: np.ndarray
+
+    np_data = np.array([1, 2, 3, 4.2])
+    model = Model(np_array=np_data)
+
+    serialized = model.model_dump()
+
+    assert serialized["np_array"] is np_data
+
+
+def test_model_validate_accepts_arrays():
+    class Model(BaseModelWithNumpy):
+        np_array: np.ndarray
+
+    np_data = np.array([1, 2, 3, 4.2])
+
+    model = Model.model_validate({"np_array": np_data})
+
+    assert model.np_array is np_data
+
+
+def test_model_validate_accepts_lists():
+    class Model(BaseModelWithNumpy):
+        np_array: np.ndarray
+
+    list_data = [1, 2, 3, 4.2]
+
+    model = Model.model_validate({"np_array": list_data})
+
+    assert np.all(model.np_array == np.array([1, 2, 3, 4.2]))
+
+
+# Test dtypes handling.
+def test_text_numpy_accepts_int_and_bool():
+    class Model(BaseModelWithNumpy):
+        np_array: np.ndarray
+
+    model1 = Model(np_array=np.array([1, 2, 3]))
+    model2 = Model(np_array=np.array([True, False, True]))
+
+    serialized1 = model1.model_dump_json()
+    serialized2 = model2.model_dump_json()
+
+    assert json.loads(serialized1)["np_array"] == [1, 2, 3]
+    assert json.loads(serialized2)["np_array"] == [True, False, True]
+
+    deserialized1 = Model.model_validate_json(serialized1)
+    deserialized2 = Model.model_validate_json(serialized2)
+
+    assert deserialized1.np_array.dtype == np.int64
+    assert np.all(deserialized1.np_array == np.array([1, 2, 3]))
+    assert deserialized2.np_array.dtype == np.bool_
+    assert np.all(deserialized2.np_array == np.array([True, False, True]))
+
+
+@pytest.mark.parametrize(
+    "np_data",
+    [
+        np.array(["a", "b", "c"], dtype=np.str_),
+        np.array([4.0, 2.0], dtype=np.float32),
+        np.array([5566, 6655], dtype=np.int16),
+        np.array([{"foo": 2}, {"bar": 4}]),
+    ],
+)
+def test_text_numpy_rejects_nonstandard_dtypes(np_data: np.ndarray):
+    class Model(BaseModelWithNumpy):
+        np_array: np.ndarray
+
+    model = Model(np_array=np_data)
+
+    with pytest.raises(ValueError, match="Cannot serialize .+ dtype"):
+        model.model_dump_json()
+
+
+@pytest.mark.parametrize(
+    ("invalid_float", "string_value", "equality_fn"),
+    [
+        (np.nan, "NaN", np.isnan),
+        (np.inf, "Infinity", np.isposinf),
+        (-np.inf, "-Infinity", np.isneginf),
+    ],
+)
+def test_model_dump_fixes_nan_inf(
+    invalid_float: float, string_value: str, equality_fn: Callable[[float], bool]
+):
+    class Model(BaseModelWithNumpy):
+        num: float
+        num_list: list[float]
+        num_array: jt.Float[np.ndarray, " n_elements"]
+        num_dict: dict[str, float]
+
+    model = Model(
+        num=invalid_float,
+        num_list=[0.0, invalid_float, 2.0],
+        num_array=np.array([0.0, invalid_float, 2.0]),
+        num_dict={"key": invalid_float},
+    )
+
+    serialized_dict = model.model_dump()
+    serialized_json_dict = model.model_dump(mode="json")
+    serialized_json_str = model.model_dump_json()
+
+    # non-JSON model_dump should preserve values as floats
+    assert equality_fn(serialized_dict["num"])
+    assert equality_fn(serialized_dict["num_list"][1])
+    assert equality_fn(serialized_dict["num_array"][1])
+    assert equality_fn(serialized_dict["num_dict"]["key"])
+
+    # JSON model_dump should convert to strings
+    assert serialized_json_dict["num"] == string_value
+    assert serialized_json_dict["num_list"] == [0, string_value, 2]
+    assert serialized_json_dict["num_array"] == [0, string_value, 2]
+    assert serialized_json_dict["num_dict"]["key"] == string_value
+
+    # model_dump_json should convert to strings
+    assert f'"num":"{string_value}"' in serialized_json_str
+    assert f'"num_list":[0.0,"{string_value}",2.0]' in serialized_json_str
+    assert f'"num_array":[0.0,"{string_value}",2.0]' in serialized_json_str
+    assert f'"key":"{string_value}"' in serialized_json_str
+
+
+def test_model_validate_accepts_nan_inf_strings():
+    class Model(BaseModelWithNumpy):
+        num: float
+        num_list: list[float]
+        num_array: jt.Float[np.ndarray, " n_elements"]
+        num_dict: dict[str, float]
+
+    serialized = {
+        "num": "NaN",
+        "num_list": ["NaN", "Infinity", "-Infinity"],
+        "num_array": ["NaN", "Infinity", "-Infinity"],
+        "num_dict": {"key0": "NaN", "key1": "Infinity", "key2": "-Infinity"},
+    }
+
+    model = Model.model_validate(serialized)
+
+    assert np.isnan(model.num)
+    assert np.isnan(model.num_list[0])
+    assert np.isnan(model.num_array[0])
+    assert np.isnan(model.num_dict["key0"])
+
+    assert np.isposinf(model.num_list[1])
+    assert np.isposinf(model.num_array[1])
+    assert np.isposinf(model.num_dict["key1"])
+
+    assert np.isneginf(model.num_array[2])
+    assert np.isneginf(model.num_list[2])
+    assert np.isneginf(model.num_dict["key2"])
+
+
+def test_model_dump_mixed_dict_with_nans():
+    class Inner(BaseModelWithNumpy):
+        num: float
+
+    class Outer(BaseModelWithNumpy):
+        nested: dict[str, float | Inner | list[Inner]]
+
+    model = Outer(
+        nested={
+            "direct": np.nan,
+            "wrapped": Inner(num=np.nan),
+            "wrapped_list": [Inner(num=np.nan), Inner(num=np.nan)],
+        }
+    )
+
+    serialized = model.model_dump(mode="json")
+
+    assert serialized == {
+        "nested": {
+            "direct": "NaN",
+            "wrapped": {"num": "NaN"},
+            "wrapped_list": [
+                {"num": "NaN"},
+                {"num": "NaN"},
+            ],
+        },
+    }
+
+
+def test_serialize_literal():
+    """Regression test: Literal is supported by Pydantic, but used to be broken by
+    Dapper serialization. Make sure this does not happen again."""
+
+    class Model(BaseModelWithNumpy):
+        lit_str: Literal["foo", "bar"]
+
+    model = Model(lit_str="foo")
+
+    serialized = model.model_dump_json()
+
+    json_obj = json.loads(serialized)
+    assert json_obj["lit_str"] == "foo"
+
+    with pytest.raises(ValueError, match="literal_error"):
+        Model.model_validate_json('{"lit_str":"invalid"}')
+
+
+def test_serialization_jax_array_mixed():
+    class ModelWithNpOrJaxArrays(BaseModelWithNumpy):
+        untyped_array: NpOrJaxArray
+        typed_array: jt.Float[NpOrJaxArray, " n_elements"]
+
+    model = ModelWithNpOrJaxArrays(
+        untyped_array=jnp.array([1.0, 2.0, 3.0], dtype=np.float64),
+        typed_array=jnp.array([4.0, 5.0, 6.0], dtype=np.float64),
+    )
+
+    # Still JAX arrays!
+    assert isinstance(model.untyped_array, jnp.ndarray)
+    assert isinstance(model.typed_array, jnp.ndarray)
+
+    serialized = model.model_dump_json()
+
+    json_obj = json.loads(serialized)
+    assert isinstance(json_obj["untyped_array"], list)
+    assert json_obj["untyped_array"] == [1.0, 2.0, 3.0]
+    assert isinstance(json_obj["typed_array"], list)
+    assert json_obj["typed_array"] == [4.0, 5.0, 6.0]
+
+    reconstructed = ModelWithNpOrJaxArrays.model_validate_json(serialized)
+
+    # After validation, arrays come back as numpy!
+    assert isinstance(reconstructed.untyped_array, np.ndarray)
+    np.testing.assert_equal(reconstructed.untyped_array, np.array([1.0, 2.0, 3.0]))
+    assert isinstance(reconstructed.typed_array, np.ndarray)
+    np.testing.assert_equal(reconstructed.typed_array, np.array([4.0, 5.0, 6.0]))
+
+
+def test_validation_jax_only_fails():
+    """We do not allow serializing JAX-only arrays in DapperData."""
+
+    class ModelWithOnlyJaxArrays(BaseModelWithNumpy):
+        jax_only_array: jt.Array
+
+    with pytest.raises(ValueError):  # noqa: PT011
+        ModelWithOnlyJaxArrays.model_validate_json('{"jax_only_array":[1.0, 2.0, 3.0]}')


### PR DESCRIPTION
### TL;DR

Added a class to help with serialization and deserialization of classes with numpy arrays annotated with jaxtyping.

Differences to serialization in repo:
- No binary blobs
- Works with `jaxtyping > 0.3.0` by matching on `jt.AbstractArray`

## Why?
numpydantic is aiming to solve a lot more than we need and caused more issues with the type system than it solved 😥.
Internally we use a different approach, which works nicely. This stripped down version of that library should make integration smoother.