### PR TITLE
Remove copyFrom constructor, now that copy semantics are working

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.cc
@@ -351,35 +351,6 @@ void FourierGeometry::extrapolateTowardsAxis() {
   }  // n
 }
 
-void FourierGeometry::copyFrom(const FourierGeometry& src) {
-  for (int jF = nsMin_; jF < nsMax_; ++jF) {
-    for (int m = 0; m < s_.mpol; ++m) {
-      for (int n = 0; n < s_.ntor + 1; ++n) {
-        int idx_fc = ((jF - nsMin_) * s_.mpol + m) * (s_.ntor + 1) + n;
-
-        rmncc[idx_fc] = src.rmncc[idx_fc];
-        zmnsc[idx_fc] = src.zmnsc[idx_fc];
-        lmnsc[idx_fc] = src.lmnsc[idx_fc];
-        if (s_.lthreed) {
-          rmnss[idx_fc] = src.rmnss[idx_fc];
-          zmncs[idx_fc] = src.zmncs[idx_fc];
-          lmncs[idx_fc] = src.lmncs[idx_fc];
-        }
-        if (s_.lasym) {
-          rmnsc[idx_fc] = src.rmnsc[idx_fc];
-          zmncc[idx_fc] = src.zmncc[idx_fc];
-          lmncc[idx_fc] = src.lmncc[idx_fc];
-          if (s_.lthreed) {
-            rmncs[idx_fc] = src.rmncs[idx_fc];
-            zmnss[idx_fc] = src.zmnss[idx_fc];
-            lmnss[idx_fc] = src.lmnss[idx_fc];
-          }
-        }
-      }  // n
-    }  // m
-  }  // j
-}
-
 void FourierGeometry::ComputeSpectralWidth(
     const FourierBasisFastPoloidal& fourier_basis,
     RadialProfiles& m_radial_profiles, const int p, const int q) const {

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.h
@@ -41,8 +41,6 @@ class FourierGeometry : public FourierCoeffs {
 
   void extrapolateTowardsAxis();
 
-  void copyFrom(const FourierGeometry &src);
-
   // Compute the spectral width of the R and Z Fourier coefficients
   // and write it into the spectral_width vector in the given RadialProfiles.
   void ComputeSpectralWidth(const FourierBasisFastPoloidal &fourier_basis,

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -1034,7 +1034,7 @@ void Vmec::RestartIteration(double& m_delt0r, int thread_id) {
     decomposed_v_[thread_id]->setZero();
 
     // restore state from backup
-    decomposed_x_[thread_id]->copyFrom(*physical_x_backup_[thread_id]);
+    *decomposed_x_[thread_id] = *physical_x_backup_[thread_id];
 
 #ifdef _OPENMP
 #pragma omp barrier
@@ -1063,7 +1063,7 @@ void Vmec::RestartIteration(double& m_delt0r, int thread_id) {
     decomposed_v_[thread_id]->setZero();
 
     // restore state from backup
-    decomposed_x_[thread_id]->copyFrom(*physical_x_backup_[thread_id]);
+    *decomposed_x_[thread_id] = *physical_x_backup_[thread_id];
 
 #ifdef _OPENMP
 #pragma omp barrier
@@ -1083,7 +1083,7 @@ void Vmec::RestartIteration(double& m_delt0r, int thread_id) {
     // save current state vector, e.g. restart_reason == NO_RESTART
 
     // update backup
-    physical_x_backup_[thread_id]->copyFrom(*decomposed_x_[thread_id]);
+    *physical_x_backup_[thread_id] = *decomposed_x_[thread_id];
   }
 #ifdef _OPENMP
 #pragma omp barrier


### PR DESCRIPTION
This was just needed because copy/move semantics were broken originally.