### PR TITLE
Fix issue in simsopt_compat when boundary surface mpol and ntor differs from vmec indata mpol and ntor

### DIFF
--- a/src/vmecpp/simsopt_compat.py
+++ b/src/vmecpp/simsopt_compat.py
@@ -452,6 +452,7 @@ class Vmec(Optimizable):
         vi = self.indata  # Shorthand
         # Convert boundary to RZFourier if needed:
         boundary_RZFourier = self.boundary.to_RZFourier()
+        boundary_RZFourier.change_resolution(self.indata.mpol, self.indata.ntor)
         vi.rbc.fill(0.0)
         vi.zbs.fill(0.0)
 


### PR DESCRIPTION
Presently, the logic here in `simsopt_compat.py` [lines 458-463](https://github.com/proximafusion/vmecpp/blob/main/src/vmecpp/simsopt_compat.py#L458-L463) assumes that the mpol and ntor of the boundary surface object are at least as large as the mpol and ntor in indata:
~~~~py
        # Transfer boundary shape data from the surface object to VMEC:
        ntor = self.indata.ntor
        for m in range(self.indata.mpol):
            for n in range(2 * ntor + 1):
                vi.rbc[m, n] = boundary_RZFourier.get_rc(m, n - ntor)
                vi.zbs[m, n] = boundary_RZFourier.get_zs(m, n - ntor)
~~~~
However the mpol and ntor values of the surface can be less than the mpol and ntor in indata if a user assigns a different surface object to `vmec.boundary`, resulting in an `IndexError`. This PR provides a fix.