### PR TITLE
Fix a race condition on liter_flag

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -674,6 +674,11 @@ absl::StatusOr<bool> Vmec::SolveEquilibrium(
          n_local_eqsolve_retries < fc_.niterv && s.ok() &&
          *s == SolveEqLoopStatus::MUST_RETRY && liter_flag;
          n_local_eqsolve_retries++) {
+// protect read of `liter_flag` from write within `SolveEquilibriumLoop` below
+#ifdef _OPENMP
+#pragma omp barrier
+#endif  // _OPENMP
+
       s = SolveEquilibriumLoop(
           thread_id, iterations_before_checkpointing, checkpoint,
           /*m_lreset_internal=*/m_lreset_internal, /*m_liter_flag=*/liter_flag);


### PR DESCRIPTION
It is read in each thread in the for loop condition check, but written
only from one thread within SolveEquilibriumLoop.
This PR introduces a barrier to protect the read from liter_flag within
the for loop condition from the write within SolveEquilibriumLoop.