### PR TITLE
Add libaec dpendency for szip support (requirement in newest netcdf version)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "netCDF4<1.7.3", # netCDF4 1.7.3 has a hard requirement on szip.
+  "netCDF4",
   "numpy",
   "pydantic>=2.11", # Introduced support for by_alias validation
   "jaxtyping>=0.2.6",
@@ -91,7 +91,7 @@ test-requires = "pytest"
 test-command = "pytest {package}/tests/test_simsopt_compat.py"
 
 [tool.cibuildwheel.linux]
-before-build = "yum install -y lapack-devel netcdf-devel hdf5-devel"
+before-build = "yum install -y lapack-devel netcdf-devel hdf5-devel libaec-devel"
 
 [tool.cibuildwheel.macos]
 before-build = "brew install gcc lapack netcdf hdf5 libomp"


### PR DESCRIPTION
I checked again, and `libaec` is such a small dependency (50kB) that I think it's acceptable to ship it. This way we stay forward compatible with netcdf versions.