### PR TITLE
no OpenMP -> no compiler warnings

### DIFF
--- a/src/vmecpp/cpp/.bazelrc
+++ b/src/vmecpp/cpp/.bazelrc
@@ -1,18 +1,17 @@
 # general compilation options
 build --cxxopt="-std=c++20" --copt="-fdiagnostics-color=always"
-# If compiling with clang or intel compilers, you will need to adjust the linked OpenMP library from libgomp to libomp
-build --copt="-fopenmp" --linkopt="-lgomp"
 
 # workaround for a Bazel 7 issue with rules_foreign_cc: https://github.com/bazelbuild/rules_foreign_cc/issues/1129
 build --sandbox_add_mount_pair=/tmp
 
+# If compiling with clang or intel compilers, you will need to adjust the linked OpenMP library from libgomp to libomp
 # -fno-math-errno yields a few % of performance improvements and we don't check errno anyways
-build:opt   -c opt --copt="-O3" --copt="-fno-math-errno"
-build:perf  -c opt --copt="-O3" --copt="-fno-math-errno" --copt="-g" --strip=never --copt="-fno-omit-frame-pointer"
-build:dbg   -c dbg --copt="-O0"
-build:asan  -c dbg --features=asan --strip=never
+build:opt   -c opt --copt="-fopenmp" --linkopt="-lgomp" --copt="-O3" --copt="-fno-math-errno"
+build:perf  -c opt --copt="-fopenmp" --linkopt="-lgomp" --copt="-O3" --copt="-fno-math-errno" --copt="-g" --strip=never --copt="-fno-omit-frame-pointer"
+build:dbg   -c dbg --copt="-fopenmp" --linkopt="-lgomp" --copt="-O0"
+build:asan  -c dbg --copt="-fopenmp" --linkopt="-lgomp" --features=asan --strip=never
 # Undefined behavior sanitization is quite slow, to compensate we compile in opt mode
-build:ubsan -c opt --features=ubsan --strip=never
+build:ubsan -c opt --copt="-fopenmp" --linkopt="-lgomp" --features=ubsan --strip=never
 
 # We observe CPU overloads when having too many OpenMP threads in parallel on the CI machines.
 # So far, it looks similar to this issue: https://stackoverflow.com/q/70126350

--- a/src/vmecpp/cpp/vmecpp/common/flow_control/flow_control.cc
+++ b/src/vmecpp/cpp/vmecpp/common/flow_control/flow_control.cc
@@ -30,7 +30,11 @@ RestartReason RestartReasonFromInt(int restart_reason) {
 
 int get_max_threads(std::optional<int> max_threads) {
   if (max_threads == std::nullopt) {
+#ifdef _OPENMP
     return omp_get_max_threads();
+#endif  // _OPENMP
+    // Default to 1 thread if OpenMP is not available
+    return 1;
   }
   CHECK_GT(max_threads.value(), 0)
       << "The number of threads must be >=1. "

--- a/src/vmecpp/cpp/vmecpp/common/util/util.cc
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.cc
@@ -119,7 +119,9 @@ void TridiagonalSolveOpenMP(
     std::vector<std::vector<double>> &m_handover_cr,
     std::vector<double> &m_handover_az,
     std::vector<std::vector<double>> &m_handover_cz) {
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
   if (myid == 0) {
     // this is the rank that has jMin;
@@ -175,7 +177,9 @@ void TridiagonalSolveOpenMP(
     m_mutices[myid + 1].lock();
   }
 
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
   // blocks until previous thread is done with this step
   // thread 0 is free to go, since its mutex is unlocked
@@ -267,7 +271,9 @@ void TridiagonalSolveOpenMP(
     m_mutices[myid - 1].lock();
   }
 
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
   m_mutices[myid].lock();
 
@@ -324,7 +330,9 @@ void TridiagonalSolveOpenMP(
     m_mutices[myid - 1].unlock();
   }
 
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 }  // TriDiagonalSolveOpenMP
 
 int vmec_adjust_num_threads(const int max_threads,

--- a/src/vmecpp/cpp/vmecpp/common/util/util_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/util/util_test.cc
@@ -177,7 +177,9 @@ TEST(TestUtil, CheckTridiagonalSolveOpenMP) {
 
   std::vector<std::mutex> mutices(max_threads);
 
+#ifdef _OPENMP
 #pragma omp parallel
+#endif  // _OPENMP
   {
 #ifdef _OPENMP
     int ncpu = omp_get_num_threads();
@@ -187,7 +189,9 @@ TEST(TestUtil, CheckTridiagonalSolveOpenMP) {
     int myid = 0;
 #endif
 
+#ifdef _OPENMP
 #pragma omp single
+#endif  // _OPENMP
     {
       all_ar.resize(ncpu);
       all_az.resize(ncpu);
@@ -289,14 +293,18 @@ TEST(TestUtil, CheckTridiagonalSolveOpenMP) {
       }  // mn
     }  // j
 
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
     // solve tri-diagonal system
     TridiagonalSolveOpenMP(ar, dr, br, cr, az, dz, bz, cz, jMin, jMax, mnmax,
                            num_basis, mutices, ncpu, myid, nsMinF, nsMaxF,
                            handover_ar, handover_cr, handover_az, handover_cz);
 
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
     // check that solution is correct
     for (int j = nsMinF; j < nsMaxF; ++j) {
@@ -313,7 +321,9 @@ TEST(TestUtil, CheckTridiagonalSolveOpenMP) {
         }  // k
       }  // mn
     }  // j
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
   }  // omp parallel
 }  // CheckTridiagonalSolveOpenMP
 

--- a/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.cc
@@ -41,12 +41,16 @@ ExternalMagneticField::ExternalMagneticField(const Sizes* s,
 void ExternalMagneticField::update(const std::span<const double> rAxis,
                                    const std::span<const double> zAxis,
                                    double netToroidalCurrent) {
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
   mgrid_.interpolate(tp_.ztMin, tp_.ztMax, s_.nZeta, sg_.r1b, sg_.z1b, interpBr,
                      interpBp, interpBz);
 
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
   if (kUseAbscabForAxisCurrent) {
     AddAxisCurrentFieldAbscab(rAxis, zAxis, netToroidalCurrent);
@@ -54,11 +58,15 @@ void ExternalMagneticField::update(const std::span<const double> rAxis,
     AddAxisCurrentFieldSimple(rAxis, zAxis, netToroidalCurrent);
   }
 
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
   covariantAndNormalComponents();
 
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 }
 
 // add in contribution from net toroidal current along magnetic axis

--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.cc
@@ -280,19 +280,29 @@ void LaplaceSolver::PerformPoloidalFourierTransforms() {
 
 void LaplaceSolver::BuildMatrix() {
   const int mnpd = (mf + 1) * (2 * nf + 1);
+#ifdef _OPENMP
 #pragma omp single
+#endif  // _OPENMP
   absl::c_fill_n(matrixShare, mnpd * mnpd, 0);
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
+#ifdef _OPENMP
 #pragma omp critical
+#endif  // _OPENMP
   {
     for (int mn_mnp = 0; mn_mnp < mnpd * mnpd; ++mn_mnp) {
       matrixShare[mn_mnp] += amat_sin_sin[mn_mnp];
     }  // mn * mn'
   }
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
+#ifdef _OPENMP
 #pragma omp single
+#endif  // _OPENMP
   {
     // TODO(jons): Get back to only having the minimal set of unique Fourier
     // coefficients in the linear system. set n = [-nf, ..., -1], m=0 elements
@@ -316,7 +326,9 @@ void LaplaceSolver::BuildMatrix() {
       matrixShare[mn * mnpd + mn] += 0.5;
     }  // mn
   }
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 }  // BuildMatrix
 
 void LaplaceSolver::DecomposeMatrix() {
@@ -348,19 +360,29 @@ void LaplaceSolver::DecomposeMatrix() {
 void LaplaceSolver::SolveForPotential(
     const std::vector<double> &bvec_sin_singular) {
   int mnpd = (mf + 1) * (2 * nf + 1);
+#ifdef _OPENMP
 #pragma omp single
+#endif  // _OPENMP
   absl::c_fill_n(bvecShare, mnpd, 0);
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
+#ifdef _OPENMP
 #pragma omp critical
+#endif  // _OPENMP
   {
     for (int mn = 0; mn < mnpd; ++mn) {
       bvecShare[mn] += bvec_sin[mn] + bvec_sin_singular[mn] / s_.nfp;
     }  // mn
   }
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
+#ifdef _OPENMP
 #pragma omp single
+#endif  // _OPENMP
   {
     // TODO(jons): Get back to only having the minimal set of unique Fourier
     // coefficients in the linear system. set n = [-nf, ..., -1], m=0 elements
@@ -386,7 +408,9 @@ void LaplaceSolver::SolveForPotential(
 
     CHECK_EQ(info, 0) << "dgetrs error";
   }
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 }
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
@@ -322,7 +322,9 @@ void MGridProvider::interpolate(int ztMin, int ztMax, int nZeta,
     }
   }
 
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 }
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.cc
@@ -99,9 +99,13 @@ bool Nestor::update(
       return true;
     }
 
+#ifdef _OPENMP
 #pragma omp single
+#endif  // _OPENMP
     ls_.DecomposeMatrix();
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
   }  // fullUpdate
 
   // virtual checkpoint, if maximum_iterations before next full Nestor update
@@ -168,19 +172,27 @@ bool Nestor::update(
   }
   local_bSubUVac *= signOfJacobian * 2.0 * M_PI;
 
+#ifdef _OPENMP
 #pragma omp single
+#endif  // _OPENMP
   {
     *bSubUVac = 0.0;
     *bSubVVac = 0.0;
   }
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
+#ifdef _OPENMP
 #pragma omp critical
+#endif  // _OPENMP
   {
     *bSubUVac += local_bSubUVac;
     *bSubVVac += local_bSubVVac;
   }
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
   // compute magnetic pressure from co- and contravariant B_vac components
   for (int kl = tp_.ztMin; kl < tp_.ztMax; ++kl) {
@@ -218,7 +230,9 @@ bool Nestor::update(
     return true;
   }
 
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
   // TODO(jons): could move bSubUVac, bSubVVac collection here to spare on
   // barrier

--- a/src/vmecpp/cpp/vmecpp/free_boundary/singular_integrals/singular_integrals.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/singular_integrals/singular_integrals.cc
@@ -155,16 +155,22 @@ void SingularIntegrals::computeCoefficients() {
 
 void SingularIntegrals::update(const std::vector<double>& bDotN,
                                bool fullUpdate) {
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
   prepareUpdate(sg_.guu, sg_.guv, sg_.gvv, sg_.auu, sg_.auv, sg_.avv,
                 fullUpdate);
 
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
   performUpdate(bDotN, fullUpdate);
 
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 }  // update
 
 void SingularIntegrals::prepareUpdate(const std::vector<double>& a,

--- a/src/vmecpp/cpp/vmecpp/free_boundary/surface_geometry/surface_geometry.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/surface_geometry/surface_geometry.cc
@@ -85,15 +85,21 @@ void SurfaceGeometry::update(
     const std::span<const double> zSC, const std::span<const double> zCS,
     const std::span<const double> zCC, const std::span<const double> zSS,
     int signOfJacobian, bool fullUpdate) {
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
   inverseDFT(rCC, rSS, rSC, rCS, zSC, zCS, zCC, zSS, fullUpdate);
 
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 
   derivedSurfaceQuantities(signOfJacobian, fullUpdate);
 
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 }
 
 // Perform inverse Fourier transform from Fourier coefficients of surface

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
@@ -828,9 +828,15 @@ void RadialProfiles::AccumulateVolumeAveragedSpectralWidth() const {
     }
   }  // jH
 
+#ifdef _OPENMP
 #pragma omp critical
+#endif  // _OPENMP
+
   m_h_.RegisterSpectralWidthContribution(spectral_width_contribution);
+
+#ifdef _OPENMP
 #pragma omp barrier
+#endif  // _OPENMP
 }  // AccumulateVolumeAveragedSpectralWidth
 
 }  // namespace vmecpp


### PR DESCRIPTION
Allow to build VMEC++ without OpenMP without warnings; needed for Hedron's compile
command extractor, which builds VMEC++ via Bazel.