### PR TITLE
Don't cancel CI on main

### DIFF
--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -10,7 +10,7 @@ on:
 # From https://stackoverflow.com/a/72408109.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   sanitizer:

--- a/.github/workflows/clang_tidy.yaml
+++ b/.github/workflows/clang_tidy.yaml
@@ -11,7 +11,7 @@ on:
 # From https://stackoverflow.com/a/72408109.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   clang-tidy:

--- a/.github/workflows/pyright.yaml
+++ b/.github/workflows/pyright.yaml
@@ -10,7 +10,7 @@ on:
 # From https://stackoverflow.com/a/72408109.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   tests:

--- a/.github/workflows/test_bazel.yaml
+++ b/.github/workflows/test_bazel.yaml
@@ -10,7 +10,7 @@ on:
 # From https://stackoverflow.com/a/72408109.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   tests:

--- a/.github/workflows/test_conda_env.yaml
+++ b/.github/workflows/test_conda_env.yaml
@@ -10,7 +10,7 @@ on:
 # From https://stackoverflow.com/a/72408109.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   test-conda-env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ on:
 # From https://stackoverflow.com/a/72408109.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Run all CI, even when newer commits are available, so we can always see a green history on main ✔️ 