### PR TITLE
Restrict pydantic version, breaking change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "netCDF4",
   "numpy",
   "pydantic>=2.11", # Introduced support for by_alias validation
+  "pydantic<2.13", # Breaking change currently under investigation
   "jaxtyping>=0.2.6",
   "jax!=0.5.2", # To prevent a circular import bug in jax on arch Linux
   "jax!=0.5.1", # To prevent a circular import bug in jax on arch Linux


### PR DESCRIPTION
pydantic 2.13 is causing validation failiures, restrict it until we understand the issue