### PR TITLE
Raise on nzeta mismatch in input vs mgrid

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -208,12 +208,21 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
                                const int iterations_before_checkpointing,
                                const int maximum_multi_grid_step,
                                std::optional<HotRestartState> initial_state) {
-  if (indata_.lfreeb && !mgrid_.IsLoaded()) {
-    // if we have a free-boundary VMEC run, we may need to load the
-    // magnetic field response table
-    absl::Status status = LoadMGrid();
-    if (!status.ok()) {
-      return status;
+  if (indata_.lfreeb) {
+    if (!mgrid_.IsLoaded()) {
+      // if we have a free-boundary VMEC run, we may need to load the
+      // magnetic field response table
+      absl::Status status = LoadMGrid();
+      if (!status.ok()) {
+        return status;
+      }
+    }
+    if (mgrid_.numPhi != indata_.nzeta) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "MGridProvider has %d phi grid points, but VmecINDATA "
+          "has %d nzeta grid points. Please ensure that the two "
+          "are consistent.",
+          mgrid_.numPhi, indata_.nzeta));
     }
   }
 

--- a/tests/test_free_boundary.py
+++ b/tests/test_free_boundary.py
@@ -68,6 +68,23 @@ def test_run_free_boundary_from_response_table():
     )
 
 
+def test_raise_invalid_nzeta():
+    makegrid_params = vmecpp.MakegridParameters.from_file(
+        TEST_DATA_DIR / "makegrid_parameters_cth_like.json"
+    )
+    # Lower the makegrid resolution
+    makegrid_params.number_of_r_grid_points = 3
+    makegrid_params.number_of_phi_grid_points = 24
+    makegrid_params.number_of_z_grid_points = 2
+    response = vmecpp.MagneticFieldResponseTable.from_coils_file(
+        TEST_DATA_DIR / "coils.cth_like", makegrid_params
+    )
+    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cth_like_free_bdy.json")
+    assert vmec_input.nzeta != makegrid_params.number_of_phi_grid_points
+    with pytest.raises(AttributeError, match=r"MGridProvider has \d"):
+        vmecpp.run(vmec_input, response, verbose=False)
+
+
 def test_makegrid_parameters_conversion(makegrid_params):
     # Convert resolution parameters to C++ and back to Python
     cpp_params = makegrid_params._to_cpp_makegrid_parameters()


### PR DESCRIPTION
When this wasn't satisfied, vmecpp usually ran into the much scarier error message `IdealMHDModel::update: VAC-VMEC I_TOR MISMATCH : BOUNDARY MAY ENCLOSE EXT. COIL`
which was misleading.