### PR TITLE
B.n free boundary solver (only valid in vacuum)

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -93,6 +93,16 @@ class FreeBoundaryMethod(str, enum.Enum):
     BIEST = "biest"
     """Boundary Integral Equation Solver for Toroidal systems."""
 
+    ONLY_COILS_BDOTN = "only_coils_bdotn"
+    """Use the coils field with B_coils.n = 0 boundary condition.
+
+    Instead of pressure continuity (B_inside^2 - B_outside^2), drives the
+    normal component of the external magnetic field to zero at the LCFS.
+
+    Warning: This is only valid for vacuum calculations and will ignore
+    the plasma current contribution!
+    """
+
 
 class OutputMode(enum.Enum):
     """Controls the output format of iteration logging.."""

--- a/src/vmecpp/cpp/vmecpp/common/flow_control/flow_control.h
+++ b/src/vmecpp/cpp/vmecpp/common/flow_control/flow_control.h
@@ -101,6 +101,8 @@ class FlowControl {
 
   // Time-trace of the force at the vacuum boundary (only for free-boundary)
   std::vector<double> delbsq;
+  // Time-trace of |B_coils . n| at the LCFS (only for free-boundary)
+  std::vector<double> delbn;
   // Time-trace of the restart reasons, for debugging purposes. Each restart is
   // a pair of <iteration, reason> (e.g. to see how many jacobian resets
   // occurred)

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -55,6 +55,8 @@ absl::StatusOr<FreeBoundaryMethod> FreeBoundaryMethodFromString(
     return FreeBoundaryMethod::ONLY_COILS;
   } else if (free_boundary_method_string == "biest") {
     return FreeBoundaryMethod::BIEST;
+  } else if (free_boundary_method_string == "only_coils_bdotn") {
+    return FreeBoundaryMethod::ONLY_COILS_BDOTN;
   }
   return absl::NotFoundError(absl::StrCat("free boundary method named '",
                                           free_boundary_method_string,
@@ -69,6 +71,8 @@ std::string ToString(FreeBoundaryMethod free_boundary_method) {
       return "only_coils";
     case FreeBoundaryMethod::BIEST:
       return "biest";
+    case FreeBoundaryMethod::ONLY_COILS_BDOTN:
+      return "only_coils_bdotn";
     default:
       LOG(FATAL)
           << "no string conversion implemented yet for FreeBoundaryMethod code "
@@ -1389,15 +1393,14 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
     }
 
     // free_boundary_method
-    // For the current state of the code, we only accept NESTOR,
-    // but in the future [TODO(jons)] also all other (implemented) enum values
-    // are valid.
     if (vmec_indata.free_boundary_method != FreeBoundaryMethod::NESTOR &&
-        vmec_indata.free_boundary_method != FreeBoundaryMethod::ONLY_COILS) {
-      return absl::InvalidArgumentError(
-          absl::StrFormat("input variable 'free_boundary_method' must be "
-                          "'nestor' or 'only_coils', but is %s\n",
-                          ToString(vmec_indata.free_boundary_method)));
+        vmec_indata.free_boundary_method != FreeBoundaryMethod::ONLY_COILS &&
+        vmec_indata.free_boundary_method !=
+            FreeBoundaryMethod::ONLY_COILS_BDOTN) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "input variable 'free_boundary_method' must be "
+          "'nestor', 'only_coils', or 'only_coils_bdotn', but is %s\n",
+          ToString(vmec_indata.free_boundary_method)));
     }
   }
 

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
@@ -36,7 +36,11 @@ enum class FreeBoundaryMethod : std::uint8_t {
 
   // use the Boundary Integral Equation Solver for Toroidal systems
   // for the free-boundary force contribution
-  BIEST
+  BIEST,
+
+  // use just the coils field with B_coils . n = 0 boundary condition
+  // instead of pressure continuity
+  ONLY_COILS_BDOTN
 };
 
 int FreeBoundaryMethodCode(FreeBoundaryMethod free_boundary_method);

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
@@ -86,6 +86,9 @@ TEST(TestVmecINDATA, CheckFreeBoundaryMethodCases) {
 
   free_boundary_method = FreeBoundaryMethod::BIEST;
   EXPECT_EQ(free_boundary_method, FreeBoundaryMethod::BIEST);
+
+  free_boundary_method = FreeBoundaryMethod::ONLY_COILS_BDOTN;
+  EXPECT_EQ(free_boundary_method, FreeBoundaryMethod::ONLY_COILS_BDOTN);
 }  // CheckFreeBoundaryMethodCases
 
 TEST(TestVmecINDATA, CheckFreeBoundaryMethodFromString) {
@@ -102,6 +105,12 @@ TEST(TestVmecINDATA, CheckFreeBoundaryMethodFromString) {
   ASSERT_TRUE(status_or_free_boundary_method.ok());
   EXPECT_EQ(*status_or_free_boundary_method, FreeBoundaryMethod::BIEST);
 
+  status_or_free_boundary_method =
+      FreeBoundaryMethodFromString("only_coils_bdotn");
+  ASSERT_TRUE(status_or_free_boundary_method.ok());
+  EXPECT_EQ(*status_or_free_boundary_method,
+            FreeBoundaryMethod::ONLY_COILS_BDOTN);
+
   status_or_free_boundary_method = FreeBoundaryMethodFromString("blablubb");
   EXPECT_FALSE(status_or_free_boundary_method.ok());
 }  // CheckFreeBoundaryMethodFromString
@@ -110,6 +119,7 @@ TEST(TestVmecINDATA, CheckFreeBoundaryMethodToString) {
   EXPECT_EQ(ToString(FreeBoundaryMethod::NESTOR), "nestor");
   EXPECT_EQ(ToString(FreeBoundaryMethod::ONLY_COILS), "only_coils");
   EXPECT_EQ(ToString(FreeBoundaryMethod::BIEST), "biest");
+  EXPECT_EQ(ToString(FreeBoundaryMethod::ONLY_COILS_BDOTN), "only_coils_bdotn");
 }  // CheckFreeBoundaryMethodToString
 
 TEST(TestVmecINDATA, CheckDefaults) {

--- a/src/vmecpp/cpp/vmecpp/free_boundary/free_boundary_base/free_boundary_base.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/free_boundary_base/free_boundary_base.h
@@ -17,6 +17,19 @@
 
 namespace vmecpp {
 
+// Describes the physical meaning of the boundary force term stored in
+// bSqVacShare by the free-boundary solver.
+enum class BoundaryForceTermType : std::uint8_t {
+  // bSqVacShare contains |B_vac|^2 / 2 (vacuum magnetic pressure).
+  // The force term uses pressure continuity: p_inside = p_outside at the LCFS.
+  kPressureContinuity,
+
+  // bSqVacShare contains B_coils . n, the normal component of the external
+  // magnetic field at the LCFS.
+  // The force term drives B_coils . n -> 0 at the boundary.
+  kNormalField
+};
+
 class FreeBoundaryBase {
  public:
   virtual ~FreeBoundaryBase() = default;
@@ -25,7 +38,8 @@ class FreeBoundaryBase {
                    const MGridProvider* mgrid, std::span<double> bSqVacShare,
                    std::span<double> vacuum_b_r_share,
                    std::span<double> vacuum_b_phi_share,
-                   std::span<double> vacuum_b_z_share)
+                   std::span<double> vacuum_b_z_share,
+                   std::span<double> b_dot_n_share)
       : s_(*s),
         fb_(&s_),
         tp_(*tp),
@@ -34,7 +48,8 @@ class FreeBoundaryBase {
         bSqVacShare(bSqVacShare),
         vacuum_b_r_share_(vacuum_b_r_share),
         vacuum_b_phi_share_(vacuum_b_phi_share),
-        vacuum_b_z_share_(vacuum_b_z_share) {}
+        vacuum_b_z_share_(vacuum_b_z_share),
+        b_dot_n_share_(b_dot_n_share) {}
 
   virtual bool update(
       const std::span<const double> rCC, const std::span<const double> rSS,
@@ -46,6 +61,10 @@ class FreeBoundaryBase {
       double netToroidalCurrent, int m_ivacskip,
       const VmecCheckpoint& vmec_checkpoint = VmecCheckpoint::NONE,
       bool at_checkpoint_iteration = false) = 0;
+
+  virtual BoundaryForceTermType GetBoundaryForceTermType() const {
+    return BoundaryForceTermType::kPressureContinuity;
+  }
 
   const SurfaceGeometry& GetSurfaceGeometry() const { return sg_; }
   const ExternalMagneticField& GetExternalMagneticField() const { return ef_; }
@@ -71,6 +90,10 @@ class FreeBoundaryBase {
   // [nZnT] cylindrical B^Z of Nestor's vacuum magnetic field
   // Points to vacuum_b_z in HandoverStorage
   std::span<double> vacuum_b_z_share_;
+
+  // [nZnT] B_coils . n at the plasma boundary
+  // Points to vacuum_b_normal in HandoverStorage
+  std::span<double> b_dot_n_share_;
 };  // FreeBoundaryBase
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.cc
@@ -13,9 +13,10 @@ Nestor::Nestor(const Sizes* s, const TangentialPartitioning* tp,
                std::span<double> bvecShare, std::span<double> bSqVacShare,
                std::span<int> iPiv, std::span<double> vacuum_b_r_share,
                std::span<double> vacuum_b_phi_share,
-               std::span<double> vacuum_b_z_share)
+               std::span<double> vacuum_b_z_share,
+               std::span<double> b_dot_n_share)
     : FreeBoundaryBase(s, tp, mgrid, bSqVacShare, vacuum_b_r_share,
-                       vacuum_b_phi_share, vacuum_b_z_share),
+                       vacuum_b_phi_share, vacuum_b_z_share, b_dot_n_share),
       nf(s_.ntor),
       mf(s_.mpol + 1),
       si_(s, &fb_, tp, &sg_, nf, mf),
@@ -221,6 +222,9 @@ bool Nestor::update(
     vacuum_b_phi_share_[kl] = sg_.r1b[kl] * bSupV;
     vacuum_b_z_share_[kl] =
         sg_.zub[kl - tp_.ztMin] * bSupU + sg_.zvb[kl - tp_.ztMin] * bSupV;
+
+    // B_coils . n for delbn diagnostic
+    b_dot_n_share_[kl] = ef_.bDotN[kl - tp_.ztMin];
   }  // kl
 
   // ... done ...

--- a/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.h
@@ -28,7 +28,7 @@ class Nestor : public FreeBoundaryBase {
          std::span<double> bvecShare, std::span<double> bSqVacShare,
          std::span<int> iPiv, std::span<double> vacuum_b_r_share,
          std::span<double> vacuum_b_phi_share,
-         std::span<double> vacuum_b_z_share);
+         std::span<double> vacuum_b_z_share, std::span<double> b_dot_n_share);
 
   bool update(
       const std::span<const double> rCC, const std::span<const double> rSS,

--- a/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.cc
@@ -10,9 +10,12 @@ OnlyCoils::OnlyCoils(const Sizes* s, const TangentialPartitioning* tp,
                      const MGridProvider* mgrid, std::span<double> bSqVacShare,
                      std::span<double> vacuum_b_r_share,
                      std::span<double> vacuum_b_phi_share,
-                     std::span<double> vacuum_b_z_share)
+                     std::span<double> vacuum_b_z_share,
+                     std::span<double> b_dot_n_share,
+                     BoundaryForceTermType boundary_force_term_type)
     : FreeBoundaryBase(s, tp, mgrid, bSqVacShare, vacuum_b_r_share,
-                       vacuum_b_phi_share, vacuum_b_z_share) {}  // OnlyCoils
+                       vacuum_b_phi_share, vacuum_b_z_share, b_dot_n_share),
+      boundary_force_term_type_(boundary_force_term_type) {}  // OnlyCoils
 
 bool OnlyCoils::update(
     const std::span<const double> rCC, const std::span<const double> rSS,
@@ -65,14 +68,19 @@ bool OnlyCoils::update(
 #pragma omp barrier
 #endif  // _OPENMP
 
-  // compute magnetic pressure from only coils: |B|^2/2
   for (int kl = tp_.ztMin; kl < tp_.ztMax; ++kl) {
     // cylindrical components of vacuum magnetic field
     vacuum_b_r_share_[kl] = ef_.interpBr[kl - tp_.ztMin];
     vacuum_b_phi_share_[kl] = ef_.interpBp[kl - tp_.ztMin];
     vacuum_b_z_share_[kl] = ef_.interpBz[kl - tp_.ztMin];
 
+    // B_coils . n is always shared back for the delbn diagnostic
+    b_dot_n_share_[kl] = ef_.bDotN[kl - tp_.ztMin];
+
     // magnetic pressure from vacuum: |B|^2/2
+    // Both modes store the full magnetic pressure here.  In kNormalField
+    // mode the correction using vacuum_b_normal is applied downstream in
+    // IdealMhdModel.
     bSqVacShare[kl] = 0.5 * (vacuum_b_r_share_[kl] * vacuum_b_r_share_[kl] +
                              vacuum_b_phi_share_[kl] * vacuum_b_phi_share_[kl] +
                              vacuum_b_z_share_[kl] * vacuum_b_z_share_[kl]);

--- a/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.h
@@ -21,7 +21,9 @@ class OnlyCoils : public FreeBoundaryBase {
             const MGridProvider* mgrid, std::span<double> bSqVacShare,
             std::span<double> vacuum_b_r_share,
             std::span<double> vacuum_b_phi_share,
-            std::span<double> vacuum_b_z_share);
+            std::span<double> vacuum_b_z_share, std::span<double> b_dot_n_share,
+            BoundaryForceTermType boundary_force_term_type =
+                BoundaryForceTermType::kPressureContinuity);
 
   bool update(
       const std::span<const double> rCC, const std::span<const double> rSS,
@@ -33,6 +35,13 @@ class OnlyCoils : public FreeBoundaryBase {
       double netToroidalCurrent, int ivacskip,
       const VmecCheckpoint& vmec_checkpoint = VmecCheckpoint::NONE,
       bool at_checkpoint_iteration = false) final;
+
+  BoundaryForceTermType GetBoundaryForceTermType() const final {
+    return boundary_force_term_type_;
+  }
+
+ private:
+  BoundaryForceTermType boundary_force_term_type_;
 };
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
@@ -175,6 +175,9 @@ class HandoverStorage {
   // [nZnT] cylindrical B^Z of Nestor's vacuum magnetic field
   std::vector<double> vacuum_b_z;
 
+  // [nZnT] B_coils . n at the plasma boundary
+  std::vector<double> vacuum_b_normal;
+
  private:
   const Sizes& s_;
 

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstdio>
 #include <iostream>
 #include <numbers>
@@ -491,6 +492,9 @@ IdealMhdModel::IdealMhdModel(
   if (m_fc_.lfreeb) {
     CHECK(m_fb_ != nullptr)
         << "Free-boundary configuration requires a Free-boundary solver";
+    boundary_force_term_type_ = m_fb_->GetBoundaryForceTermType();
+  } else {
+    boundary_force_term_type_ = BoundaryForceTermType::kPressureContinuity;
   }
 
   // init members
@@ -568,6 +572,7 @@ IdealMhdModel::IdealMhdModel(
 
   insideTotalPressure.resize(s_.nZnT);
   delBSq.resize(s_.nZnT);
+  delBn.resize(s_.nZnT);
 
   armn_e.resize(nrzt);
   armn_o.resize(nrzt);
@@ -1020,14 +1025,26 @@ absl::StatusOr<bool> IdealMhdModel::update(
       }
 
       if (r_.nsMaxF1 == m_fc_.ns) {
-        // MUST NOT BREAK TRI-DIAGONAL RADIAL COUPLING: OFFENDS PRECONDITIONER!
-        // double edgePressure = 1.5 * p.presH[r.nsMaxH-1 - r.nsMinH] - 0.5 *
-        // p.presH[r.nsMinH - r.nsMinH];
+        // MUST NOT BREAK TRI-DIAGONAL RADIAL COUPLING: OFFENDS
+        // PRECONDITIONER!
         double edgePressure =
             m_p_.evalMassProfile((m_fc_.ns - 1.5) / (m_fc_.ns - 1.0));
         if (edgePressure != 0.0) {
           edgePressure = m_p_.evalMassProfile(1.0) / edgePressure *
                          m_p_.presH[r_.nsMaxH - 1 - r_.nsMinH];
+        }
+
+        // B.n homotopy weight: ramps from 0 (pure pressure continuity)
+        // to 1 (full B.n correction) as FSQ drops on a log scale.
+        // vacuum_magnetic_pressure always contains |B|^2/2; the correction
+        // subtracts w * (B.n)^2/2 so the effective outside pressure becomes
+        // |B_tangential|^2/2 at w=1, enforcing B.n = 0 at equilibrium.
+        double bdotn_weight = 0.0;
+        if (boundary_force_term_type_ == BoundaryForceTermType::kNormalField &&
+            m_fc_.res0 > 0.0 && m_fc_.fsq > 0.0 && m_fc_.res0 > m_fc_.ftolv) {
+          double log_total_range = std::log10(m_fc_.res0 / m_fc_.ftolv);
+          double log_progress = std::log10(m_fc_.res0 / m_fc_.fsq);
+          bdotn_weight = std::clamp(log_progress / log_total_range, 0.0, 1.0);
         }
 
         for (int kl = 0; kl < s_.nZnT; ++kl) {
@@ -1038,14 +1055,22 @@ absl::StatusOr<bool> IdealMhdModel::update(
               0.5 * totalPressure[(r_.nsMaxH - 2 - r_.nsMinH) * s_.nZnT + kl];
 
           // net pressure from outside on LCFS
-          // FIXME(eguiraud) slow loop over Nestor output
           // NOTE: here is the interface between the fast-toroidal setup in
-          // Nestor and fast-poloidal setup in VMEC
+          // the free-boundary solver and fast-poloidal setup in VMEC
           const int k = kl / s_.nThetaEff;
           const int l = kl % s_.nThetaEff;
           const int idx_lk = l * s_.nZeta + k;
+
           double outsideEdgePressure =
               m_h_.vacuum_magnetic_pressure[idx_lk] + edgePressure;
+
+          // In kNormalField mode, subtract weighted (B.n)^2/2 so the
+          // effective outside pressure is a blend between |B|^2/2 and
+          // |B_tangential|^2/2 = (|B|^2 - (B.n)^2)/2.
+          if (bdotn_weight > 0.0) {
+            double bn = m_h_.vacuum_b_normal[idx_lk];
+            outsideEdgePressure -= bdotn_weight * 0.5 * bn * bn;
+          }
 
           // term to enter MHD forces
           int idx_kl = (r_.nsMaxF1 - 1 - r_.nsMinF1) * s_.nZnT + kl;
@@ -1054,6 +1079,7 @@ absl::StatusOr<bool> IdealMhdModel::update(
 
           // for printout: global mismatch between inside and outside pressure
           delBSq[kl] = fabs(outsideEdgePressure - insideTotalPressure[kl]);
+          delBn[kl] = fabs(m_h_.vacuum_b_normal[idx_lk]);
         }
 
         if (m_vacuum_pressure_state_ == VacuumPressureState::kInitialized) {
@@ -3020,7 +3046,7 @@ void IdealMhdModel::assembleTotalForces() {
 #pragma omp barrier
 #endif  // _OPENMP
 
-  // free-boundary contribution: include force on boundary from NESTOR
+  // free-boundary contribution: include force on boundary from vacuum solver
   if (m_fc_.lfreeb &&
       (m_vacuum_pressure_state_ == VacuumPressureState::kInitialized ||
        m_vacuum_pressure_state_ == VacuumPressureState::kActive) &&
@@ -3582,6 +3608,21 @@ double IdealMhdModel::get_delbsq() const {
     delBSqAvg /= delBSqNorm;
   }
   return delBSqAvg;
+}
+
+double IdealMhdModel::get_delbn() const {
+  double delBnAvg = 0.0;
+  if (m_fc_.lfreeb &&
+      m_vacuum_pressure_state_ == VacuumPressureState::kActive) {
+    double delBnNorm = 0.0;
+    for (int kl = 0; kl < s_.nZnT; ++kl) {
+      int l = kl % s_.nThetaEff;
+      delBnAvg += delBn[kl] * s_.wInt[l];
+      delBnNorm += insideTotalPressure[kl] * s_.wInt[l];
+    }
+    delBnAvg /= delBnNorm;
+  }
+  return delBnAvg;
 }
 
 int IdealMhdModel::get_ivacskip() const { return ivacskip; }

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
@@ -218,6 +218,9 @@ class IdealMhdModel {
   // Computes the mismatch in |B|^2 at the LCFS.
   double get_delbsq() const;
 
+  // Computes the surface-averaged |B_coils . n| at the LCFS.
+  double get_delbn() const;
+
   // `ivacskip` is the current counter that controls whether a full update or a
   // partial update of the Nestor free boundary force contribution is computed.
   int get_ivacskip() const;
@@ -336,6 +339,9 @@ class IdealMhdModel {
   // mismatch in |B|^2 between plasma and vacuum regions at LCFS
   std::vector<double> delBSq;
 
+  // |B_coils . n| at each point on the LCFS
+  std::vector<double> delBn;
+
   /**********************************************/
 
   // real-space forces
@@ -426,6 +432,7 @@ class IdealMhdModel {
   const RadialPartitioning& r_;
   FreeBoundaryBase* m_fb_;
   VacuumPressureState& m_vacuum_pressure_state_;
+  BoundaryForceTermType boundary_force_term_type_;
 
   int signOfJacobian;
 

--- a/src/vmecpp/cpp/vmecpp/vmec/iteration_logger/iteration_logger.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/iteration_logger/iteration_logger.cc
@@ -72,12 +72,13 @@ void IterationLogger::LogIteration(int iter, double fsqr, double fsqz,
                                    double fsql, double fsqr1, double fsqz1,
                                    double fsql1, double delt, double rax,
                                    double w_mhd, double beta_vol_avg,
-                                   double vol_avg_m, double delbsq) {
+                                   double vol_avg_m, double delbsq,
+                                   double delbn) {
   if (mode_ == OutputMode::kSilent) return;
 
   if (mode_ == OutputMode::kLegacy) {
     PrintLegacyRow(iter, fsqr, fsqz, fsql, fsqr1, fsqz1, fsql1, delt, rax,
-                   w_mhd, beta_vol_avg, vol_avg_m, delbsq);
+                   w_mhd, beta_vol_avg, vol_avg_m, delbsq, delbn);
     return;
   }
 
@@ -101,6 +102,7 @@ void IterationLogger::LogIteration(int iter, double fsqr, double fsqz,
   stage.last_w_mhd = w_mhd;
   stage.last_rax = rax;
   stage.last_delbsq = delbsq;
+  stage.last_delbn = delbn;
 
   if (mode_ == OutputMode::kProgress) {
     RenderProgressDisplay();
@@ -251,7 +253,8 @@ void IterationLogger::RenderProgressDisplay() {
         "RAX=%.4f",
         s.last_iter, s.last_fsq, s.last_beta, s.last_w_mhd, s.last_rax);
     if (is_free_boundary_) {
-      output_ << absl::StrFormat("  DELBSQ=%.3e", s.last_delbsq);
+      output_ << absl::StrFormat("  DELBSQ=%.3e  DELBN=%.3e", s.last_delbsq,
+                                 s.last_delbn);
     }
     output_ << kReset << "\n";
     lines++;
@@ -289,7 +292,8 @@ void IterationLogger::RenderSingleLineProgress() {
   output_ << absl::StrFormat(" %5.1f%%  FSQ=%.2e", progress_frac * 100.0,
                              s.last_fsq);
   if (is_free_boundary_) {
-    output_ << absl::StrFormat("  delbsq=%.2e", s.last_delbsq);
+    output_ << absl::StrFormat("  delbsq=%.2e  delbn=%.2e", s.last_delbsq,
+                               s.last_delbn);
   }
 
   // Pad with spaces to clear any leftover characters from a longer line.
@@ -402,10 +406,10 @@ void IterationLogger::PrintLegacyHeader() const {
   if (is_free_boundary_) {
     output_ << " ITER |    FSQR     FSQZ     FSQL    |    fsqr     fsqz      "
                "fsql   |   DELT   |  RAX(v=0) |    W_MHD   |   <BETA>   |  "
-               "<M>  |  DELBSQ  \n";
+               "<M>  |  DELBSQ  |  DELBN   \n";
     output_ << "------+------------------------------+-----------------------"
                "-------+----------+-----------+------------+------------+----"
-               "---+----------\n";
+               "---+----------+----------\n";
   } else {
     output_ << " ITER |    FSQR     FSQZ     FSQL    |    fsqr     fsqz    "
                "  fsql  "
@@ -420,13 +424,14 @@ void IterationLogger::PrintLegacyRow(int iter, double fsqr, double fsqz,
                                      double fsql, double fsqr1, double fsqz1,
                                      double fsql1, double delt, double rax,
                                      double w_mhd, double beta_vol_avg,
-                                     double vol_avg_m, double delbsq) const {
+                                     double vol_avg_m, double delbsq,
+                                     double delbn) const {
   if (is_free_boundary_) {
     output_ << absl::StrFormat(
         "%5d | %.2e  %.2e  %.2e | %.2e  %.2e  %.2e | %.2e | "
-        "%.3e | %.4e | %.4e | %5.3f | %.3e\n",
+        "%.3e | %.4e | %.4e | %5.3f | %.3e | %.3e\n",
         iter, fsqr, fsqz, fsql, fsqr1, fsqz1, fsql1, delt, rax, w_mhd,
-        beta_vol_avg, vol_avg_m, delbsq);
+        beta_vol_avg, vol_avg_m, delbsq, delbn);
   } else {
     output_ << absl::StrFormat(
         "%5d | %.2e  %.2e  %.2e | %.2e  %.2e  %.2e | %.2e | "

--- a/src/vmecpp/cpp/vmecpp/vmec/iteration_logger/iteration_logger.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/iteration_logger/iteration_logger.h
@@ -66,7 +66,7 @@ class IterationLogger {
   void LogIteration(int iter, double fsqr, double fsqz, double fsql,
                     double fsqr1, double fsqz1, double fsql1, double delt,
                     double rax, double w_mhd, double beta_vol_avg,
-                    double vol_avg_m, double delbsq);
+                    double vol_avg_m, double delbsq, double delbn);
 
   // Called after SolveEquilibrium completes for a stage.
   void EndStage(double mhd_energy);
@@ -87,6 +87,7 @@ class IterationLogger {
     double last_w_mhd = 0.0;
     double last_rax = 0.0;
     double last_delbsq = 0.0;
+    double last_delbn = 0.0;
     bool initial_fsq_set = false;
     bool completed = false;
   };
@@ -117,7 +118,7 @@ class IterationLogger {
   void PrintLegacyRow(int iter, double fsqr, double fsqz, double fsql,
                       double fsqr1, double fsqz1, double fsql1, double delt,
                       double rax, double w_mhd, double beta_vol_avg,
-                      double vol_avg_m, double delbsq) const;
+                      double vol_avg_m, double delbsq, double delbn) const;
 
   std::ostream& output_;
   OutputMode mode_;

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -200,6 +200,7 @@ PYBIND11_MODULE(_vmecpp, m) {
       .value("NESTOR", vmecpp::FreeBoundaryMethod::NESTOR)
       .value("ONLY_COILS", vmecpp::FreeBoundaryMethod::ONLY_COILS)
       .value("BIEST", vmecpp::FreeBoundaryMethod::BIEST)
+      .value("ONLY_COILS_BDOTN", vmecpp::FreeBoundaryMethod::ONLY_COILS_BDOTN)
       .export_values()
       .finalize();
 

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -220,15 +220,19 @@ Vmec::Vmec(const VmecINDATA& indata, std::optional<int> max_threads,
     h_.vacuum_b_r.resize(s_.nZnT);
     h_.vacuum_b_phi.resize(s_.nZnT);
     h_.vacuum_b_z.resize(s_.nZnT);
+    h_.vacuum_b_normal.resize(s_.nZnT, 0.0);
 
     // TODO(jons): move this check to better-suited place
-    if (indata_.free_boundary_method == FreeBoundaryMethod::ONLY_COILS &&
+    if ((indata_.free_boundary_method == FreeBoundaryMethod::ONLY_COILS ||
+         indata_.free_boundary_method ==
+             FreeBoundaryMethod::ONLY_COILS_BDOTN) &&
         (indata_.curtor != 0.0 || indata_.pres_scale != 0.0)) {
       throw std::invalid_argument(
-          absl::StrCat("curtor and pres_scale must be zero when using "
-                       "'only_coils' free boundary method, but were ",
-                       indata_.curtor, " and ", indata_.pres_scale));
-    }  // check that cutor==0 and pres_scale==0 for only_coils
+          absl::StrCat("curtor and pres_scale must be zero when using '",
+                       ToString(indata_.free_boundary_method),
+                       "' free boundary method, but were ", indata_.curtor,
+                       " and ", indata_.pres_scale));
+    }  // check that cutor==0 and pres_scale==0 for only_coils variants
   }
 }
 
@@ -528,12 +532,19 @@ bool Vmec::InitializeRadial(
           fb_[thread_id] = std::make_unique<Nestor>(
               &s_, tp_[thread_id].get(), &mgrid_, matrixShare, bvecShare,
               h_.vacuum_magnetic_pressure, iPiv, h_.vacuum_b_r, h_.vacuum_b_phi,
-              h_.vacuum_b_z);
+              h_.vacuum_b_z, h_.vacuum_b_normal);
         } else if (indata_.free_boundary_method ==
                    FreeBoundaryMethod::ONLY_COILS) {
           fb_[thread_id] = std::make_unique<OnlyCoils>(
               &s_, tp_[thread_id].get(), &mgrid_, h_.vacuum_magnetic_pressure,
-              h_.vacuum_b_r, h_.vacuum_b_phi, h_.vacuum_b_z);
+              h_.vacuum_b_r, h_.vacuum_b_phi, h_.vacuum_b_z,
+              h_.vacuum_b_normal);
+        } else if (indata_.free_boundary_method ==
+                   FreeBoundaryMethod::ONLY_COILS_BDOTN) {
+          fb_[thread_id] = std::make_unique<OnlyCoils>(
+              &s_, tp_[thread_id].get(), &mgrid_, h_.vacuum_magnetic_pressure,
+              h_.vacuum_b_r, h_.vacuum_b_phi, h_.vacuum_b_z, h_.vacuum_b_normal,
+              BoundaryForceTermType::kNormalField);
         } else {
           LOG(FATAL) << absl::StrCat("free boundary method '",
                                      ToString(indata_.free_boundary_method),
@@ -1226,10 +1237,12 @@ absl::StatusOr<bool> Vmec::Evolve(VmecCheckpoint checkpoint,
     fc_.force_residual_z.push_back(fc_.fsqz);
     fc_.force_residual_lambda.push_back(fc_.fsql);
     if (fc_.lfreeb) {
-      // delbsq is only available on the LCFS thread
+      // delbsq and delbn are only available on the LCFS thread
       fc_.delbsq.push_back(m_[thread_id]->get_delbsq());
+      fc_.delbn.push_back(m_[thread_id]->get_delbn());
     } else {
       fc_.delbsq.push_back(0.0);
+      fc_.delbn.push_back(0.0);
     }
     fc_.restart_reasons.push_back(fc_.restart_reason);
     fc_.mhd_energy.push_back(h_.mhdEnergy);
@@ -1281,10 +1294,12 @@ void Vmec::Printout(double delt0r, int thread_id, int iter2) {
 
     // mismatch in |B|^2 at LCFS for free-boundary
     double delbsq = m_[thread_id]->get_delbsq();
+    // |B_coils . n| at LCFS
+    double delbn = m_[thread_id]->get_delbn();
 
     logger_.LogIteration(iter2, fc_.fsqr, fc_.fsqz, fc_.fsql, fc_.fsqr1,
                          fc_.fsqz1, fc_.fsql1, delt0r, r00, energy, betaVolAvg,
-                         volAvgM, delbsq);
+                         volAvgM, delbsq, delbn);
   }  // thread which has boundary
 }
 


### PR DESCRIPTION
### TL;DR

Added a new free boundary method `ONLY_COILS_BDOTN` that uses B_coils·n = 0 boundary condition instead of pressure continuity for vacuum calculations.