### PR TITLE
Remove all non-ASCII characters from VMEC++.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,18 +175,18 @@ VMEC++ is a modern C++ reimplementation of the VMEC magnetohydrodynamic equilibr
 VMEC++ uses **two different Fourier representations**:
 
 **Internal Product Basis** (Computational efficiency):
-- `rmncc_`: R × cos(mθ) × cos(nζ) coefficients
-- `rmnss_`: R × sin(mθ) × sin(nζ) coefficients
+- `rmncc_`: R \times cos(m\theta) \times cos(n\zeta) coefficients
+- `rmnss_`: R \times sin(m\theta) \times sin(n\zeta) coefficients
 - Enables separable FFTs for performance
 
 **External Combined Basis** (Researcher interface):
-- `rmnc`: R × cos(mθ - nζ) coefficients (traditional VMEC format)
-- `zmns`: Z × sin(mθ - nζ) coefficients
+- `rmnc`: R \times cos(m\theta - n\zeta) coefficients (traditional VMEC format)
+- `zmns`: Z \times sin(m\theta - n\zeta) coefficients
 - Compatible with research literature and SIMSOPT
 
 **Key Physics Variables** (preserve traditional names):
-- `bsupu_`: B^θ contravariant magnetic field component
-- `bsupv_`: B^ζ contravariant magnetic field component
+- `bsupu_`: B^\theta contravariant magnetic field component
+- `bsupv_`: B^\zeta contravariant magnetic field component
 - `iotaf_`: Rotational transform on full grid
 - `presf_`: Pressure on full grid
 

--- a/examples/compare_vmecpp_to_parvmec.py
+++ b/examples/compare_vmecpp_to_parvmec.py
@@ -69,7 +69,7 @@ for phi_degrees in [0, 18, 36]:
     plt.grid(True)
     plt.legend(loc="upper right")
 
-    plt.title(f"$\\varphi = {phi_degrees}°$")
+    plt.title(f"$\\varphi = {phi_degrees}$ deg")
 
 # plot iota profile comparison
 s_half = (0.5 + np.arange(ref_ns - 1)) / (ref_ns - 1.0)


### PR DESCRIPTION
Ensure that no non-ASCII characters remain present anywhere in the
VMEC++ source code and adjust the naming guide to make sure the source
tree stays clean in this regard.