### PR TITLE
Pass Magnetic response table to Python layer by reference

### DIFF
--- a/examples/freeboundary_run_and_hot_restart.py
+++ b/examples/freeboundary_run_and_hot_restart.py
@@ -27,18 +27,21 @@ magnetic_response_table = vmecpp.MagneticFieldResponseTable.from_coils_file(
 # The OutputQuantities object returned has attributes corresponding
 # to the usual outputs: wout, jxbout, mercier, ...
 vmec_output = vmecpp.run(vmec_input, magnetic_field=magnetic_response_table)
-print("  initial volume:", vmec_output.wout.volume_p)
 
-# Now let's perturb the plasma boundary a little bit...
-vmec_input.rbc[0, 0] *= 0.8
-vmec_input.rbc[1, 0] *= 1.2
+# Now let's perturb the magnetic field...
+magnetic_response_table.b_p *= 1.05
+magnetic_response_table.b_r *= 1.05
+magnetic_response_table.b_z *= 1.05
 
 # ...and run VMEC++ again, but using its "hot restart" feature:
 # passing the previously obtained output_quantities ensures that
 # the run starts already close to the equilibrium, so it will take
-# very few iterations to converge this time.
+# fewer iterations to converge this time.
 perturbed_output = vmecpp.run(
     vmec_input, magnetic_field=magnetic_response_table, restart_from=vmec_output
 )
+# Because we increased the magnetic field strength by 5%, but kept the enclosed magnetic
+# flux the same (vmec_input.phiedge), the volume reduced by 5%.
+print("initial   volume:", vmec_output.wout.volume_p)
 print("perturbed volume:", perturbed_output.wout.volume_p)
 print("Difference:      ", vmec_output.wout.volume_p - perturbed_output.wout.volume_p)

--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -18,12 +18,12 @@ import numpy as np
 import pydantic
 
 from vmecpp import _util
-from vmecpp._pydantic_numpy import BaseModelWithNumpy
-from vmecpp.cpp import _vmecpp  # type: ignore # bindings to the C++ core
-from vmecpp.free_boundary import (
+from vmecpp._free_boundary import (
     MagneticFieldResponseTable,
     MakegridParameters,
 )
+from vmecpp._pydantic_numpy import BaseModelWithNumpy
+from vmecpp.cpp import _vmecpp  # type: ignore # bindings to the C++ core
 
 logger = logging.getLogger(__name__)
 
@@ -1376,7 +1376,7 @@ def run(
         cpp_indata.mgrid_file = "NONE"
         cpp_output_quantities = _vmecpp.run(
             cpp_indata,
-            magnetic_response_table=magnetic_field,
+            magnetic_response_table=magnetic_field._to_cpp_magnetic_field_response_table(),
             initial_state=initial_state,
             max_threads=max_threads,
             verbose=verbose,

--- a/src/vmecpp/_free_boundary.py
+++ b/src/vmecpp/_free_boundary.py
@@ -116,6 +116,29 @@ class MagneticFieldResponseTable(BaseModelWithNumpy):
             cpp_response_table
         )
 
+    def _to_cpp_magnetic_field_response_table(
+        self,
+    ) -> _vmecpp.MagneticFieldResponseTable:
+        """Convert the Pydantic object to a C++ MagneticFieldResponseTable object,
+        avoiding a copy if possible."""
+        # If vmecpp.MagneticFieldResponseTable was created from a C++ object, the
+        # arrays be views to the memory of the C++ object. We don't need to create
+        # a new object and just return the underling one.
+        underlying = self.b_r.base
+        if (
+            isinstance(underlying, _vmecpp.MagneticFieldResponseTable)
+            and underlying == self.b_p.base
+            and underlying == self.b_z.base
+        ):
+            return underlying
+        # Otherwise, create a new C++ object
+        return _vmecpp.MagneticFieldResponseTable(
+            self.parameters._to_cpp_makegrid_parameters(),
+            self.b_r,
+            self.b_p,
+            self.b_z,
+        )
+
 
 __all__ = [
     "MagneticFieldResponseTable",

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -719,18 +719,23 @@ PYBIND11_MODULE(_vmecpp, m) {
             return GetValueOrThrow(maybe_config);
           },
           py::arg("file"));
-  py::class_<makegrid::MagneticFieldResponseTable>(m,
-                                                   "MagneticFieldResponseTable")
-      .def(
-          py::init<const makegrid::MakegridParameters &,
-                   const makegrid::RowMatrixXd &, const makegrid::RowMatrixXd &,
-                   const makegrid::RowMatrixXd &>(),
-          py::arg("parameters"), py::arg("b_r"), py::arg("b_p"), py::arg("b_z"))
-      .def_readonly("parameters",
-                    &makegrid::MagneticFieldResponseTable::parameters)
-      .def_readwrite("b_r", &makegrid::MagneticFieldResponseTable::b_r)
-      .def_readwrite("b_p", &makegrid::MagneticFieldResponseTable::b_p)
-      .def_readwrite("b_z", &makegrid::MagneticFieldResponseTable::b_z);
+  auto response_table =
+      py::class_<makegrid::MagneticFieldResponseTable>(
+          m, "MagneticFieldResponseTable")
+          .def(py::init<const makegrid::MakegridParameters &,
+                        const makegrid::RowMatrixXd &,
+                        const makegrid::RowMatrixXd &,
+                        const makegrid::RowMatrixXd &>(),
+               py::arg("parameters"), py::arg("b_r"), py::arg("b_p"),
+               py::arg("b_z"))
+          .def_readonly("parameters",
+                        &makegrid::MagneticFieldResponseTable::parameters);
+  DefEigenProperty(response_table, "b_r",
+                   &makegrid::MagneticFieldResponseTable::b_r);
+  DefEigenProperty(response_table, "b_p",
+                   &makegrid::MagneticFieldResponseTable::b_p);
+  DefEigenProperty(response_table, "b_z",
+                   &makegrid::MagneticFieldResponseTable::b_z);
 
   m.def(
       "compute_magnetic_field_response_table",

--- a/tests/test_free_boundary.py
+++ b/tests/test_free_boundary.py
@@ -3,9 +3,13 @@
 # SPDX-License-Identifier: MIT
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 import vmecpp
+
+REPO_ROOT = Path(__file__).parent.parent
+TEST_DATA_DIR = REPO_ROOT / "src" / "vmecpp" / "cpp" / "vmecpp" / "test_data"
 
 
 @pytest.fixture
@@ -13,42 +17,140 @@ def makegrid_params() -> vmecpp.MakegridParameters:
     return vmecpp.MakegridParameters(
         normalize_by_currents=True,
         assume_stellarator_symmetry=True,
-        number_of_field_periods=5,
+        number_of_field_periods=2,
         r_grid_minimum=0.1,
         r_grid_maximum=1.0,
         number_of_r_grid_points=10,
         z_grid_minimum=-0.5,
         z_grid_maximum=0.5,
         number_of_z_grid_points=20,
-        number_of_phi_grid_points=30,
+        number_of_phi_grid_points=20,
+    )
+
+
+def test_run_free_boundary_from_response_table():
+    makegrid_params = vmecpp.MakegridParameters.from_file(
+        TEST_DATA_DIR / "makegrid_parameters_cth_like.json"
+    )
+    # Lower the makegrid resolution
+    makegrid_params.number_of_r_grid_points = 31
+    makegrid_params.number_of_phi_grid_points = 36
+    makegrid_params.number_of_z_grid_points = 20
+    response = vmecpp.MagneticFieldResponseTable.from_coils_file(
+        TEST_DATA_DIR / "coils.cth_like", makegrid_params
+    )
+    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cth_like_free_bdy.json")
+    vmec_output = vmecpp.run(vmec_input, response)
+    assert vmec_output.wout.volume == pytest.approx(0.307512, 1e-5, 1e-5)
+
+    # Test hot-restart functionality
+    hot_restart_output = vmecpp.run(
+        vmec_input, magnetic_field=response, restart_from=vmec_output
+    )
+    # The change in initial guess should only result in a tiny change in output
+    assert hot_restart_output.wout.volume != vmec_output.wout.volume
+    assert hot_restart_output.wout.volume == pytest.approx(
+        vmec_output.wout.volume, 1e-5, 1e-5
     )
 
 
 def test_makegrid_parameters_conversion(makegrid_params):
-    # Convert to Python and back to C++
+    # Convert resolution parameters to C++ and back to Python
     cpp_params = makegrid_params._to_cpp_makegrid_parameters()
     py_params = vmecpp.MakegridParameters._from_cpp_makegrid_parameters(cpp_params)
     assert makegrid_params == py_params
 
 
+def test_response_table_conversion(makegrid_params):
+    # Create a dummy response table
+    response_table = vmecpp.MagneticFieldResponseTable(
+        parameters=makegrid_params,
+        b_r=np.linspace(0, 1, 10 * 20 * 20).reshape((1, 10 * 20 * 20)),
+        b_z=np.linspace(0, 1, 10 * 20 * 20).reshape((1, 10 * 20 * 20)),
+        b_p=np.linspace(0, 1, 10 * 20 * 20).reshape((1, 10 * 20 * 20)),
+    )
+
+    # Convert to C++ and back to Python
+    cpp_response_table = response_table._to_cpp_magnetic_field_response_table()
+    py_response_table = (
+        vmecpp.MagneticFieldResponseTable._from_cpp_magnetic_field_response_table(
+            cpp_response_table
+        )
+    )
+
+    np.testing.assert_allclose(response_table.b_r, py_response_table.b_r)
+    np.testing.assert_allclose(response_table.b_z, py_response_table.b_z)
+    np.testing.assert_allclose(response_table.b_p, py_response_table.b_p)
+
+
+def test_response_table_round_trip(makegrid_params):
+    """Check that converting C++ to Python and back returns the original C++ object
+    instead of a new copy."""
+    cpp_response1 = vmecpp._vmecpp.MagneticFieldResponseTable(
+        parameters=makegrid_params._to_cpp_makegrid_parameters(),
+        b_r=np.linspace(0, 1, 10).reshape((1, 10)),
+        b_z=np.linspace(0, 1, 10).reshape((1, 10)),
+        b_p=np.linspace(0, 1, 10).reshape((1, 10)),
+    )
+    py_response = (
+        vmecpp.MagneticFieldResponseTable._from_cpp_magnetic_field_response_table(
+            cpp_response1
+        )
+    )
+    # Read-write arrays
+    assert py_response.b_p.flags["WRITEABLE"]
+    assert py_response.b_p.flags["C_CONTIGUOUS"]
+    assert py_response.b_p.flags["ALIGNED"]
+
+    cpp_response2 = py_response._to_cpp_magnetic_field_response_table()
+
+    assert isinstance(cpp_response1, vmecpp._vmecpp.MagneticFieldResponseTable)
+    assert cpp_response1 == cpp_response2
+
+    np.testing.assert_equal(cpp_response1.b_r, cpp_response2.b_r)
+    np.testing.assert_equal(cpp_response1.b_z, cpp_response2.b_z)
+    np.testing.assert_equal(cpp_response1.b_p, cpp_response2.b_p)
+
+    # Since they reference the same memory, changes should be visible in all objects
+    cpp_response2.b_r[0, 0] = 5
+    assert cpp_response1.b_r[0, 0] == 5
+    np.testing.assert_equal(cpp_response1.b_r, cpp_response2.b_r)
+    np.testing.assert_equal(py_response.b_r, cpp_response2.b_r)
+
+
+def test_response_table_py_to_cpp_copy(makegrid_params):
+    """When creating a MagneticFieldResponseTable C++ object from a Pydantic object, the
+    arrays are copies and NOT linked, but copied."""
+    response_table = vmecpp.MagneticFieldResponseTable(
+        parameters=makegrid_params,
+        b_r=np.linspace(0, 1, 10 * 20 * 20).reshape((1, 10 * 20 * 20)),
+        b_z=np.linspace(0, 1, 10 * 20 * 20).reshape((1, 10 * 20 * 20)),
+        b_p=np.linspace(0, 1, 10 * 20 * 20).reshape((1, 10 * 20 * 20)),
+    )
+
+    # Convert to C++, this will copy the data
+    cpp_response_table = response_table._to_cpp_magnetic_field_response_table()
+    assert cpp_response_table.b_p.flags["WRITEABLE"]
+    assert cpp_response_table.b_p.flags["C_CONTIGUOUS"]
+    assert cpp_response_table.b_p.flags["ALIGNED"]
+    assert cpp_response_table.b_r.base is not response_table.b_r.base
+
+
 def test_magnetic_field_response_table_loading(makegrid_params):
-    coils_file = "path/to/invalid_coils_file"
+    invalid_coils_file = "path/to/invalid_coils_file"
     with pytest.raises(RuntimeError):
-        vmecpp.MagneticFieldResponseTable.from_coils_file(coils_file, makegrid_params)
+        vmecpp.MagneticFieldResponseTable.from_coils_file(
+            invalid_coils_file, makegrid_params
+        )
     # Test with a valid file
-    coils_file = (
-        Path(__file__).parent.parent
-        / "src"
-        / "vmecpp"
-        / "cpp"
-        / "vmecpp"
+    response = vmecpp.MagneticFieldResponseTable.from_coils_file(
+        TEST_DATA_DIR
+        / ".."
         / "common"
         / "makegrid_lib"
         / "test_data"
-        / "coils.test_symmetric_even"
-    )
-    response = vmecpp.MagneticFieldResponseTable.from_coils_file(
-        coils_file, makegrid_params
+        / "coils.test_symmetric_even",
+        makegrid_params,
     )
     assert response.b_p.shape == response.b_r.shape
     assert response.b_z.shape == response.b_p.shape


### PR DESCRIPTION
### TL;DR

Improve free boundary VMEC++ functionality by optimizing memory management and adding a demonstration of magnetic field perturbation.

### What changed?

- Renamed `free_boundary.py` to `_free_boundary.py` to indicate it's an internal module
- Added `_to_cpp_magnetic_field_response_table()` method to fix free-boundary run calls
- Modified the C++ bindings to use `DefEigenProperty` for the magnetic field arrays, to avoid unnecessary copies when converting between Python and C++ objects and make the pydantic numypy arrays views to the memory allocated in C++
- Updated the free boundary example to demonstrate perturbing the magnetic field strength instead of the plasma boundary
- Added tests for the free boundary functionality, including memory sharing and hot restart capabilities

### How to test?

- Run the updated `examples/freeboundary_run_and_hot_restart.py` to see the effect of perturbing the magnetic field

### Why make this change?

- Allows passing and handling the MagneticFieldReponseTable memory in place