### PR TITLE
Add a Python 3.13 Nix development shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ export HDF5_ROOT=$(brew --prefix hdf5)
 python3.10 -m pip install git+https://github.com/proximafusion/vmecpp
 ```
 
-### With Nix
+### With Nix (Community support)
 
 For a Linux development shell with the latest supported Python version:
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ See [below](#differences-with-respect-to-parvmecvmec2000) for more details.
   - [Arch](#arch-linux)
   - [Fedora](#fedora)
   - [MacOS](#macos)
+  - [With Nix](#with-nix)
   - [As part of a conda environment](#as-part-of-a-conda-environment)
   - [C++ build from source](#c-build-from-source)
 - [Hot restart](#hot-restart)
@@ -218,6 +219,20 @@ export OpenMP_ROOT=$(brew --prefix)/opt/libomp
 export HDF5_ROOT=$(brew --prefix hdf5)
 python3.10 -m pip install git+https://github.com/proximafusion/vmecpp
 ```
+
+### With Nix
+
+For a Linux development shell with the latest supported Python version:
+
+```shell
+nix develop
+python --version
+python -m pip install -e .[test]
+```
+
+The shell provides Python 3.13 together with the native build dependencies needed
+to build and test VMEC++, including CMake, GCC, GFortran, HDF5, NetCDF, LAPACK,
+OpenMPI, and Git LFS.
 
 ### As part of a conda environment
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,95 @@
+{
+  description = "Nix development shell for vmecpp";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  };
+
+  outputs = { nixpkgs, ... }:
+    let
+      lib = nixpkgs.lib;
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = lib.genAttrs supportedSystems;
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          python = pkgs.python313;
+          hdf5 = pkgs.hdf5-fortran;
+          hdf5Merged = pkgs.symlinkJoin {
+            name = "hdf5-merged";
+            paths = [
+              hdf5
+              hdf5.dev
+              hdf5.bin
+            ];
+            postBuild = ''
+              rm "$out/lib/cmake/hdf5-config.cmake"
+              sed \
+                -e 's|"''${CMAKE_CURRENT_LIST_DIR}/\.\./\.\./\.\./[^"]*"|"'"$out"'"|' \
+                -e 's|''${PACKAGE_PREFIX_DIR}//nix/store/[a-z0-9]*-hdf5-cpp-fortran-[^/]*/|''${PACKAGE_PREFIX_DIR}/|g' \
+                -e 's|"//nix/store/[a-z0-9]*-hdf5-cpp-fortran-[^/]*/|"'"$out"'/|g' \
+                "${hdf5.dev}/lib/cmake/hdf5-config.cmake" \
+                > "$out/lib/cmake/hdf5-config.cmake"
+
+              for f in "$out"/lib/cmake/hdf5-targets*.cmake; do
+                rm "$f"
+                sed \
+                  -e 's|${hdf5}|'"$out"'|g' \
+                  -e 's|${hdf5.dev}|'"$out"'|g' \
+                  "${hdf5.dev}/lib/cmake/$(basename "$f")" \
+                  > "$f"
+              done
+            '';
+          };
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              python
+              cmake
+              ninja
+              gcc
+              gfortran
+              pkg-config
+              hdf5Merged
+              netcdf
+              netcdffortran
+              blis
+              lapack-reference
+              nodejs
+              openmpi
+              git
+              git-lfs
+            ];
+
+            shellHook = ''
+              export CC=${pkgs.gcc}/bin/gcc
+              export CXX=${pkgs.gcc}/bin/g++
+              export FC=${pkgs.gfortran}/bin/gfortran
+              export CMAKE_GENERATOR=Ninja
+              export HDF5_DIR=${hdf5Merged}/lib/cmake
+              export CMAKE_ARGS="-DHDF5_DIR=${hdf5Merged}/lib/cmake -DCMAKE_DISABLE_FIND_PACKAGE_netCDF=TRUE -DBLAS_LIBRARIES=${pkgs.blis}/lib/libblas.so -DLAPACK_LIBRARIES=${pkgs.lapack-reference}/lib/liblapack.so"
+              export LD_LIBRARY_PATH=${lib.makeLibraryPath [
+                pkgs.stdenv.cc.cc
+                pkgs.blis
+                pkgs.lapack-reference
+              ]}:''${LD_LIBRARY_PATH:-}
+              vmecpp_pip_constraints="''${TMPDIR:-/tmp}/vmecpp-pip-constraints.txt"
+              cat > "$vmecpp_pip_constraints" <<EOF
+pydantic<2.13
+EOF
+              export PIP_CONSTRAINT="$vmecpp_pip_constraints"
+              export PIP_BUILD_CONSTRAINT="$vmecpp_pip_constraints"
+              export SKIP="pyright"
+            '';
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
## Summary

This adds a small Nix flake for a Linux development shell on the latest supported Python version.

The shell is set up to match the supported local workflow rather than the experimental Python 3.14 line:
- Python 3.13
- GCC, GFortran, CMake, Ninja, HDF5, NetCDF, MPI, Git LFS
- BLIS for BLAS and netlib LAPACK
- a patched merged HDF5 package so CMake stays on Nix-managed libraries
- `pydantic<2.13` in the shell to avoid current upstream serialization breakage during local install and tests
- `SKIP=pyright` in the shell to mirror the current upstream pre-commit CI job

This is the first small split from the broader tokamak-support work tracked in itpplasma/vmecpp#4.

## Verification

### Test fails on main
```console
$ tmpdir=$(mktemp -d /tmp/vmecpp-main-XXXXXX)
$ git -C /tmp/vmecpp-ci-flake archive upstream/main | tar -x -C "$tmpdir"
$ cd "$tmpdir"
$ nix develop
path "/tmp/vmecpp-main-sEgqSX" does not contain a 'flake.nix', searching up
error: could not find a flake.nix file
```

### Test passes after fix
```console
$ cd /tmp/vmecpp-ci-flake
$ nix develop --command bash -lc 'python -m venv /tmp/vmecpp-ci-flake-venv && source /tmp/vmecpp-ci-flake-venv/bin/activate && python -m pip install --upgrade pip && python -m pip install pre-commit && python -m pip install -e .[test] && python -m pytest tests/test_init.py tests/cpp/vmecpp/vmec/pybind11/test_pybind_vmec.py -q && pre-commit run --all-files'
...
37 passed in 25.78s
...
clang-format.............................................................Passed
pyright.................................................................Skipped
```
