### PR TITLE
Generalized wout handling, supports arbitrary extra fields now

### DIFF
--- a/src/vmecpp/_util.py
+++ b/src/vmecpp/_util.py
@@ -412,3 +412,18 @@ def sparse_to_dense_coefficients_implicit(
         ntor = int(max(ntor, abs(sparse_entry["n"])))
     mpol += 1
     return sparse_to_dense_coefficients(maybe_sparse_list, mpol, ntor)
+
+
+def pad_to_target(value, target_length: int, default_value: float):
+    if len(value) <= target_length:
+        return np.pad(
+            value,
+            (0, target_length - len(value)),
+            mode="constant",
+            constant_values=default_value,
+        )
+    msg = (
+        f"Array length {len(value)} exceeds target "
+        f"length {target_length} allowed for serialization"
+    )
+    raise ValueError(msg)


### PR DESCRIPTION
## Design Logic
Pydantic provides all kinds of hooks to modify data before serialization and the ability to set a `field_alias`. We combine these features to dump wout files with arbitrary fields, and handle subtle differences betwee `VmecWOut` Python type and the NetCDF type. 

- Special handling (e.g. allow for padding, interpret as int but serialize as float) is done in the pre/post `BeforeValidator` and `PlainSerializer` hooks
- The dimension annotations of the fields == wout dimensions
