### PR TITLE
Add ubsan to the CI

### DIFF
--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -13,9 +13,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  asan:
-    name: Address sanitizer
+  sanitizer:
+    name: Run ${{ matrix.sanitizer }}
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        sanitizer: [asan, ubsan]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -26,7 +29,7 @@ jobs:
       - name: Build VMEC++ via bazel
         run: |
           cd src/vmecpp/cpp
-          bazel build --config=asan -- //...
+          bazel build --config=${{ matrix.sanitizer }} -- //...
       - uses: actions/checkout@v4
         with:
           repository: proximafusion/vmecpp_large_cpp_tests
@@ -35,8 +38,8 @@ jobs:
       - name: Build VMEC++ C++ tests via bazel
         run: |
           cd src/vmecpp/cpp
-          bazel build --config=asan -- //vmecpp_large_cpp_tests/...
-      - name: Test with ASAN
+          bazel build --config=${{ matrix.sanitizer }} -- //vmecpp_large_cpp_tests/...
+      - name: Test with ${{ matrix.sanitizer }}
         run: |
           cd src/vmecpp/cpp
-          bazel test --test_timeout=3600 --jobs=1 --config=asan --test_output=errors -- //...
+          bazel test --test_timeout=3600 --jobs=1 --config=${{ matrix.sanitizer }} --test_output=errors -- //...

--- a/src/vmecpp/cpp/.bazelrc
+++ b/src/vmecpp/cpp/.bazelrc
@@ -11,6 +11,8 @@ build:opt   -c opt --copt="-O3" --copt="-fno-math-errno"
 build:perf  -c opt --copt="-O3" --copt="-fno-math-errno" --copt="-g" --strip=never --copt="-fno-omit-frame-pointer"
 build:dbg   -c dbg --copt="-O0"
 build:asan  -c dbg --features=asan --strip=never
+# Undefined behavior sanitization is quite slow, to compensate we compile in opt mode
+build:ubsan -c opt --features=ubsan --strip=never
 
 # We observe CPU overloads when having too many OpenMP threads in parallel on the CI machines.
 # So far, it looks similar to this issue: https://stackoverflow.com/q/70126350


### PR DESCRIPTION
### TL;DR

Added Undefined Behavior Sanitizer (UBSan) to the CI workflow alongside the existing Address Sanitizer (ASan).
https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html

### Why make this change?

I observed rare instances of nan values in output quantities, and wondered if there are remaining undefined behavior/uninitialized memory issues that ASan doesn't detect:
- Integer overflow
- Null pointer dereference
- Using misaligned pointers
- Signed integer overflow
- Array bounds violations

Two minor UB cases were caught (downstack PRs), but mainly this will ensure we don't introduce UB with upstack refactorings.