### PR TITLE
CIbuildwheel MacOS fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ version_file = "src/vmecpp/__about__.py"
 
 [tool.cibuildwheel]
 archs = ["native"]
-skip = ["pp*", "*-musllinux*"]
+skip = ["*-musllinux*"]
 build-frontend = "build[uv]" # More modern package manager than pip, with faster builds
 test-skip = ["cp314-*", "cp314t-*"] # Skip tests on Python 3.14 until all our dependencies start supporting it. The wheels are still valid, and become installable the moment simsopt releases 3.14 support.
 test-requires = "pytest"
@@ -93,6 +93,9 @@ test-command = "pytest {package}/tests/test_simsopt_compat.py"
 
 [tool.cibuildwheel.linux]
 before-build = "yum install -y lapack-devel netcdf-devel hdf5-devel"
+
+[tool.cibuildwheel.macos]
+before-build = "brew install gcc lapack netcdf hdf5 libomp"
 
 [tool.coverage.run]
 source_pkgs = ["vmecpp", "tests"]


### PR DESCRIPTION
- Eventho the logs say these packages are already installed on MAC, CI fails when we don't "re-install" them. 
- Only CPython is enabled by default on the newer cibuildwheel, no need to skip.