### PR TITLE
Skip gradual vacuum pressure activation on hot-restart

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/util/util.h
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.h
@@ -165,12 +165,16 @@ enum class VmecStatus : std::uint8_t {
 enum class VacuumPressureState : std::int8_t {
   // No vacuum pressure
   kOff = -1,
-  // No vacuum pressure yet, force free-boundary update
+
+  // No vacuum pressure yet, force free-boundary update, but ignore the result
+  // in this force-balance computation.
   kInitializing = 0,
-  // vacuum pressure turned on
-  // soft restart equilibrium calculation by returning BAD_JACOBIAN
-  // in the process of reducing rCon0,zCon0 *= 0.9;
+
+  // vacuum pressure turned on.
+  // soft restart equilibrium calculation by returning BAD_JACOBIAN in the
+  // process of reducing rCon0,zCon0 *= 0.9;
   kInitialized = 1,
+
   // vacuum pressure turned on
   // in the process of reducing rCon0,zCon0 *= 0.9;
   kActive = 2

--- a/src/vmecpp/cpp/vmecpp/free_boundary/free_boundary_base/free_boundary_base.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/free_boundary_base/free_boundary_base.h
@@ -58,10 +58,18 @@ class FreeBoundaryBase {
   SurfaceGeometry sg_;
   ExternalMagneticField ef_;
 
+  // [nZnT] vacuum magnetic pressure |B_vac^2|/2 at the plasma boundary
+  // Points to vacuum_magnetic_pressure in HandoverStorage
   std::span<double> bSqVacShare;
 
+  // [nZnT] cylindrical B^R of Nestor's vacuum magnetic field
+  // Points to vacuum_b_r in HandoverStorage
   std::span<double> vacuum_b_r_share_;
+  // [nZnT] cylindrical B^phi of Nestor's vacuum magnetic field
+  // Points to vacuum_b_phi in HandoverStorage
   std::span<double> vacuum_b_phi_share_;
+  // [nZnT] cylindrical B^Z of Nestor's vacuum magnetic field
+  // Points to vacuum_b_z in HandoverStorage
   std::span<double> vacuum_b_z_share_;
 };  // FreeBoundaryBase
 

--- a/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
@@ -88,6 +88,9 @@ class HandoverStorage {
   // Amperes
   double bSubVVac;
 
+  // Used only in rzConIntoVolume() to extrapolate the constraint force
+  // contribution from the LCFS into the plasma volume.
+  // TODO(jurasic) this should have a smaller scope.
   std::vector<double> rCon_LCFS;
   std::vector<double> zCon_LCFS;
 

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -862,7 +862,9 @@ absl::StatusOr<bool> IdealMhdModel::update(
   // end of bcovar
 
   // back in funct3d, free-boundary force contribution active?
-  if (m_fc_.lfreeb && iter2 > 1) {
+  // This can even happen in the first iteration when hot-restarted.
+  if (m_fc_.lfreeb &&
+      (iter2 > 1 || m_vacuum_pressure_state_ != VacuumPressureState::kOff)) {
     ivacskip = (iter2 - iter1) % nvacskip;
     // when R+Z force residuals are <1e-3, enable vacuum contribution
     if (m_vacuum_pressure_state_ != VacuumPressureState::kActive &&
@@ -887,7 +889,8 @@ absl::StatusOr<bool> IdealMhdModel::update(
         m_last_full_update_nestor = iter2;
       }
     }
-
+// protects read of `m_vacuum_pressure_state_` below from the write above
+#pragma omp barrier
     if (m_vacuum_pressure_state_ != VacuumPressureState::kOff) {
       // IF INITIALLY ON, MUST TURN OFF rcon0, zcon0 SLOWLY
       for (int jF = r_.nsMinF; jF < r_.nsMaxF; ++jF) {
@@ -1076,10 +1079,24 @@ absl::StatusOr<bool> IdealMhdModel::update(
 
   // COMPUTE INVARIANT RESIDUALS
 
-  // include edge contribution only if converged well enough fast enough (?)
+  // include edge contribution if the equilibrium has converged very quickly,
+  // to prevent a strong force-imbalance at the LCFS-vacuum transition, since
+  // the termination criterion based on sum(force residuals) < ftol only
+  // considers the inner flux-surfaces, but not the balance with the magnetic
+  // pressure in vacuum at the LCFS. This special case includes that force
+  // contribution in the first few iterations, preventing termination, to
+  // ensure the free-boundary forces have "enough time" to propagate through
+  // to the inner surfaces.
+  // TODO(jurasic) the hard-coded 50 and 1e-6 are only here for backwards
+  // compatibility, ideally vacuum-pressure should always part of the
+  // force-balance
+  bool almost_converged = (m_fc.fsqr + m_fc.fsqz) < 1.0e-6;
+  // In iter==1, the forces are initialized to 1.0 so includeEdgeRZForces
+  // wouldn't trigger without special handling for the hot-restart case.
+  bool hot_restart = (iter2 == 1 && m_vacuum_pressure_state_ ==
+                                        VacuumPressureState::kInitialized);
   bool includeEdgeRZForces =
-      ((iter2 - iter1) < 50 && (m_fc.fsqr + m_fc.fsqz) < 1.0e-6);
-
+      ((iter2 - iter1) < 50 && (almost_converged || hot_restart));
   std::vector<double> localFResInvar(3, 0.0);
   m_decomposed_f.residuals(localFResInvar, includeEdgeRZForces);
 
@@ -1392,7 +1409,12 @@ void IdealMhdModel::dft_FourierToReal_2d_symm(
   }  // jF
 }  // dft_FourierToReal_2d_symm
 
-/** extrapolate (r,z)Con from boundary into volume */
+/** extrapolate (r,z)Con from boundary into volume.
+ * Only called on initialization/soft reset to set (r,z)Con0 to a large value.
+ * Since (r,z)Con0 are subtracted from (r,z)Con, this effectively disables the
+ * constraint. Over the iterations, (r,z)Con0 are gradually reduced to zero,
+ * enabling the constraint again.
+ */
 void IdealMhdModel::rzConIntoVolume() {
   // The CPU which has the LCFS needs to compute (r,z)Con at the LCFS
   // for computing (r,z)Con0 by extrapolation from the LCFS into the volume.

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
@@ -258,9 +258,15 @@ class IdealMhdModel {
   std::vector<double> rCon;
 
   // constraint force contribution Y on full-grid
+  // In free-boundary this starts as a large value and is slowly reduced to zero
+  // to gradually increase the vacuum pressure constraint (force felt from the
+  // B^2 contribution).
   std::vector<double> zCon;
 
-  // initial constraint force contribution X on full-grid
+  // initial constraint force contribution X on full-grid.
+  // In free-boundary this starts as a large value and is slowly reduced to zero
+  // to gradually increase the vacuum pressure constraint (force felt from the
+  // B^2 contribution).
   std::vector<double> rCon0;
 
   // initial constraint force contribution Y on full-grid

--- a/tests/test_free_boundary.py
+++ b/tests/test_free_boundary.py
@@ -40,17 +40,31 @@ def test_run_free_boundary_from_response_table():
         TEST_DATA_DIR / "coils.cth_like", makegrid_params
     )
     vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cth_like_free_bdy.json")
-    vmec_output = vmecpp.run(vmec_input, response)
+    vmec_output = vmecpp.run(vmec_input, response, verbose=False)
     assert vmec_output.wout.volume == pytest.approx(0.307512, 1e-5, 1e-5)
 
-    # Test hot-restart functionality
+    # Test hot-restart functionality. w/o perturbation, should converge immediately
     hot_restart_output = vmecpp.run(
         vmec_input, magnetic_field=response, restart_from=vmec_output
     )
-    # The change in initial guess should only result in a tiny change in output
-    assert hot_restart_output.wout.volume != vmec_output.wout.volume
+    assert hot_restart_output.wout.itfsq >= 1
+    # Max iterations for includeEdgeRZForces special case
+    assert hot_restart_output.wout.itfsq <= 50
     assert hot_restart_output.wout.volume == pytest.approx(
         vmec_output.wout.volume, 1e-5, 1e-5
+    )
+    FLUX_INCREASE = 1.02
+    response.b_r *= FLUX_INCREASE
+    response.b_p *= FLUX_INCREASE
+    response.b_z *= FLUX_INCREASE
+    hot_restart_output_perturbed = vmecpp.run(
+        vmec_input, magnetic_field=response, restart_from=vmec_output, verbose=False
+    )
+    assert hot_restart_output_perturbed.wout.itfsq > 1
+    assert hot_restart_output_perturbed.wout.itfsq < vmec_output.wout.itfsq
+    # The change in field strength should only result in a proportional change in volume
+    assert hot_restart_output_perturbed.wout.volume * FLUX_INCREASE == pytest.approx(
+        vmec_output.wout.volume, 1e-3, 1e-3
     )
 
 


### PR DESCRIPTION
Usually VMEC turns on the pressure gradually over the first few iterations, to improve robustness. When hot-restarting, we don't want to do that, because the initial guess should already be close to the final solution. Therefore we initialize the vacuum state to `kInitialized` from the beginning, which transitions to `kActive` after the first iteration.

One additional change to the iteration logic is required for everything to work:

The problem is that only the pre-conditioned force-balance includes the vacuum contribution, but the termination criterion (`fsqr<ftol && fsqz<ftol && fsql<ftol`) depends only on the regular, invariant forces. This means a hot-restarted, free-boundary iteration would immediately, if the inner surfaces are in force-balance, eventhough the vacuum force-balance at the LCFS may not be fullfilled at all! 
Additional logic is required to handle that case, and prevent termination at 0 iterations.