### PR TITLE
Migrate FourierBasisFastPoloidal and FourierBasisFastToroidal to Eigen3

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -1971,8 +1971,8 @@ def run(
         >>> path = "examples/data/solovev.json"
         >>> vmec_input = vmecpp.VmecInput.from_file(path)
         >>> output = vmecpp.run(vmec_input, verbose=False, max_threads=1)
-        >>> round(output.wout.b0, 14) # Exact value may differ by C library
-        0.20333137113443
+        >>> round(output.wout.b0, 10) # Exact value may differ by C library
+        0.2033313711
     """
     input = VmecInput.model_validate(input)
     cpp_indata = input._to_cpp_vmecindata()

--- a/src/vmecpp/cpp/.bazelrc
+++ b/src/vmecpp/cpp/.bazelrc
@@ -6,10 +6,10 @@ build --sandbox_add_mount_pair=/tmp
 
 # If compiling with clang or intel compilers, you will need to adjust the linked OpenMP library from libgomp to libomp
 # -fno-math-errno yields a few % of performance improvements and we don't check errno anyways
-build:opt   -c opt --copt="-fopenmp" --linkopt="-lgomp" --copt="-O3" --copt="-fno-math-errno"
-build:perf  -c opt --copt="-fopenmp" --linkopt="-lgomp" --copt="-O3" --copt="-fno-math-errno" --copt="-g" --strip=never --copt="-fno-omit-frame-pointer"
+build:opt   -c opt --copt="-fopenmp" --linkopt="-lgomp" --copt="-O3" --copt="-DNDEBUG" --copt="-fno-math-errno"
+build:perf  -c opt --copt="-fopenmp" --linkopt="-lgomp" --copt="-O3" --copt="-DNDEBUG" --copt="-fno-math-errno" --copt="-g" --strip=never --copt="-fno-omit-frame-pointer"
 build:dbg   -c dbg --copt="-fopenmp" --linkopt="-lgomp" --copt="-O0"
-build:asan  -c dbg --copt="-fopenmp" --linkopt="-lgomp" --features=asan --strip=never
+build:asan  -c opt --copt="-fopenmp" --linkopt="-lgomp" --copt="-DNDEBUG" --features=asan --strip=never
 # Undefined behavior sanitization is quite slow, to compensate we compile in opt mode
 build:ubsan -c opt --copt="-fopenmp" --linkopt="-lgomp" --features=ubsan --strip=never
 

--- a/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_poloidal/fourier_basis_fast_poloidal.cc
+++ b/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_poloidal/fourier_basis_fast_poloidal.cc
@@ -6,7 +6,6 @@
 
 #include <cmath>
 #include <numbers>
-#include <vector>
 
 #include "absl/algorithm/container.h"
 #include "absl/log/check.h"
@@ -36,13 +35,17 @@ FourierBasisFastPoloidal::FourierBasisFastPoloidal(const Sizes* s) : s_(*s) {
 
   // -----------------
 
-  xm.resize(s_.mnmax, 0);
-  xn.resize(s_.mnmax, 0);
+  xm.resize(s_.mnmax);
+  xm.setZero();
+  xn.resize(s_.mnmax);
+  xn.setZero();
 
   computeConversionIndices(/*m_xm=*/xm, /*m_xn=*/xn, s_.ntor, s_.mpol, s_.nfp);
 
-  xm_nyq.resize(s_.mnmax_nyq, 0);
-  xn_nyq.resize(s_.mnmax_nyq, 0);
+  xm_nyq.resize(s_.mnmax_nyq);
+  xm_nyq.setZero();
+  xn_nyq.resize(s_.mnmax_nyq);
+  xn_nyq.setZero();
 
   computeConversionIndices(/*m_xm=*/xm_nyq, /*m_xn=*/xn_nyq, s_.nnyq,
                            s_.mnyq + 1, s_.nfp);
@@ -347,8 +350,8 @@ int FourierBasisFastPoloidal::mnMax(int m_size, int n_size) const {
   return mnmax;
 }
 
-void FourierBasisFastPoloidal::computeConversionIndices(std::vector<int>& m_xm,
-                                                        std::vector<int>& m_xn,
+void FourierBasisFastPoloidal::computeConversionIndices(Eigen::VectorXi& m_xm,
+                                                        Eigen::VectorXi& m_xn,
                                                         int n_size, int m_size,
                                                         int nfp) const {
   const int mnmax = mnMax(m_size, n_size);

--- a/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_poloidal/fourier_basis_fast_poloidal.h
+++ b/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_poloidal/fourier_basis_fast_poloidal.h
@@ -5,8 +5,8 @@
 #ifndef VMECPP_COMMON_FOURIER_BASIS_FAST_POLOIDAL_FOURIER_BASIS_FAST_POLOIDAL_H_
 #define VMECPP_COMMON_FOURIER_BASIS_FAST_POLOIDAL_FOURIER_BASIS_FAST_POLOIDAL_H_
 
+#include <Eigen/Dense>
 #include <span>
-#include <vector>
 
 #include "vmecpp/common/sizes/sizes.h"
 
@@ -43,13 +43,13 @@ class FourierBasisFastPoloidal {
   // Applied to cos(m*\theta) and sin(m*\theta) basis functions for DFT
   // normalization Enables proper normalization: 1/\pi for m>0 modes, 1/(2\pi)
   // for m=0 mode
-  std::vector<double> mscale;
+  Eigen::VectorXd mscale;
 
   // [nnyq2+1] Toroidal mode scaling factors: sqrt(2) for n>0, 1.0 for n=0
   // Applied to cos(n*\zeta) and sin(n*\zeta) basis functions for DFT
   // normalization Enables proper normalization: 1/\pi for n>0 modes, 1/(2\pi)
   // for n=0 mode
-  std::vector<double> nscale;
+  Eigen::VectorXd nscale;
 
   // ============================================================================
   // POLOIDAL BASIS FUNCTIONS (m-major layout: [m][l])
@@ -59,23 +59,23 @@ class FourierBasisFastPoloidal {
   // Layout: cosmu[m*nThetaReduced + l] = cos(m*\theta[l]) * mscale[m]
   // \theta[l] = 2*\pi*l/nThetaEven for l=0...nThetaReduced-1 (reduced [0,\pi]
   // interval)
-  std::vector<double> cosmu;
+  Eigen::VectorXd cosmu;
 
   // [nThetaReduced * (mnyq2+1)] Pre-scaled poloidal sine basis
   // Layout: sinmu[m*nThetaReduced + l] = sin(m*\theta[l]) * mscale[m]
-  std::vector<double> sinmu;
+  Eigen::VectorXd sinmu;
 
   // [nThetaReduced * (mnyq2+1)] Pre-scaled poloidal cosine derivative
   // Layout: cosmum[m*nThetaReduced + l] = m * cos(m*\theta[l]) * mscale[m]
   // Used for computing \partial/\partial\theta derivatives in force
   // calculations
-  std::vector<double> cosmum;
+  Eigen::VectorXd cosmum;
 
   // [nThetaReduced * (mnyq2+1)] Pre-scaled poloidal sine derivative
   // Layout: sinmum[m*nThetaReduced + l] = -m * sin(m*\theta[l]) * mscale[m]
   // Used for computing \partial/\partial\theta derivatives in force
   // calculations
-  std::vector<double> sinmum;
+  Eigen::VectorXd sinmum;
 
   // ============================================================================
   // POLOIDAL BASIS WITH INTEGRATION WEIGHTS
@@ -84,21 +84,21 @@ class FourierBasisFastPoloidal {
   // [nThetaReduced * (mnyq2+1)] Integration-weighted poloidal cosine basis
   // Layout: cosmui[m*nThetaReduced + l] = cosmu[m*nThetaReduced + l] * intNorm
   // intNorm = 1/(nZeta*(nThetaReduced-1)), with boundary point factor 1/2
-  std::vector<double> cosmui;
+  Eigen::VectorXd cosmui;
 
   // [nThetaReduced * (mnyq2+1)] Integration-weighted poloidal sine basis
   // Layout: sinmui[m*nThetaReduced + l] = sinmu[m*nThetaReduced + l] * intNorm
-  std::vector<double> sinmui;
+  Eigen::VectorXd sinmui;
 
   // [nThetaReduced * (mnyq2+1)] Integration-weighted poloidal cosine derivative
   // Layout: cosmumi[m*nThetaReduced + l] = cosmum[m*nThetaReduced + l] *
   // intNorm
-  std::vector<double> cosmumi;
+  Eigen::VectorXd cosmumi;
 
   // [nThetaReduced * (mnyq2+1)] Integration-weighted poloidal sine derivative
   // Layout: sinmumi[m*nThetaReduced + l] = sinmum[m*nThetaReduced + l] *
   // intNorm
-  std::vector<double> sinmumi;
+  Eigen::VectorXd sinmumi;
 
   // ============================================================================
   // TOROIDAL BASIS FUNCTIONS (zeta-major layout: [k][n])
@@ -107,23 +107,23 @@ class FourierBasisFastPoloidal {
   // [(nnyq2+1) * nZeta] Pre-scaled toroidal cosine basis
   // Layout: cosnv[k*(nnyq2+1) + n] = cos(n*\zeta[k]) * nscale[n]
   // \zeta[k] = 2*\pi*k/nZeta for k=0...nZeta-1 (full [0,2\pi] interval)
-  std::vector<double> cosnv;
+  Eigen::VectorXd cosnv;
 
   // [(nnyq2+1) * nZeta] Pre-scaled toroidal sine basis
   // Layout: sinnv[k*(nnyq2+1) + n] = sin(n*\zeta[k]) * nscale[n]
-  std::vector<double> sinnv;
+  Eigen::VectorXd sinnv;
 
   // [(nnyq2+1) * nZeta] Pre-scaled toroidal cosine derivative with nfp factor
   // Layout: cosnvn[k*(nnyq2+1) + n] = n*nfp * cos(n*\zeta[k]) * nscale[n]
   // Factor nfp converts \partial/\partial\zeta to \partial/\partial\phi
   // derivatives
-  std::vector<double> cosnvn;
+  Eigen::VectorXd cosnvn;
 
   // [(nnyq2+1) * nZeta] Pre-scaled toroidal sine derivative with nfp factor
   // Layout: sinnvn[k*(nnyq2+1) + n] = -n*nfp * sin(n*\zeta[k]) * nscale[n]
   // Factor nfp converts \partial/\partial\zeta to \partial/\partial\phi
   // derivatives
-  std::vector<double> sinnvn;
+  Eigen::VectorXd sinnvn;
 
   // ============================================================================
   // FOURIER BASIS CONVERSION FUNCTIONS
@@ -271,7 +271,7 @@ class FourierBasisFastPoloidal {
 
   int mnIdx(int m, int n) const;
   int mnMax(int m_size, int n_size) const;
-  void computeConversionIndices(std::vector<int>& m_xm, std::vector<int>& m_xn,
+  void computeConversionIndices(Eigen::VectorXi& m_xm, Eigen::VectorXi& m_xn,
                                 int n_size, int m_size, int nfp) const;
 
   // ============================================================================
@@ -281,25 +281,25 @@ class FourierBasisFastPoloidal {
   // [mnmax] Poloidal mode numbers for standard resolution Fourier coefficients
   // Layout: xm[mn] = poloidal mode number m for the mn-th coefficient
   // Maps linear coefficient index mn to 2D mode (m,n) for spectral operations
-  std::vector<int> xm;
+  Eigen::VectorXi xm;
 
   // [mnmax] Toroidal mode numbers for standard resolution Fourier coefficients
   // Layout: xn[mn] = toroidal mode number n*nfp for the mn-th coefficient
   // Factor nfp included to convert from field periods to geometric toroidal
   // modes
-  std::vector<int> xn;
+  Eigen::VectorXi xn;
 
   // [mnmax_nyq] Poloidal mode numbers for Nyquist-extended Fourier coefficients
   // Layout: xm_nyq[mn] = poloidal mode number m for the mn-th Nyquist
   // coefficient Extended resolution to avoid aliasing in nonlinear force
   // calculations
-  std::vector<int> xm_nyq;
+  Eigen::VectorXi xm_nyq;
 
   // [mnmax_nyq] Toroidal mode numbers for Nyquist-extended Fourier coefficients
   // Layout: xn_nyq[mn] = toroidal mode number n*nfp for the mn-th Nyquist
   // coefficient Extended resolution to avoid aliasing in nonlinear force
   // calculations
-  std::vector<int> xn_nyq;
+  Eigen::VectorXi xn_nyq;
 
  private:
   const Sizes& s_;

--- a/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_toroidal/fourier_basis_fast_toroidal.cc
+++ b/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_toroidal/fourier_basis_fast_toroidal.cc
@@ -6,7 +6,6 @@
 
 #include <cmath>
 #include <numbers>
-#include <vector>
 
 #include "absl/algorithm/container.h"
 #include "absl/log/check.h"
@@ -36,13 +35,17 @@ FourierBasisFastToroidal::FourierBasisFastToroidal(const Sizes* s) : s_(*s) {
 
   // -----------------
 
-  xm.resize(s_.mnmax, 0);
-  xn.resize(s_.mnmax, 0);
+  xm.resize(s_.mnmax);
+  xm.setZero();
+  xn.resize(s_.mnmax);
+  xn.setZero();
 
   computeConversionIndices(/*m_xm=*/xm, /*m_xn=*/xn, s_.ntor, s_.mpol, s_.nfp);
 
-  xm_nyq.resize(s_.mnmax_nyq, 0);
-  xn_nyq.resize(s_.mnmax_nyq, 0);
+  xm_nyq.resize(s_.mnmax_nyq);
+  xm_nyq.setZero();
+  xn_nyq.resize(s_.mnmax_nyq);
+  xn_nyq.setZero();
 
   computeConversionIndices(/*m_xm=*/xm_nyq, /*m_xn=*/xn_nyq, s_.nnyq,
                            s_.mnyq + 1, s_.nfp);
@@ -350,8 +353,8 @@ int FourierBasisFastToroidal::mnMax(int m_size, int n_size) const {
   return mnmax;
 }
 
-void FourierBasisFastToroidal::computeConversionIndices(std::vector<int>& m_xm,
-                                                        std::vector<int>& m_xn,
+void FourierBasisFastToroidal::computeConversionIndices(Eigen::VectorXi& m_xm,
+                                                        Eigen::VectorXi& m_xn,
                                                         int n_size, int m_size,
                                                         int nfp) const {
   const int mnmax = mnMax(m_size, n_size);

--- a/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_toroidal/fourier_basis_fast_toroidal.h
+++ b/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_toroidal/fourier_basis_fast_toroidal.h
@@ -5,8 +5,8 @@
 #ifndef VMECPP_COMMON_FOURIER_BASIS_FAST_TOROIDAL_FOURIER_BASIS_FAST_TOROIDAL_H_
 #define VMECPP_COMMON_FOURIER_BASIS_FAST_TOROIDAL_FOURIER_BASIS_FAST_TOROIDAL_H_
 
+#include <Eigen/Dense>
 #include <span>
-#include <vector>
 
 #include "vmecpp/common/sizes/sizes.h"
 
@@ -44,13 +44,13 @@ class FourierBasisFastToroidal {
   // Applied to cos(m*\theta) and sin(m*\theta) basis functions for DFT
   // normalization Enables proper normalization: 1/\pi for m>0 modes, 1/(2\pi)
   // for m=0 mode
-  std::vector<double> mscale;
+  Eigen::VectorXd mscale;
 
   // [nnyq2+1] Toroidal mode scaling factors: sqrt(2) for n>0, 1.0 for n=0
   // Applied to cos(n*\zeta) and sin(n*\zeta) basis functions for DFT
   // normalization Enables proper normalization: 1/\pi for n>0 modes, 1/(2\pi)
   // for n=0 mode
-  std::vector<double> nscale;
+  Eigen::VectorXd nscale;
 
   // ============================================================================
   // POLOIDAL BASIS FUNCTIONS (l-major layout: [l][m])
@@ -60,23 +60,23 @@ class FourierBasisFastToroidal {
   // Layout: cosmu[l*(mnyq2+1) + m] = cos(m*\theta[l]) * mscale[m]
   // \theta[l] = 2*\pi*l/nThetaEven for l=0...nThetaReduced-1 (reduced [0,\pi]
   // interval)
-  std::vector<double> cosmu;
+  Eigen::VectorXd cosmu;
 
   // [nThetaReduced * (mnyq2+1)] Pre-scaled poloidal sine basis
   // Layout: sinmu[l*(mnyq2+1) + m] = sin(m*\theta[l]) * mscale[m]
-  std::vector<double> sinmu;
+  Eigen::VectorXd sinmu;
 
   // [nThetaReduced * (mnyq2+1)] Pre-scaled poloidal cosine derivative
   // Layout: cosmum[l*(mnyq2+1) + m] = m * cos(m*\theta[l]) * mscale[m]
   // Used for computing \partial/\partial\theta derivatives in force
   // calculations
-  std::vector<double> cosmum;
+  Eigen::VectorXd cosmum;
 
   // [nThetaReduced * (mnyq2+1)] Pre-scaled poloidal sine derivative
   // Layout: sinmum[l*(mnyq2+1) + m] = -m * sin(m*\theta[l]) * mscale[m]
   // Used for computing \partial/\partial\theta derivatives in force
   // calculations
-  std::vector<double> sinmum;
+  Eigen::VectorXd sinmum;
 
   // ============================================================================
   // POLOIDAL BASIS WITH INTEGRATION WEIGHTS
@@ -85,19 +85,19 @@ class FourierBasisFastToroidal {
   // [nThetaReduced * (mnyq2+1)] Integration-weighted poloidal cosine basis
   // Layout: cosmui[l*(mnyq2+1) + m] = cosmu[l*(mnyq2+1) + m] * intNorm
   // intNorm = 1/(nZeta*(nThetaReduced-1)), with boundary point factor 1/2
-  std::vector<double> cosmui;
+  Eigen::VectorXd cosmui;
 
   // [nThetaReduced * (mnyq2+1)] Integration-weighted poloidal sine basis
   // Layout: sinmui[l*(mnyq2+1) + m] = sinmu[l*(mnyq2+1) + m] * intNorm
-  std::vector<double> sinmui;
+  Eigen::VectorXd sinmui;
 
   // [nThetaReduced * (mnyq2+1)] Integration-weighted poloidal cosine derivative
   // Layout: cosmumi[l*(mnyq2+1) + m] = cosmum[l*(mnyq2+1) + m] * intNorm
-  std::vector<double> cosmumi;
+  Eigen::VectorXd cosmumi;
 
   // [nThetaReduced * (mnyq2+1)] Integration-weighted poloidal sine derivative
   // Layout: sinmumi[l*(mnyq2+1) + m] = sinmum[l*(mnyq2+1) + m] * intNorm
-  std::vector<double> sinmumi;
+  Eigen::VectorXd sinmumi;
 
   // ============================================================================
   // TOROIDAL BASIS FUNCTIONS (n-major layout: [n][k])
@@ -106,23 +106,23 @@ class FourierBasisFastToroidal {
   // [(nnyq2+1) * nZeta] Pre-scaled toroidal cosine basis
   // Layout: cosnv[n*nZeta + k] = cos(n*\zeta[k]) * nscale[n]
   // \zeta[k] = 2*\pi*k/nZeta for k=0...nZeta-1 (full [0,2\pi] interval)
-  std::vector<double> cosnv;
+  Eigen::VectorXd cosnv;
 
   // [(nnyq2+1) * nZeta] Pre-scaled toroidal sine basis
   // Layout: sinnv[n*nZeta + k] = sin(n*\zeta[k]) * nscale[n]
-  std::vector<double> sinnv;
+  Eigen::VectorXd sinnv;
 
   // [(nnyq2+1) * nZeta] Pre-scaled toroidal cosine derivative with nfp factor
   // Layout: cosnvn[n*nZeta + k] = n*nfp * cos(n*\zeta[k]) * nscale[n]
   // Factor nfp converts \partial/\partial\zeta to \partial/\partial\phi
   // derivatives
-  std::vector<double> cosnvn;
+  Eigen::VectorXd cosnvn;
 
   // [(nnyq2+1) * nZeta] Pre-scaled toroidal sine derivative with nfp factor
   // Layout: sinnvn[n*nZeta + k] = -n*nfp * sin(n*\zeta[k]) * nscale[n]
   // Factor nfp converts \partial/\partial\zeta to \partial/\partial\phi
   // derivatives
-  std::vector<double> sinnvn;
+  Eigen::VectorXd sinnvn;
 
   // ============================================================================
   // FOURIER BASIS CONVERSION FUNCTIONS
@@ -270,7 +270,7 @@ class FourierBasisFastToroidal {
 
   int mnIdx(int m, int n) const;
   int mnMax(int m_size, int n_size) const;
-  void computeConversionIndices(std::vector<int>& m_xm, std::vector<int>& m_xn,
+  void computeConversionIndices(Eigen::VectorXi& m_xm, Eigen::VectorXi& m_xn,
                                 int n_size, int m_size, int nfp) const;
 
   // ============================================================================
@@ -280,25 +280,25 @@ class FourierBasisFastToroidal {
   // [mnmax] Poloidal mode numbers for standard resolution Fourier coefficients
   // Layout: xm[mn] = poloidal mode number m for the mn-th coefficient
   // Maps linear coefficient index mn to 2D mode (m,n) for spectral operations
-  std::vector<int> xm;
+  Eigen::VectorXi xm;
 
   // [mnmax] Toroidal mode numbers for standard resolution Fourier coefficients
   // Layout: xn[mn] = toroidal mode number n*nfp for the mn-th coefficient
   // Factor nfp included to convert from field periods to geometric toroidal
   // modes
-  std::vector<int> xn;
+  Eigen::VectorXi xn;
 
   // [mnmax_nyq] Poloidal mode numbers for Nyquist-extended Fourier coefficients
   // Layout: xm_nyq[mn] = poloidal mode number m for the mn-th Nyquist
   // coefficient Extended resolution to avoid aliasing in nonlinear force
   // calculations
-  std::vector<int> xm_nyq;
+  Eigen::VectorXi xm_nyq;
 
   // [mnmax_nyq] Toroidal mode numbers for Nyquist-extended Fourier coefficients
   // Layout: xn_nyq[mn] = toroidal mode number n*nfp for the mn-th Nyquist
   // coefficient Extended resolution to avoid aliasing in nonlinear force
   // calculations
-  std::vector<int> xn_nyq;
+  Eigen::VectorXi xn_nyq;
 
  private:
   const Sizes& s_;

--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/boundaries.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/boundaries.h
@@ -5,7 +5,7 @@
 #ifndef VMECPP_VMEC_BOUNDARIES_BOUNDARIES_H_
 #define VMECPP_VMEC_BOUNDARIES_BOUNDARIES_H_
 
-#include <vector>
+#include <Eigen/Dense>
 
 #include "vmecpp/common/fourier_basis_fast_poloidal/fourier_basis_fast_poloidal.h"
 #include "vmecpp/common/sizes/sizes.h"
@@ -36,20 +36,20 @@ class Boundaries {
   void RecomputeMagneticAxisToFixJacobianSign(int number_of_flux_surfaces,
                                               int sign_of_jacobian);
 
-  std::vector<double> raxis_c;
-  std::vector<double> zaxis_s;
-  std::vector<double> raxis_s;
-  std::vector<double> zaxis_c;
+  Eigen::VectorXd raxis_c;
+  Eigen::VectorXd zaxis_s;
+  Eigen::VectorXd raxis_s;
+  Eigen::VectorXd zaxis_c;
 
-  std::vector<double> rbcc;
-  std::vector<double> rbss;
-  std::vector<double> rbsc;
-  std::vector<double> rbcs;
+  Eigen::VectorXd rbcc;
+  Eigen::VectorXd rbss;
+  Eigen::VectorXd rbsc;
+  Eigen::VectorXd rbcs;
 
-  std::vector<double> zbsc;
-  std::vector<double> zbcs;
-  std::vector<double> zbcc;
-  std::vector<double> zbss;
+  Eigen::VectorXd zbsc;
+  Eigen::VectorXd zbcs;
+  Eigen::VectorXd zbcc;
+  Eigen::VectorXd zbss;
 
  private:
   const Sizes& s_;

--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/guess_magnetic_axis.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/guess_magnetic_axis.cc
@@ -11,13 +11,13 @@ namespace vmecpp {
 
 RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
     int number_of_flux_surfaces, int sign_of_jacobian, const Sizes& s,
-    const FourierBasisFastPoloidal& t, const std::vector<double>& rbcc,
-    const std::vector<double>& rbss, const std::vector<double>& rbsc,
-    const std::vector<double>& rbcs, const std::vector<double>& zbsc,
-    const std::vector<double>& zbcs, const std::vector<double>& zbcc,
-    const std::vector<double>& zbss, const std::vector<double>& raxis_c,
-    const std::vector<double>& raxis_s, const std::vector<double>& zaxis_s,
-    const std::vector<double>& zaxis_c) {
+    const FourierBasisFastPoloidal& t, const Eigen::VectorXd& rbcc,
+    const Eigen::VectorXd& rbss, const Eigen::VectorXd& rbsc,
+    const Eigen::VectorXd& rbcs, const Eigen::VectorXd& zbsc,
+    const Eigen::VectorXd& zbcs, const Eigen::VectorXd& zbcc,
+    const Eigen::VectorXd& zbss, const Eigen::VectorXd& raxis_c,
+    const Eigen::VectorXd& raxis_s, const Eigen::VectorXd& zaxis_s,
+    const Eigen::VectorXd& zaxis_c) {
   RecomputeAxisWorkspace w;
 
   w.r_axis.resize(s.nZeta);

--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/guess_magnetic_axis.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/guess_magnetic_axis.h
@@ -5,6 +5,7 @@
 #ifndef VMECPP_VMEC_BOUNDARIES_GUESS_MAGNETIC_AXIS_H_
 #define VMECPP_VMEC_BOUNDARIES_GUESS_MAGNETIC_AXIS_H_
 
+#include <Eigen/Dense>
 #include <vector>
 
 #include "vmecpp/common/fourier_basis_fast_poloidal/fourier_basis_fast_poloidal.h"
@@ -61,13 +62,13 @@ struct RecomputeAxisWorkspace {
 // done assuming the given number_of_flux_surfaces.
 RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
     int number_of_flux_surfaces, int sign_of_jacobian, const Sizes& s,
-    const FourierBasisFastPoloidal& t, const std::vector<double>& rbcc,
-    const std::vector<double>& rbss, const std::vector<double>& rbsc,
-    const std::vector<double>& rbcs, const std::vector<double>& zbsc,
-    const std::vector<double>& zbcs, const std::vector<double>& zbcc,
-    const std::vector<double>& zbss, const std::vector<double>& raxis_c,
-    const std::vector<double>& raxis_s, const std::vector<double>& zaxis_s,
-    const std::vector<double>& zaxis_c);
+    const FourierBasisFastPoloidal& t, const Eigen::VectorXd& rbcc,
+    const Eigen::VectorXd& rbss, const Eigen::VectorXd& rbsc,
+    const Eigen::VectorXd& rbcs, const Eigen::VectorXd& zbsc,
+    const Eigen::VectorXd& zbcs, const Eigen::VectorXd& zbcc,
+    const Eigen::VectorXd& zbss, const Eigen::VectorXd& raxis_c,
+    const Eigen::VectorXd& raxis_s, const Eigen::VectorXd& zaxis_s,
+    const Eigen::VectorXd& zaxis_c);
 
 }  // namespace vmecpp
 

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.cc
@@ -26,22 +26,34 @@ FourierCoeffs::FourierCoeffs(const Sizes* s, const RadialPartitioning* r,
   int num_fc_RZ = (jMaxIncludingBoundary - nsMin) * s_.mpol * (s_.ntor + 1);
   int num_fc_L = (jMaxIncludingBoundary - nsMin) * s_.mpol * (s_.ntor + 1);
 
-  rcc.resize(num_fc_RZ, 0.0);
-  zsc.resize(num_fc_RZ, 0.0);
-  lsc.resize(num_fc_L, 0.0);
+  rcc.resize(num_fc_RZ);
+  rcc.setZero();
+  zsc.resize(num_fc_RZ);
+  zsc.setZero();
+  lsc.resize(num_fc_L);
+  lsc.setZero();
   if (s_.lthreed) {
-    rss.resize(num_fc_RZ, 0.0);
-    zcs.resize(num_fc_RZ, 0.0);
-    lcs.resize(num_fc_L, 0.0);
+    rss.resize(num_fc_RZ);
+    rss.setZero();
+    zcs.resize(num_fc_RZ);
+    zcs.setZero();
+    lcs.resize(num_fc_L);
+    lcs.setZero();
   }
   if (s_.lasym) {
-    rsc.resize(num_fc_RZ, 0.0);
-    zcc.resize(num_fc_RZ, 0.0);
-    lcc.resize(num_fc_L, 0.0);
+    rsc.resize(num_fc_RZ);
+    rsc.setZero();
+    zcc.resize(num_fc_RZ);
+    zcc.setZero();
+    lcc.resize(num_fc_L);
+    lcc.setZero();
     if (s_.lthreed) {
-      rcs.resize(num_fc_RZ, 0.0);
-      zss.resize(num_fc_RZ, 0.0);
-      lss.resize(num_fc_L, 0.0);
+      rcs.resize(num_fc_RZ);
+      rcs.setZero();
+      zss.resize(num_fc_RZ);
+      zss.setZero();
+      lss.resize(num_fc_L);
+      lss.setZero();
     }
   }
 }
@@ -109,7 +121,7 @@ void FourierCoeffs::setZero() {
 
 /** apply even/odd-m decomposition */
 void FourierCoeffs::decomposeInto(FourierCoeffs& m_x,
-                                  const std::vector<double>& scalxc) const {
+                                  const Eigen::VectorXd& scalxc) const {
   // TODO(jons): understand correct limits in fixed-boundary vs. free-boundary
   int jMaxIncludingBoundary = nsMax_;
   if (r_.nsMaxF1 == ns) {

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.h
@@ -5,6 +5,7 @@
 #ifndef VMECPP_VMEC_FOURIER_COEFFICIENTS_FOURIER_COEFFICIENTS_H_
 #define VMECPP_VMEC_FOURIER_COEFFICIENTS_FOURIER_COEFFICIENTS_H_
 
+#include <Eigen/Dense>
 #include <cstdio>
 #include <optional>
 #include <vector>
@@ -26,8 +27,7 @@ class FourierCoeffs {
 
   void setZero();
 
-  void decomposeInto(FourierCoeffs& m_x,
-                     const std::vector<double>& scalxc) const;
+  void decomposeInto(FourierCoeffs& m_x, const Eigen::VectorXd& scalxc) const;
   void m1Constraint(double scalingFactor,
                     std::optional<int> jMax = std::nullopt);
 
@@ -52,44 +52,44 @@ class FourierCoeffs {
   const int ns;
 
   // [ns x numFC] R ~ cos(m*theta)*cos(n*zeta)
-  std::vector<double> rcc;
+  Eigen::VectorXd rcc;
 
   // [ns x numFC] R ~ sin(m*theta)*sin(n*zeta)
-  std::vector<double> rss;
+  Eigen::VectorXd rss;
 
   // [ns x numFC] R ~ sin(m*theta)*cos(n*zeta)
-  std::vector<double> rsc;
+  Eigen::VectorXd rsc;
 
   // [ns x numFC] R ~ cos(m*theta)*sin(n*zeta)
-  std::vector<double> rcs;
+  Eigen::VectorXd rcs;
 
   //***************/
 
   // [ns x numFC] Z ~ sin(m*theta)*cos(n*zeta)
-  std::vector<double> zsc;
+  Eigen::VectorXd zsc;
 
   // [ns x numFC] Z ~ cos(m*theta)*sin(n*zeta)
-  std::vector<double> zcs;
+  Eigen::VectorXd zcs;
 
   // [ns x numFC] Z ~ cos(m*theta)*cos(n*zeta)
-  std::vector<double> zcc;
+  Eigen::VectorXd zcc;
 
   // [ns x numFC] Z ~ sin(m*theta)*sin(n*zeta)
-  std::vector<double> zss;
+  Eigen::VectorXd zss;
 
   //***************/
 
   // [ns x numFC] lambda ~ sin(m*theta)*cos(n*zeta)
-  std::vector<double> lsc;
+  Eigen::VectorXd lsc;
 
   // [ns x numFC] lambda ~ cos(m*theta)*sin(n*zeta)
-  std::vector<double> lcs;
+  Eigen::VectorXd lcs;
 
   // [ns x numFC] lambda ~ cos(m*theta)*cos(n*zeta)
-  std::vector<double> lcc;
+  Eigen::VectorXd lcc;
 
   // [ns x numFC] lambda ~ sin(m*theta)*sin(n*zeta)
-  std::vector<double> lss;
+  Eigen::VectorXd lss;
 };
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_forces/fourier_forces.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_forces/fourier_forces.cc
@@ -13,18 +13,18 @@ namespace vmecpp {
 FourierForces::FourierForces(const Sizes* s, const RadialPartitioning* r,
                              int ns)
     : FourierCoeffs(s, r, r->nsMinF, r->nsMaxF, ns),
-      frcc(rcc),
-      frss(rss),
-      frsc(rsc),
-      frcs(rcs),
-      fzsc(zsc),
-      fzcs(zcs),
-      fzcc(zcc),
-      fzss(zss),
-      flsc(lsc),
-      flcs(lcs),
-      flcc(lcc),
-      flss(lss) {}
+      frcc(rcc.data(), rcc.size()),
+      frss(rss.data(), rss.size()),
+      frsc(rsc.data(), rsc.size()),
+      frcs(rcs.data(), rcs.size()),
+      fzsc(zsc.data(), zsc.size()),
+      fzcs(zcs.data(), zcs.size()),
+      fzcc(zcc.data(), zcc.size()),
+      fzss(zss.data(), zss.size()),
+      flsc(lsc.data(), lsc.size()),
+      flcs(lcs.data(), lcs.size()),
+      flcc(lcc.data(), lcc.size()),
+      flss(lss.data(), lss.size()) {}
 
 FourierForces::FourierForces(const FourierForces& other)
     : FourierCoeffs(other),

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.cc
@@ -15,20 +15,20 @@ namespace vmecpp {
 FourierGeometry::FourierGeometry(const Sizes* s, const RadialPartitioning* r,
                                  int ns)
     : FourierCoeffs(s, r, r->nsMinF1, r->nsMaxF1, ns),
-      rmncc(rcc),
-      rmnss(rss),
-      rmnsc(rsc),
-      rmncs(rcs),
+      rmncc(rcc.data(), rcc.size()),
+      rmnss(rss.data(), rss.size()),
+      rmnsc(rsc.data(), rsc.size()),
+      rmncs(rcs.data(), rcs.size()),
 
-      zmnsc(zsc),
-      zmncs(zcs),
-      zmncc(zcc),
-      zmnss(zss),
+      zmnsc(zsc.data(), zsc.size()),
+      zmncs(zcs.data(), zcs.size()),
+      zmncc(zcc.data(), zcc.size()),
+      zmnss(zss.data(), zss.size()),
 
-      lmnsc(lsc),
-      lmncs(lcs),
-      lmncc(lcc),
-      lmnss(lss) {}
+      lmnsc(lsc.data(), lsc.size()),
+      lmncs(lcs.data(), lcs.size()),
+      lmncc(lcc.data(), lcc.size()),
+      lmnss(lss.data(), lss.size()) {}
 
 FourierGeometry::FourierGeometry(const FourierGeometry& other)
     : FourierCoeffs(other),
@@ -375,8 +375,9 @@ void FourierGeometry::ComputeSpectralWidth(
         const double basis_norm =
             fourier_basis.mscale[m] * fourier_basis.nscale[n];
 
-        std::vector<double> r_coefficients(4, 0.0);
-        std::vector<double> z_coefficients(4, 0.0);
+        // Use Eigen for vectorized norm computation
+        Eigen::Vector4d r_coefficients = Eigen::Vector4d::Zero();
+        Eigen::Vector4d z_coefficients = Eigen::Vector4d::Zero();
         int basis_dimension = 0;
 
         r_coefficients[basis_dimension] = rmncc[fourier_index];
@@ -422,14 +423,10 @@ void FourierGeometry::ComputeSpectralWidth(
           basis_dimension++;
         }
 
-        double coefficient_norm = 0.0;
-        for (int basis_index = 0; basis_index < basis_dimension;
-             ++basis_index) {
-          coefficient_norm +=
-              r_coefficients[basis_index] * r_coefficients[basis_index];
-          coefficient_norm +=
-              z_coefficients[basis_index] * z_coefficients[basis_index];
-        }  // basis_index
+        // Vectorized squared norm computation
+        double coefficient_norm =
+            r_coefficients.head(basis_dimension).squaredNorm() +
+            z_coefficients.head(basis_dimension).squaredNorm();
         coefficient_norm *= basis_norm * basis_norm;
 
         spectral_width_numerator += coefficient_norm * std::pow(m, p + q);

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_velocity/fourier_velocity.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_velocity/fourier_velocity.cc
@@ -11,18 +11,18 @@ namespace vmecpp {
 FourierVelocity::FourierVelocity(const Sizes* s, const RadialPartitioning* r,
                                  int ns)
     : FourierCoeffs(s, r, r->nsMinF, r->nsMaxF, ns),
-      vrcc(rcc),
-      vrss(rss),
-      vrsc(rsc),
-      vrcs(rcs),
-      vzsc(zsc),
-      vzcs(zcs),
-      vzcc(zcc),
-      vzss(zss),
-      vlsc(lsc),
-      vlcs(lcs),
-      vlcc(lcc),
-      vlss(lss) {}
+      vrcc(rcc.data(), rcc.size()),
+      vrss(rss.data(), rss.size()),
+      vrsc(rsc.data(), rsc.size()),
+      vrcs(rcs.data(), rcs.size()),
+      vzsc(zsc.data(), zsc.size()),
+      vzcs(zcs.data(), zcs.size()),
+      vzcc(zcc.data(), zcc.size()),
+      vzss(zss.data(), zss.size()),
+      vlsc(lsc.data(), lsc.size()),
+      vlcs(lcs.data(), lcs.size()),
+      vlcc(lcc.data(), lcc.size()),
+      vlss(lss.data(), lss.size()) {}
 
 FourierVelocity::FourierVelocity(const FourierVelocity& other)
     : FourierCoeffs(other),

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -110,55 +110,56 @@ void vmecpp::ForcesToFourier3DSymmFastPoloidal(
       const auto& fzcon = m_even ? d.fzcon_e : d.fzcon_o;
 
       for (int k = 0; k < s.nZeta; ++k) {
-        double rmkcc = 0.0;
-        double rmkcc_n = 0.0;
-        double rmkss = 0.0;
-        double rmkss_n = 0.0;
-        double zmksc = 0.0;
-        double zmksc_n = 0.0;
-        double zmkcs = 0.0;
-        double zmkcs_n = 0.0;
-        double lmksc = 0.0;
-        double lmksc_n = 0.0;
-        double lmkcs = 0.0;
-        double lmkcs_n = 0.0;
-
         const int idx_kl_base = ((jF - rp.nsMinF) * s.nZeta + k) * s.nThetaEff;
         const int idx_ml_base = m * s.nThetaReduced;
 
-        // NOTE: nThetaReduced is usually pretty small, 9 for cma.json
-        // and 16 for w7x_ref_167_12_12.json, so in our benchmark forcing
-        // the compiler to auto-vectorize this loop was a pessimization.
-        for (int l = 0; l < s.nThetaReduced; ++l) {
-          const int idx_kl = idx_kl_base + l;
-          const int idx_ml = idx_ml_base + l;
+        // Vectorized poloidal loop using Eigen operations
+        auto cosmui_seg = fb.cosmui.segment(idx_ml_base, s.nThetaReduced);
+        auto sinmui_seg = fb.sinmui.segment(idx_ml_base, s.nThetaReduced);
+        auto cosmumi_seg = fb.cosmumi.segment(idx_ml_base, s.nThetaReduced);
+        auto sinmumi_seg = fb.sinmumi.segment(idx_ml_base, s.nThetaReduced);
 
-          const double cosmui = fb.cosmui[idx_ml];
-          const double sinmui = fb.sinmui[idx_ml];
-          const double cosmumi = fb.cosmumi[idx_ml];
-          const double sinmumi = fb.sinmumi[idx_ml];
+        auto blmn_seg = Eigen::Map<const Eigen::VectorXd>(
+            blmn.data() + idx_kl_base, s.nThetaReduced);
+        auto clmn_seg = Eigen::Map<const Eigen::VectorXd>(
+            clmn.data() + idx_kl_base, s.nThetaReduced);
+        auto crmn_seg = Eigen::Map<const Eigen::VectorXd>(
+            crmn.data() + idx_kl_base, s.nThetaReduced);
+        auto czmn_seg = Eigen::Map<const Eigen::VectorXd>(
+            czmn.data() + idx_kl_base, s.nThetaReduced);
+        auto armn_seg = Eigen::Map<const Eigen::VectorXd>(
+            armn.data() + idx_kl_base, s.nThetaReduced);
+        auto azmn_seg = Eigen::Map<const Eigen::VectorXd>(
+            azmn.data() + idx_kl_base, s.nThetaReduced);
+        auto brmn_seg = Eigen::Map<const Eigen::VectorXd>(
+            brmn.data() + idx_kl_base, s.nThetaReduced);
+        auto bzmn_seg = Eigen::Map<const Eigen::VectorXd>(
+            bzmn.data() + idx_kl_base, s.nThetaReduced);
+        auto frcon_seg = Eigen::Map<const Eigen::VectorXd>(
+            frcon.data() + idx_kl_base, s.nThetaReduced);
+        auto fzcon_seg = Eigen::Map<const Eigen::VectorXd>(
+            fzcon.data() + idx_kl_base, s.nThetaReduced);
 
-          lmksc += blmn[idx_kl] * cosmumi;   // --> flsc (no A)
-          lmkcs += blmn[idx_kl] * sinmumi;   // --> flcs
-          lmkcs_n -= clmn[idx_kl] * cosmui;  // --> flcs
-          lmksc_n -= clmn[idx_kl] * sinmui;  // --> flsc
+        double lmksc = blmn_seg.dot(cosmumi_seg);
+        double lmkcs = blmn_seg.dot(sinmumi_seg);
+        double lmkcs_n = -clmn_seg.dot(cosmui_seg);
+        double lmksc_n = -clmn_seg.dot(sinmui_seg);
 
-          rmkcc_n -= crmn[idx_kl] * cosmui;  // --> frcc
-          zmkcs_n -= czmn[idx_kl] * cosmui;  // --> fzcs
+        double rmkcc_n = -crmn_seg.dot(cosmui_seg);
+        double zmkcs_n = -czmn_seg.dot(cosmui_seg);
 
-          rmkss_n -= crmn[idx_kl] * sinmui;  // --> frss
-          zmksc_n -= czmn[idx_kl] * sinmui;  // --> fzsc
+        double rmkss_n = -crmn_seg.dot(sinmui_seg);
+        double zmksc_n = -czmn_seg.dot(sinmui_seg);
 
-          // assemble effective R and Z forces from MHD and spectral
-          // condensation contributions
-          const double tempR = armn[idx_kl] + xmpq[m] * frcon[idx_kl];
-          const double tempZ = azmn[idx_kl] + xmpq[m] * fzcon[idx_kl];
+        // Assemble effective R and Z forces from MHD and spectral condensation
+        // contributions
+        auto tempR_seg = armn_seg + xmpq[m] * frcon_seg;
+        auto tempZ_seg = azmn_seg + xmpq[m] * fzcon_seg;
 
-          rmkcc += tempR * cosmui + brmn[idx_kl] * sinmumi;  // --> frcc
-          rmkss += tempR * sinmui + brmn[idx_kl] * cosmumi;  // --> frss
-          zmksc += tempZ * sinmui + bzmn[idx_kl] * cosmumi;  // --> fzsc
-          zmkcs += tempZ * cosmui + bzmn[idx_kl] * sinmumi;  // --> fzcs
-        }  // l
+        double rmkcc = tempR_seg.dot(cosmui_seg) + brmn_seg.dot(sinmumi_seg);
+        double rmkss = tempR_seg.dot(sinmui_seg) + brmn_seg.dot(cosmumi_seg);
+        double zmksc = tempZ_seg.dot(sinmui_seg) + bzmn_seg.dot(cosmumi_seg);
+        double zmkcs = tempZ_seg.dot(cosmui_seg) + bzmn_seg.dot(sinmumi_seg);
 
         for (int n = 0; n < s.ntor + 1; ++n) {
           const int idx_mn = ((jF - rp.nsMinF) * s.mpol + m) * (s.ntor + 1) + n;
@@ -193,28 +194,24 @@ void vmecpp::ForcesToFourier3DSymmFastPoloidal(
       const auto& clmn = m_even ? d.clmn_e : d.clmn_o;
 
       for (int k = 0; k < s.nZeta; ++k) {
-        double lmksc = 0.0;
-        double lmksc_n = 0.0;
-        double lmkcs = 0.0;
-        double lmkcs_n = 0.0;
-
         const int idx_kl_base = ((jF - rp.nsMinF) * s.nZeta + k) * s.nThetaEff;
         const int idx_ml_base = m * s.nThetaReduced;
 
-        for (int l = 0; l < s.nThetaReduced; ++l) {
-          const int idx_kl = idx_kl_base + l;
-          const int idx_ml = idx_ml_base + l;
+        // Vectorized poloidal loop using Eigen operations
+        auto cosmui_seg = fb.cosmui.segment(idx_ml_base, s.nThetaReduced);
+        auto sinmui_seg = fb.sinmui.segment(idx_ml_base, s.nThetaReduced);
+        auto cosmumi_seg = fb.cosmumi.segment(idx_ml_base, s.nThetaReduced);
+        auto sinmumi_seg = fb.sinmumi.segment(idx_ml_base, s.nThetaReduced);
 
-          const double cosmui = fb.cosmui[idx_ml];
-          const double sinmui = fb.sinmui[idx_ml];
-          const double cosmumi = fb.cosmumi[idx_ml];
-          const double sinmumi = fb.sinmumi[idx_ml];
+        auto blmn_seg = Eigen::Map<const Eigen::VectorXd>(
+            blmn.data() + idx_kl_base, s.nThetaReduced);
+        auto clmn_seg = Eigen::Map<const Eigen::VectorXd>(
+            clmn.data() + idx_kl_base, s.nThetaReduced);
 
-          lmksc += blmn[idx_kl] * cosmumi;   // --> flsc (no A)
-          lmkcs += blmn[idx_kl] * sinmumi;   // --> flcs
-          lmkcs_n -= clmn[idx_kl] * cosmui;  // --> flcs
-          lmksc_n -= clmn[idx_kl] * sinmui;  // --> flsc
-        }  // l
+        double lmksc = blmn_seg.dot(cosmumi_seg);
+        double lmkcs = blmn_seg.dot(sinmumi_seg);
+        double lmkcs_n = -clmn_seg.dot(cosmui_seg);
+        double lmksc_n = -clmn_seg.dot(sinmui_seg);
 
         for (int n = 0; n < s.ntor + 1; ++n) {
           const int idx_mn = ((jF - rp.nsMinF) * s.mpol + m) * (s.ntor + 1) + n;
@@ -293,100 +290,97 @@ void vmecpp::FourierToReal3DSymmFastPoloidal(
       }
 
       for (int k = 0; k < s.nZeta; ++k) {
-        double rmkcc = 0.0;
-        double rmkcc_n = 0.0;
-        double rmkss = 0.0;
-        double rmkss_n = 0.0;
-        double zmksc = 0.0;
-        double zmksc_n = 0.0;
-        double zmkcs = 0.0;
-        double zmkcs_n = 0.0;
-        double lmksc = 0.0;
-        double lmksc_n = 0.0;
-        double lmkcs = 0.0;
-        double lmkcs_n = 0.0;
+        // INVERSE TRANSFORM IN N-ZETA, FOR FIXED M
+        // Vectorized toroidal accumulation loop
+        const int idx_kn_base = k * (s.nnyq2 + 1);
+        const int idx_mn_base = ((jF - nsMinF1) * s.mpol + m) * (s.ntor + 1);
 
-        for (int n = 0; n < s.ntor + 1; ++n) {
-          // INVERSE TRANSFORM IN N-ZETA, FOR FIXED M
+        auto cosnv_seg = fb.cosnv.segment(idx_kn_base, s.ntor + 1);
+        auto sinnv_seg = fb.sinnv.segment(idx_kn_base, s.ntor + 1);
+        auto sinnvn_seg = fb.sinnvn.segment(idx_kn_base, s.ntor + 1);
+        auto cosnvn_seg = fb.cosnvn.segment(idx_kn_base, s.ntor + 1);
 
-          const int idx_kn = k * (s.nnyq2 + 1) + n;
+        auto rmncc_seg = Eigen::Map<const Eigen::VectorXd>(
+            physical_x.rmncc.data() + idx_mn_base, s.ntor + 1);
+        auto rmnss_seg = Eigen::Map<const Eigen::VectorXd>(
+            physical_x.rmnss.data() + idx_mn_base, s.ntor + 1);
+        auto zmnsc_seg = Eigen::Map<const Eigen::VectorXd>(
+            physical_x.zmnsc.data() + idx_mn_base, s.ntor + 1);
+        auto zmncs_seg = Eigen::Map<const Eigen::VectorXd>(
+            physical_x.zmncs.data() + idx_mn_base, s.ntor + 1);
+        auto lmnsc_seg = Eigen::Map<const Eigen::VectorXd>(
+            physical_x.lmnsc.data() + idx_mn_base, s.ntor + 1);
+        auto lmncs_seg = Eigen::Map<const Eigen::VectorXd>(
+            physical_x.lmncs.data() + idx_mn_base, s.ntor + 1);
 
-          double cosnv = fb.cosnv[idx_kn];
-          double sinnv = fb.sinnv[idx_kn];
-          double sinnvn = fb.sinnvn[idx_kn];
-          double cosnvn = fb.cosnvn[idx_kn];
-
-          int idx_mn = ((jF - nsMinF1) * s.mpol + m) * (s.ntor + 1) + n;
-
-          rmkcc += physical_x.rmncc[idx_mn] * cosnv;
-          rmkcc_n += physical_x.rmncc[idx_mn] * sinnvn;
-          rmkss += physical_x.rmnss[idx_mn] * sinnv;
-          rmkss_n += physical_x.rmnss[idx_mn] * cosnvn;
-          zmksc += physical_x.zmnsc[idx_mn] * cosnv;
-          zmksc_n += physical_x.zmnsc[idx_mn] * sinnvn;
-          zmkcs += physical_x.zmncs[idx_mn] * sinnv;
-          zmkcs_n += physical_x.zmncs[idx_mn] * cosnvn;
-          lmksc += physical_x.lmnsc[idx_mn] * cosnv;
-          lmksc_n += physical_x.lmnsc[idx_mn] * sinnvn;
-          lmkcs += physical_x.lmncs[idx_mn] * sinnv;
-          lmkcs_n += physical_x.lmncs[idx_mn] * cosnvn;
-        }  // n
+        double rmkcc = rmncc_seg.dot(cosnv_seg);
+        double rmkcc_n = rmncc_seg.dot(sinnvn_seg);
+        double rmkss = rmnss_seg.dot(sinnv_seg);
+        double rmkss_n = rmnss_seg.dot(cosnvn_seg);
+        double zmksc = zmnsc_seg.dot(cosnv_seg);
+        double zmksc_n = zmnsc_seg.dot(sinnvn_seg);
+        double zmkcs = zmncs_seg.dot(sinnv_seg);
+        double zmkcs_n = zmncs_seg.dot(cosnvn_seg);
+        double lmksc = lmnsc_seg.dot(cosnv_seg);
+        double lmksc_n = lmnsc_seg.dot(sinnvn_seg);
+        double lmkcs = lmncs_seg.dot(sinnv_seg);
+        double lmkcs_n = lmncs_seg.dot(cosnvn_seg);
 
         // INVERSE TRANSFORM IN M-THETA, FOR ALL RADIAL, ZETA VALUES
         const int idx_kl_base = ((jF - nsMinF1) * s.nZeta + k) * s.nThetaEff;
 
-        // the loop over l is split to help compiler auto-vectorization
-        for (int l = 0; l < s.nThetaReduced; ++l) {
-          const int idx_ml = idx_ml_base + l;
+        // Vectorized poloidal loops using Eigen operations
+        auto sinmum_seg = fb.sinmum.segment(idx_ml_base, s.nThetaReduced);
+        auto cosmum_seg = fb.cosmum.segment(idx_ml_base, s.nThetaReduced);
 
-          const double sinmum = fb.sinmum[idx_ml];
-          const double cosmum = fb.cosmum[idx_ml];
+        auto ru_seg = Eigen::Map<Eigen::VectorXd>(ru.data() + idx_kl_base,
+                                                  s.nThetaReduced);
+        auto zu_seg = Eigen::Map<Eigen::VectorXd>(zu.data() + idx_kl_base,
+                                                  s.nThetaReduced);
+        auto lu_seg = Eigen::Map<Eigen::VectorXd>(lu.data() + idx_kl_base,
+                                                  s.nThetaReduced);
 
-          const int idx_kl = idx_kl_base + l;
-          ru[idx_kl] += rmkcc * sinmum + rmkss * cosmum;
-          zu[idx_kl] += zmksc * cosmum + zmkcs * sinmum;
-          lu[idx_kl] += lmksc * cosmum + lmkcs * sinmum;
-        }  // l
+        // NOTE: element-wise multiplication
+        ru_seg += rmkcc * sinmum_seg + rmkss * cosmum_seg;
+        zu_seg += zmksc * cosmum_seg + zmkcs * sinmum_seg;
+        lu_seg += lmksc * cosmum_seg + lmkcs * sinmum_seg;
 
-        for (int l = 0; l < s.nThetaReduced; ++l) {
-          const int idx_kl = idx_kl_base + l;
-          const int idx_ml = idx_ml_base + l;
+        auto cosmu_seg = fb.cosmu.segment(idx_ml_base, s.nThetaReduced);
+        auto sinmu_seg = fb.sinmu.segment(idx_ml_base, s.nThetaReduced);
 
-          const double cosmu = fb.cosmu[idx_ml];
-          const double sinmu = fb.sinmu[idx_ml];
-          rv[idx_kl] += rmkcc_n * cosmu + rmkss_n * sinmu;
-          zv[idx_kl] += zmksc_n * sinmu + zmkcs_n * cosmu;
-          // it is here that lv gets a negative sign!
-          lv[idx_kl] -= lmksc_n * sinmu + lmkcs_n * cosmu;
-        }  // l
+        auto rv_seg = Eigen::Map<Eigen::VectorXd>(rv.data() + idx_kl_base,
+                                                  s.nThetaReduced);
+        auto zv_seg = Eigen::Map<Eigen::VectorXd>(zv.data() + idx_kl_base,
+                                                  s.nThetaReduced);
+        auto lv_seg = Eigen::Map<Eigen::VectorXd>(lv.data() + idx_kl_base,
+                                                  s.nThetaReduced);
 
-        for (int l = 0; l < s.nThetaReduced; ++l) {
-          const int idx_ml = idx_ml_base + l;
+        // NOTE: element-wise multiplication
+        rv_seg += rmkcc_n * cosmu_seg + rmkss_n * sinmu_seg;
+        zv_seg += zmksc_n * sinmu_seg + zmkcs_n * cosmu_seg;
+        // it is here that lv gets a negative sign!
+        lv_seg -= lmksc_n * sinmu_seg + lmkcs_n * cosmu_seg;
 
-          const double cosmu = fb.cosmu[idx_ml];
-          const double sinmu = fb.sinmu[idx_ml];
+        auto r1_seg = Eigen::Map<Eigen::VectorXd>(r1.data() + idx_kl_base,
+                                                  s.nThetaReduced);
+        auto z1_seg = Eigen::Map<Eigen::VectorXd>(z1.data() + idx_kl_base,
+                                                  s.nThetaReduced);
 
-          const int idx_kl = idx_kl_base + l;
-
-          r1[idx_kl] += rmkcc * cosmu + rmkss * sinmu;
-          z1[idx_kl] += zmksc * sinmu + zmkcs * cosmu;
-        }  // l
+        r1_seg += rmkcc * cosmu_seg + rmkss * sinmu_seg;
+        z1_seg += zmksc * sinmu_seg + zmkcs * cosmu_seg;
 
         if (nsMinF <= jF && jF < r.nsMaxFIncludingLcfs) {
-          for (int l = 0; l < s.nThetaReduced; ++l) {
-            const int idx_ml = idx_ml_base + l;
-            const double cosmu = fb.cosmu[idx_ml];
-            const double sinmu = fb.sinmu[idx_ml];
+          // spectral condensation is local per flux surface
+          const int idx_con_base = ((jF - nsMinF) * s.nZeta + k) * s.nThetaEff;
 
-            // spectral condensation is local per flux surface
-            // --> no need for numFull1
-            const int idx_con = ((jF - nsMinF) * s.nZeta + k) * s.nThetaEff + l;
-            m_geometry.rCon[idx_con] +=
-                (rmkcc * cosmu + rmkss * sinmu) * con_factor;
-            m_geometry.zCon[idx_con] +=
-                (zmksc * sinmu + zmkcs * cosmu) * con_factor;
-          }
-        }  // l
+          auto rCon_seg = Eigen::Map<Eigen::VectorXd>(
+              m_geometry.rCon.data() + idx_con_base, s.nThetaReduced);
+          auto zCon_seg = Eigen::Map<Eigen::VectorXd>(
+              m_geometry.zCon.data() + idx_con_base, s.nThetaReduced);
+
+          rCon_seg += (rmkcc * cosmu_seg + rmkss * sinmu_seg) * con_factor;
+          zCon_seg += (zmksc * sinmu_seg + zmkcs * cosmu_seg) * con_factor;
+        }
       }  // k
     }  // m
   }  // j
@@ -413,18 +407,18 @@ void vmecpp::deAliasConstraintForce(
       absl::c_fill_n(m_gcs, s_.ntor + 1, 0);
 
       for (int k = 0; k < s_.nZeta; ++k) {
-        double w0 = 0.0;
-        double w1 = 0.0;
-
         // fwd transform in poloidal direction
         // integrate poloidally to get m-th poloidal Fourier coefficient
-        for (int l = 0; l < s_.nThetaReduced; ++l) {
-          const int idx_ml = m * s_.nThetaReduced + l;
+        const int kl_base = ((jF - rp.nsMinF) * s_.nZeta + k) * s_.nThetaEff;
+        const int ml_base = m * s_.nThetaReduced;
 
-          int idx_kl = ((jF - rp.nsMinF) * s_.nZeta + k) * s_.nThetaEff + l;
-          w0 += gConEff[idx_kl] * fb.sinmui[idx_ml];
-          w1 += gConEff[idx_kl] * fb.cosmui[idx_ml];
-        }  // l
+        auto gConEff_seg = Eigen::Map<const Eigen::VectorXd>(
+            gConEff.data() + kl_base, s_.nThetaReduced);
+        auto sinmui_seg = fb.sinmui.segment(ml_base, s_.nThetaReduced);
+        auto cosmui_seg = fb.cosmui.segment(ml_base, s_.nThetaReduced);
+
+        double w0 = gConEff_seg.dot(sinmui_seg);
+        double w1 = gConEff_seg.dot(cosmui_seg);
 
         // forward Fourier transform in toroidal direction for full set of mode
         // numbers (n = 0, 1, ..., ntor)
@@ -444,15 +438,18 @@ void vmecpp::deAliasConstraintForce(
 
       // inverse Fourier-transform from reduced set of mode numbers
       for (int k = 0; k < s_.nZeta; ++k) {
-        double w0 = 0.0;
-        double w1 = 0.0;
-
         // collect contribution to current grid point from n-th toroidal mode
-        for (int n = 0; n < s_.ntor + 1; ++n) {
-          int idx_kn = k * (s_.nnyq2 + 1) + n;
-          w0 += m_gsc[n] * fb.cosnv[idx_kn];
-          w1 += m_gcs[n] * fb.sinnv[idx_kn];
-        }  // n
+        const int kn_base = k * (s_.nnyq2 + 1);
+        auto cosnv_seg = fb.cosnv.segment(kn_base, s_.ntor + 1);
+        auto sinnv_seg = fb.sinnv.segment(kn_base, s_.ntor + 1);
+
+        auto m_gsc_seg =
+            Eigen::Map<const Eigen::VectorXd>(m_gsc.data(), s_.ntor + 1);
+        auto m_gcs_seg =
+            Eigen::Map<const Eigen::VectorXd>(m_gcs.data(), s_.ntor + 1);
+
+        double w0 = m_gsc_seg.dot(cosnv_seg);
+        double w1 = m_gcs_seg.dot(sinnv_seg);
 
         // inv transform in poloidal direction
         for (int l = 0; l < s_.nThetaReduced; ++l) {
@@ -2885,8 +2882,8 @@ void IdealMhdModel::computePreconditioningMatrix(
     }  // kl
   }  // jH
 
-  const std::vector<double>& sm = m_p_.sm;
-  const std::vector<double>& sp = m_p_.sp;
+  const Eigen::VectorXd& sm = m_p_.sm;
+  const Eigen::VectorXd& sp = m_p_.sp;
 
   // radial assembly of preconditioning matrix element components
   // All this sm, sp logic seems to be related to the odd-m scaling factors...

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -4394,11 +4394,11 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
   // -------------------
   // mode numbers for Fourier coefficient arrays below
 
-  // copy STL vectors into Eigen vectors
-  wout.xm = ToEigenVector(t.xm);
-  wout.xn = ToEigenVector(t.xn);
-  wout.xm_nyq = ToEigenVector(t.xm_nyq);
-  wout.xn_nyq = ToEigenVector(t.xn_nyq);
+  // copy Eigen vectors into wout
+  wout.xm = t.xm;
+  wout.xn = t.xn;
+  wout.xm_nyq = t.xm_nyq;
+  wout.xn_nyq = t.xn_nyq;
 
   // -------------------
   // stellarator-symmetric Fourier coefficients

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
@@ -9,7 +9,6 @@
 #include <cstdio>
 #include <iostream>
 #include <string>
-#include <vector>
 
 #include "absl/log/log.h"
 #include "absl/strings/str_format.h"
@@ -73,14 +72,17 @@ RadialProfiles::RadialProfiles(const RadialPartitioning* r,
   dVdsF.resize(r_.nsMaxFi - r_.nsMinFi);
   equiF.resize(r_.nsMaxFi - r_.nsMinFi);
 
-  spectral_width.resize(r_.nsMaxF1 - r_.nsMinF1, 0.0);
+  spectral_width.resize(r_.nsMaxF1 - r_.nsMinF1);
+  spectral_width.setZero();
 
   // ---------------------------------
 
   scalxc.resize((r_.nsMaxF1 - r_.nsMinF1) * 2);
 
-  sm.resize(r_.nsMaxH - r_.nsMinH, 0.0);
-  sp.resize(r_.nsMaxH - r_.nsMinH, 0.0);
+  sm.resize(r_.nsMaxH - r_.nsMinH);
+  sm.setZero();
+  sp.resize(r_.nsMaxH - r_.nsMinH);
+  sp.setZero();
 }
 
 void RadialProfiles::setupInputProfiles() {

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.h
@@ -9,7 +9,6 @@
 #include <cfloat>
 #include <cmath>
 #include <string>
-#include <vector>
 
 #include "vmecpp/common/flow_control/flow_control.h"
 #include "vmecpp/common/util/util.h"
@@ -114,19 +113,19 @@ class RadialProfiles {
   ProfileParameterization pcurrType;
 
   // half-grid
-  std::vector<double> phipH;
-  std::vector<double> chipH;
-  std::vector<double> iotaH;
-  std::vector<double> currH;
-  std::vector<double> massH;
-  std::vector<double> sqrtSH;
+  Eigen::VectorXd phipH;
+  Eigen::VectorXd chipH;
+  Eigen::VectorXd iotaH;
+  Eigen::VectorXd currH;
+  Eigen::VectorXd massH;
+  Eigen::VectorXd sqrtSH;
 
   // full-grid
-  std::vector<double> phipF;
-  std::vector<double> chipF;
-  std::vector<double> iotaF;
-  std::vector<double> sqrtSF;
-  std::vector<double> radialBlending;
+  Eigen::VectorXd phipF;
+  Eigen::VectorXd chipF;
+  Eigen::VectorXd iotaF;
+  Eigen::VectorXd sqrtSF;
+  Eigen::VectorXd radialBlending;
 
   // ---------------------------------
 
@@ -139,47 +138,47 @@ class RadialProfiles {
   double pressureScalingFactor;
 
   /** sm[j] = sqrt(s_{j-1/2}) / sqrt(s_j) for all force-j (numFull) */
-  std::vector<double> sm;
+  Eigen::VectorXd sm;
 
   /** sp[j] = sqrt(s_{j+1/2}) / sqrt(s_j) for all force-j (numFull) */
-  std::vector<double> sp;
+  Eigen::VectorXd sp;
 
   // part 2: derived radial profiles
 
   /** differential volume, half-grid */
-  std::vector<double> dVdsH;
+  Eigen::VectorXd dVdsH;
 
   /** kinetic pressure, half-grid */
-  std::vector<double> presH;
+  Eigen::VectorXd presH;
 
   /** enclosed poloidal current, half-grid */
-  std::vector<double> bvcoH;
+  Eigen::VectorXd bvcoH;
 
   /** enclosed toroidal current, half-grid */
-  std::vector<double> bucoH;
+  Eigen::VectorXd bucoH;
 
   /** poloidal current density, interior full-grid */
-  std::vector<double> jcuruF;
+  Eigen::VectorXd jcuruF;
 
   /** toroidal current density, interior full-grid */
-  std::vector<double> jcurvF;
+  Eigen::VectorXd jcurvF;
 
   /** pressure gradient, interior full-grid */
-  std::vector<double> presgradF;
+  Eigen::VectorXd presgradF;
 
   /** differential volume, interior full-grid */
-  std::vector<double> dVdsF;
+  Eigen::VectorXd dVdsF;
 
   /** radial force balance residual, interior full-grid */
-  std::vector<double> equiF;
+  Eigen::VectorXd equiF;
 
   // [nsMinF1 ... nsMaxF1] surface-averaged spectral width profile on full-grid
-  std::vector<double> spectral_width;
+  Eigen::VectorXd spectral_width;
 
   // ---------------------------------
 
   /** [ns x 2] 1/sqrtSF for odd-m; 1 for even-m */
-  std::vector<double> scalxc;
+  Eigen::VectorXd scalxc;
 
  private:
   const RadialPartitioning& r_;

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/BUILD.bazel
@@ -47,7 +47,7 @@ cc_test(
         "//util/file_io:file_io",
         "//util/testing:numerical_comparison_lib",
     ],
-    size = "small",
+    size = "medium",
 )
 
 cc_test(
@@ -62,5 +62,5 @@ cc_test(
         "//util/testing:numerical_comparison_lib",
         "//vmecpp/vmec/vmec",
     ],
-    size = "small",
+    size = "medium",
 )

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -183,9 +183,7 @@ Vmec::Vmec(const VmecINDATA& indata, std::optional<int> max_threads,
     iPiv.resize(mnpd, 0);
     bvecShare.resize(mnpd, 0.0);
 
-    // not so nice to do this here, but meh...
     h_.vacuum_magnetic_pressure.resize(s_.nZnT, 0.0);
-
     h_.vacuum_b_r.resize(s_.nZnT);
     h_.vacuum_b_phi.resize(s_.nZnT);
     h_.vacuum_b_z.resize(s_.nZnT);


### PR DESCRIPTION
Part of the larger migration of `vmecpp` to Eigen datatypes instead of std::vectors.