### PR TITLE
szip requirement in netcdf, limit version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "netCDF4",
+  "netCDF4<1.7.3", # netCDF4 1.7.3 has a hard requirement on szip.
   "numpy",
   "pydantic>=2.11", # Introduced support for by_alias validation
   "jaxtyping>=0.2.6",


### PR DESCRIPTION
**This fixes the pip wheel failiure**

The new NetCDF version made szip a hard requirement. Since we ship binary dependencies with the wheel, we decided to limit the netcdf version for now instead of shipping a larger binary package.

This is not a permanent solution, and if it becomes a problem, we need to add szip to the linux images for the wheel build.