### PR TITLE
[flow control] Convert while to for loop (num_eqsolve_retries_)

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -654,16 +654,21 @@ absl::StatusOr<bool> Vmec::SolveEquilibrium(
     bool lreset_internal = false;
 
     absl::StatusOr<SolveEqLoopStatus> s = SolveEqLoopStatus::MUST_RETRY;
-    while (s.ok() && *s == SolveEqLoopStatus::MUST_RETRY) {
-#pragma omp single
-      {
-        // !!! THIS must be the ONLY place where this gets incremented !!!
-        num_eqsolve_retries_++;
-      }
 
+    // n_local_eqsolve_retries is a thread-local counter
+    // max iterations only to ensure this terminates eventually, should never be
+    // reached.
+    int n_local_eqsolve_retries = 0;
+    for (n_local_eqsolve_retries = 0;
+         n_local_eqsolve_retries < fc_.niterv && s.ok() &&
+         *s == SolveEqLoopStatus::MUST_RETRY;
+         n_local_eqsolve_retries++) {
       s = SolveEquilibriumLoop(thread_id, iterations_before_checkpointing,
                                checkpoint, lreset_internal);
     }
+#pragma omp single nowait  // nowait because critical below has an implicit
+                           // barrier
+    num_eqsolve_retries_ += n_local_eqsolve_retries;
 
 #pragma omp critical
     {


### PR DESCRIPTION
Part of the mission to track down why VMEC++ sometimes doesn't terminate.

The control flow _should_ never reach niterv resets, but this makes it easier to reason that it will definitely terminate.