### PR TITLE
CIbuildwheel update. Minimum supported linux version changed from manylinux2014 to manylinux_2_28

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         # ubuntu-24.04-arm not supported due to lack of netcdf-devel hdf5-devel
-        os: [ubuntu-24.04, macos-13, macos-14]
+        os: [ubuntu-24.04, macos-14, macos-15-intel]
 
     steps:
       - name: Checkout repository
@@ -23,11 +23,11 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6 # We use uv in cibuildwheel for faster builds
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.0
+        uses: pypa/cibuildwheel@v3.3.1
         # All the settings for cibuildwheel are in pyproject.toml
         env:
           CIBW_ENVIRONMENT_MACOS: >
-            MACOSX_DEPLOYMENT_TARGET=${{ matrix.os == 'macos-14' && '14.0' || '13.0' }}
+            MACOSX_DEPLOYMENT_TARGET=${{ matrix.os == 'macos-14' && '14.0' || '15.0' }}
             DYLD_LIBRARY_PATH=/usr/local/opt/gcc/lib/gcc/current/:$DYLD_LIBRARY_PATH
             FC=gfortran-14
             HDF5_ROOT=$(brew --prefix hdf5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,14 +87,12 @@ version_file = "src/vmecpp/__about__.py"
 archs = ["native"]
 skip = ["pp*", "*-musllinux*"]
 build-frontend = "build[uv]" # More modern package manager than pip, with faster builds
+test-skip = ["cp314-*", "cp314t-*"] # Skip tests on Python 3.14 until all our dependencies start supporting it. The wheels are still valid, and become installable the moment simsopt releases 3.14 support.
 test-requires = "pytest"
 test-command = "pytest {package}/tests/test_simsopt_compat.py"
 
 [tool.cibuildwheel.linux]
-before-build = "yum install -y lapack-devel netcdf-devel hdf5-devel libaec-devel"
-
-[tool.cibuildwheel.macos]
-before-build = "brew install gcc lapack netcdf hdf5 libomp"
+before-build = "yum install -y lapack-devel netcdf-devel hdf5-devel"
 
 [tool.coverage.run]
 source_pkgs = ["vmecpp", "tests"]


### PR DESCRIPTION
- Switch to newe `cibuildwheel` for slightly faster builds, bug-fixes, more modern defaults and in preparation for Python 3.14 support. This implicitly changes the default `manylinux` version from 2014 to `manylinux_2_28` https://github.com/pypa/manylinux which raises the minimum necessary Ubuntu version to Ubuntu >18 (which at this point is also over 7y old). 
- macos-13 runners have been deprecated by GitHub. This drops support for the platform from our side as well, older vmec++ versions will stay accessible for installation via PyPi.
