### PR TITLE
Converted ivac counter to an enum with descriptive states

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/util/util.h
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.h
@@ -162,6 +162,20 @@ enum class VmecStatus : std::uint8_t {
   SUCCESSFUL_TERMINATION = 11
 };
 
+enum class VacuumPressureState : std::int8_t {
+  // No vacuum pressure
+  kOff = -1,
+  // No vacuum pressure yet, force free-boundary update
+  kInitializing = 0,
+  // vacuum pressure turned on
+  // soft restart equilibrium calculation by returning BAD_JACOBIAN
+  // in the process of reducing rCon0,zCon0 *= 0.9;
+  kInitialized = 1,
+  // vacuum pressure turned on
+  // in the process of reducing rCon0,zCon0 *= 0.9;
+  kActive = 2
+};
+
 int VmecStatusCode(const VmecStatus vmec_status);
 
 std::string VmecStatusAsString(const VmecStatus vmec_status);

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
@@ -39,7 +39,7 @@ void ForcesToFourier3DSymmFastPoloidal(const RealSpaceForces& d,
                                        const RadialPartitioning& rp,
                                        const FlowControl& fc, const Sizes& s,
                                        const FourierBasisFastPoloidal& fb,
-                                       int ivac,
+                                       VacuumPressureState ivac,
                                        FourierForces& physical_forces);
 
 // Implemented as a free function for easier testing and benchmarking.
@@ -68,7 +68,7 @@ class IdealMhdModel {
                 const VmecConstants* constants, ThreadLocalStorage* m_ls,
                 HandoverStorage* m_h, const RadialPartitioning* r,
                 FreeBoundaryBase* m_fb, int signOfJacobian, int nvacskip,
-                int* m_ivac);
+                VacuumPressureState* m_ivac);
 
   void setFromINDATA(int ncurr, double adiabaticIndex, double tCon0);
 
@@ -419,7 +419,7 @@ class IdealMhdModel {
   HandoverStorage& m_h_;
   const RadialPartitioning& r_;
   FreeBoundaryBase* m_fb_;
-  int& m_ivac_;
+  VacuumPressureState& m_ivac_;
 
   int signOfJacobian;
 

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -1277,8 +1277,8 @@ vmecpp::OutputQuantities vmecpp::ComputeOutputQuantities(
     const std::vector<std::unique_ptr<FourierGeometry>>& decomposed_x,
     const std::vector<std::unique_ptr<IdealMhdModel>>& models_from_threads,
     const std::vector<std::unique_ptr<RadialProfiles>>& radial_profiles,
-    const VmecCheckpoint& checkpoint, int ivac, VmecStatus vmec_status,
-    int iter2) {
+    const VmecCheckpoint& checkpoint, VacuumPressureState ivac,
+    VmecStatus vmec_status, int iter2) {
   OutputQuantities output_quantities;
 
   output_quantities.vmec_internal_results = GatherDataFromThreads(
@@ -3438,7 +3438,7 @@ vmecpp::ComputeIntermediateThreed1GeometricMagneticQuantities(
     const VmecInternalResults& vmec_internal_results,
     const JxBOutFileContents& jxbout,
     const Threed1FirstTableIntermediate& threed1_first_table_intermediate,
-    int ivac) {
+    VacuumPressureState ivac) {
   Threed1GeometricAndMagneticQuantitiesIntermediate intermediate;
 
   // Calculate mean (toroidally averaged) poloidal cross section area & toroidal
@@ -3557,7 +3557,7 @@ vmecpp::ComputeIntermediateThreed1GeometricMagneticQuantities(
     intermediate.redge[kl] =
         vmec_internal_results.r_e(lcfs_kl) + vmec_internal_results.r_o(lcfs_kl);
   }  // kl
-  if (fc.lfreeb && ivac > 1) {
+  if (fc.lfreeb && ivac == VacuumPressureState::kActive) {
     for (int k = 0; k < s.nZeta; ++k) {
       for (int l = 0; l < s.nThetaEff; ++l) {
         // FIXME(eguiraud) slow loop for nestor
@@ -4076,7 +4076,8 @@ vmecpp::Threed1ShafranovIntegrals vmecpp::ComputeThreed1ShafranovIntegrals(
     const VmecInternalResults& vmec_internal_results,
     const Threed1GeometricAndMagneticQuantitiesIntermediate&
         threed1_geometric_magnetic_intermediate,
-    const Threed1GeometricAndMagneticQuantities& threed1_geomag, int ivac) {
+    const Threed1GeometricAndMagneticQuantities& threed1_geomag,
+    VacuumPressureState ivac) {
   Threed1ShafranovIntegrals result;
 
   // Shafranov surface integrals s1,s2
@@ -4085,7 +4086,7 @@ vmecpp::Threed1ShafranovIntegrals vmecpp::ComputeThreed1ShafranovIntegrals(
   // Note: if ctor = 0, use Int(Bsupu*Bsubu dV) for ctor*ctor/R
   // Phys. Fluids B, Vol 5 (1993) p 3121, Eq. 9a-9d
   std::vector<double> bpol2vac(s.nZnT, 0.0);
-  if (fc.lfreeb && ivac > 1) {
+  if (fc.lfreeb && ivac == vmecpp::VacuumPressureState::kActive) {
     for (int l = 0; l < s.nThetaEff; ++l) {
       for (int k = 0; k < s.nZeta; ++k) {
         // FIXME(eguiraud) slow loop for nestor

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
@@ -1350,8 +1350,8 @@ OutputQuantities ComputeOutputQuantities(
     const std::vector<std::unique_ptr<FourierGeometry> >& decomposed_x,
     const std::vector<std::unique_ptr<IdealMhdModel> >& models_from_threads,
     const std::vector<std::unique_ptr<RadialProfiles> >& radial_profiles,
-    const VmecCheckpoint& checkpoint, int ivac, VmecStatus vmec_status,
-    int iter2);
+    const VmecCheckpoint& checkpoint, VacuumPressureState ivac,
+    VmecStatus vmec_status, int iter2);
 
 // gather data from all threads into the main thread
 VmecInternalResults GatherDataFromThreads(
@@ -1444,7 +1444,7 @@ ComputeIntermediateThreed1GeometricMagneticQuantities(
     const VmecInternalResults& vmec_internal_results,
     const JxBOutFileContents& jxbout,
     const Threed1FirstTableIntermediate& threed1_first_table_intermediate,
-    int ivac);
+    VacuumPressureState ivac);
 
 Threed1GeometricAndMagneticQuantities ComputeThreed1GeometricMagneticQuantities(
     const Sizes& s, const FlowControl& fc,
@@ -1477,7 +1477,8 @@ Threed1ShafranovIntegrals ComputeThreed1ShafranovIntegrals(
     const VmecInternalResults& vmec_internal_results,
     const Threed1GeometricAndMagneticQuantitiesIntermediate&
         threed1_geometric_magnetic_intermediate,
-    const Threed1GeometricAndMagneticQuantities& threed1_geomag, int ivac);
+    const Threed1GeometricAndMagneticQuantities& threed1_geomag,
+    VacuumPressureState ivac);
 
 WOutFileContents ComputeWOutFileContents(
     const VmecINDATA& indata, const Sizes& s, const FourierBasisFastPoloidal& t,

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
@@ -140,7 +140,7 @@ class Vmec {
                        const FourierForces& decomposed_f,
                        HandoverStorage& m_h_) const;
 
-  int get_ivac() const { return ivac_; }
+  int get_ivac() const { return static_cast<int>(ivac_); }
   int get_num_eqsolve_retries() const { return num_eqsolve_retries_; }
   VmecStatus get_status() const { return status_; }
   int get_iter1() const { return iter1_; }
@@ -204,8 +204,7 @@ class Vmec {
   bool verbose_;
 
   // initialization state counter for Nestor
-  // TODO(eguiraud): make this an enum and document the various states
-  int ivac_;
+  VacuumPressureState ivac_;
 
   // 0 if in regular multi-grid sequence;
   // 1 if have tried from scratch with intermediate ns=3, ftolv=1.0e-4


### PR DESCRIPTION
### TL;DR

Replaced integer-based vacuum pressure state tracking with a strongly-typed enum for better clarity.

### What changed?

- Added a new `PlasmaPressureState` enum class to replace the integer-based `ivac` variable
- Defined clear states for vacuum pressure: `OFF`, `INITIALIZED0`, `INITIALIZED`, and `ACTIVE`
- Updated all references to `ivac` throughout the codebase to use the new enum
- Replaced numeric comparisons with explicit enum state checks