### PR TITLE
Abseil errors instead of LOG(FATAL)

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/magnetic_configuration_lib/magnetic_configuration_lib.cc
+++ b/src/vmecpp/cpp/vmecpp/common/magnetic_configuration_lib/magnetic_configuration_lib.cc
@@ -366,7 +366,7 @@ absl::Status MoveRadially(double radial_step,
             error_message << "current carrier type ";
             error_message << m_current_carrier->type_case();
             error_message << " not implemented yet.";
-            LOG(FATAL) << error_message.str();
+            return absl::InvalidArgumentError(error_message.str());
         }
       }  // CurrentCarrier
     }  // Coil

--- a/src/vmecpp/cpp/vmecpp/common/magnetic_field_provider/magnetic_field_provider_lib.cc
+++ b/src/vmecpp/cpp/vmecpp/common/magnetic_field_provider/magnetic_field_provider_lib.cc
@@ -24,9 +24,9 @@ using composed_types::Normalize;
 using composed_types::Vector3d;
 
 absl::Status MagneticField(
-    const InfiniteStraightFilament &infinite_straight_filament, double current,
-    const std::vector<std::vector<double>> &evaluation_positions,
-    std::vector<std::vector<double>> &m_magnetic_field,
+    const InfiniteStraightFilament& infinite_straight_filament, double current,
+    const std::vector<std::vector<double>>& evaluation_positions,
+    std::vector<std::vector<double>>& m_magnetic_field,
     bool check_current_carrier) {
   if (check_current_carrier) {
     absl::Status status =
@@ -44,7 +44,7 @@ absl::Status MagneticField(
   }
   const double magnetic_field_scale = abscab::MU_0 * current / (2.0 * M_PI);
 
-  const Vector3d &direction = infinite_straight_filament.direction();
+  const Vector3d& direction = infinite_straight_filament.direction();
   const double direction_x = direction.x();
   const double direction_y = direction.y();
   const double direction_z = direction.z();
@@ -59,7 +59,7 @@ absl::Status MagneticField(
   const double normalized_direction_y = direction_y / direction_length;
   const double normalized_direction_z = direction_z / direction_length;
 
-  const Vector3d &origin = infinite_straight_filament.origin();
+  const Vector3d& origin = infinite_straight_filament.origin();
   const double origin_x = origin.x();
   const double origin_y = origin.y();
   const double origin_z = origin.z();
@@ -148,9 +148,9 @@ absl::Status MagneticField(
 }  // MagneticField for InfiniteStraightFilament
 
 absl::Status MagneticField(
-    const CircularFilament &circular_filament, double current,
-    const std::vector<std::vector<double>> &evaluation_positions,
-    std::vector<std::vector<double>> &m_magnetic_field,
+    const CircularFilament& circular_filament, double current,
+    const std::vector<std::vector<double>>& evaluation_positions,
+    std::vector<std::vector<double>>& m_magnetic_field,
     bool check_current_carrier) {
   if (check_current_carrier) {
     absl::Status status = IsCircularFilamentFullyPopulated(circular_filament);
@@ -161,14 +161,14 @@ absl::Status MagneticField(
     }
   }
 
-  const Vector3d &center_vector = circular_filament.center();
+  const Vector3d& center_vector = circular_filament.center();
   std::vector<double> center = {
       center_vector.x(),
       center_vector.y(),
       center_vector.z(),
   };
 
-  const Vector3d &normal_vector = circular_filament.normal();
+  const Vector3d& normal_vector = circular_filament.normal();
   std::vector<double> normal = {
       normal_vector.x(),
       normal_vector.y(),
@@ -210,9 +210,9 @@ absl::Status MagneticField(
 }  // MagneticField for CircularFilament
 
 absl::Status MagneticField(
-    const PolygonFilament &polygon_filament, double current,
-    const std::vector<std::vector<double>> &evaluation_positions,
-    std::vector<std::vector<double>> &m_magnetic_field,
+    const PolygonFilament& polygon_filament, double current,
+    const std::vector<std::vector<double>>& evaluation_positions,
+    std::vector<std::vector<double>>& m_magnetic_field,
     bool check_current_carrier) {
   if (check_current_carrier) {
     absl::Status status = IsPolygonFilamentFullyPopulated(polygon_filament);
@@ -244,7 +244,7 @@ absl::Status MagneticField(
 
   // copy filament geometry into one-dimensional array for ABSCAB
   for (int i = 0; i < polygon_filament.vertices_size(); ++i) {
-    const Vector3d &vertex = polygon_filament.vertices(i);
+    const Vector3d& vertex = polygon_filament.vertices(i);
     vertices_1d[i * 3 + 0] = vertex.x();
     vertices_1d[i * 3 + 1] = vertex.y();
     vertices_1d[i * 3 + 2] = vertex.z();
@@ -266,9 +266,9 @@ absl::Status MagneticField(
 }  // MagneticField for PolygonFilament
 
 absl::Status MagneticField(
-    const MagneticConfiguration &magnetic_configuration,
-    const std::vector<std::vector<double>> &evaluation_positions,
-    std::vector<std::vector<double>> &m_magnetic_field,
+    const MagneticConfiguration& magnetic_configuration,
+    const std::vector<std::vector<double>>& evaluation_positions,
+    std::vector<std::vector<double>>& m_magnetic_field,
     bool check_current_carrier) {
   if (check_current_carrier) {
     absl::Status status =
@@ -280,14 +280,14 @@ absl::Status MagneticField(
     }
   }
 
-  for (const SerialCircuit &serial_circuit :
+  for (const SerialCircuit& serial_circuit :
        magnetic_configuration.serial_circuits()) {
     if (!serial_circuit.has_current() || serial_circuit.current() == 0.0) {
       // skip contributions with assumed zero current
       continue;
     }
 
-    for (const Coil &coil : serial_circuit.coils()) {
+    for (const Coil& coil : serial_circuit.coils()) {
       // NOTE: Re-compute the circuit current "from scratch" in every iteration.
       // Otherwise, the number of winding of the different coils
       // all get multiplied on top of each other for each successive coil!
@@ -299,7 +299,7 @@ absl::Status MagneticField(
         current = serial_circuit.current();
       }
 
-      for (const CurrentCarrier &current_carrier : coil.current_carriers()) {
+      for (const CurrentCarrier& current_carrier : coil.current_carriers()) {
         switch (current_carrier.type_case()) {
           case CurrentCarrier::TypeCase::kInfiniteStraightFilament:
             CHECK_OK(MagneticField(current_carrier.infinite_straight_filament(),
@@ -324,7 +324,7 @@ absl::Status MagneticField(
             error_message << "current carrier type ";
             error_message << current_carrier.type_case();
             error_message << " not implemented yet.";
-            LOG(FATAL) << error_message.str();
+            return absl::InvalidArgumentError(error_message.str());
         }
       }  // CurrentCarrier
     }  // Coil
@@ -339,9 +339,9 @@ absl::Status MagneticField(
 // so there is no method to compute a contribution from it here.
 
 absl::Status VectorPotential(
-    const CircularFilament &circular_filament, double current,
-    const std::vector<std::vector<double>> &evaluation_positions,
-    std::vector<std::vector<double>> &m_vector_potential,
+    const CircularFilament& circular_filament, double current,
+    const std::vector<std::vector<double>>& evaluation_positions,
+    std::vector<std::vector<double>>& m_vector_potential,
     bool check_current_carrier) {
   if (check_current_carrier) {
     absl::Status status = IsCircularFilamentFullyPopulated(circular_filament);
@@ -352,14 +352,14 @@ absl::Status VectorPotential(
     }
   }
 
-  const Vector3d &center_vector = circular_filament.center();
+  const Vector3d& center_vector = circular_filament.center();
   std::vector<double> center = {
       center_vector.x(),
       center_vector.y(),
       center_vector.z(),
   };
 
-  const Vector3d &normal_vector = circular_filament.normal();
+  const Vector3d& normal_vector = circular_filament.normal();
   std::vector<double> normal = {
       normal_vector.x(),
       normal_vector.y(),
@@ -403,9 +403,9 @@ absl::Status VectorPotential(
 }  // VectorPotential for CircularFilament
 
 absl::Status VectorPotential(
-    const PolygonFilament &polygon_filament, double current,
-    const std::vector<std::vector<double>> &evaluation_positions,
-    std::vector<std::vector<double>> &m_vector_potential,
+    const PolygonFilament& polygon_filament, double current,
+    const std::vector<std::vector<double>>& evaluation_positions,
+    std::vector<std::vector<double>>& m_vector_potential,
     bool check_current_carrier) {
   if (check_current_carrier) {
     absl::Status status = IsPolygonFilamentFullyPopulated(polygon_filament);
@@ -437,7 +437,7 @@ absl::Status VectorPotential(
 
   // copy filament geometry into one-dimensional array for ABSCAB
   for (int i = 0; i < polygon_filament.vertices_size(); ++i) {
-    const Vector3d &vertex = polygon_filament.vertices(i);
+    const Vector3d& vertex = polygon_filament.vertices(i);
     vertices_1d[i * 3 + 0] = vertex.x();
     vertices_1d[i * 3 + 1] = vertex.y();
     vertices_1d[i * 3 + 2] = vertex.z();
@@ -459,9 +459,9 @@ absl::Status VectorPotential(
 }  // VectorPotential for PolygonFilament
 
 absl::Status VectorPotential(
-    const MagneticConfiguration &magnetic_configuration,
-    const std::vector<std::vector<double>> &evaluation_positions,
-    std::vector<std::vector<double>> &m_vector_potential,
+    const MagneticConfiguration& magnetic_configuration,
+    const std::vector<std::vector<double>>& evaluation_positions,
+    std::vector<std::vector<double>>& m_vector_potential,
     bool check_current_carrier) {
   if (check_current_carrier) {
     absl::Status status =
@@ -475,10 +475,10 @@ absl::Status VectorPotential(
     // Check that no InfiniteStraightFilament is present in the
     // MagneticConfiguration, as the magnetic vector potential diverges for this
     // type of current carrier.
-    for (const SerialCircuit &serial_circuit :
+    for (const SerialCircuit& serial_circuit :
          magnetic_configuration.serial_circuits()) {
-      for (const Coil &coil : serial_circuit.coils()) {
-        for (const CurrentCarrier &current_carrier : coil.current_carriers()) {
+      for (const Coil& coil : serial_circuit.coils()) {
+        for (const CurrentCarrier& current_carrier : coil.current_carriers()) {
           if (current_carrier.has_infinite_straight_filament()) {
             return absl::InvalidArgumentError(
                 "Cannot compute the magnetic vector potential of an infinite "
@@ -489,14 +489,14 @@ absl::Status VectorPotential(
     }
   }
 
-  for (const SerialCircuit &serial_circuit :
+  for (const SerialCircuit& serial_circuit :
        magnetic_configuration.serial_circuits()) {
     if (!serial_circuit.has_current() || serial_circuit.current() == 0.0) {
       // skip contributions with assumed zero current
       continue;
     }
 
-    for (const Coil &coil : serial_circuit.coils()) {
+    for (const Coil& coil : serial_circuit.coils()) {
       // NOTE: Re-compute the circuit current "from scratch" in every iteration.
       // Otherwise, the number of winding of the different coils
       // all get multiplied on top of each other for each successive coil!
@@ -508,7 +508,7 @@ absl::Status VectorPotential(
         current = serial_circuit.current();
       }
 
-      for (const CurrentCarrier &current_carrier : coil.current_carriers()) {
+      for (const CurrentCarrier& current_carrier : coil.current_carriers()) {
         switch (current_carrier.type_case()) {
           case CurrentCarrier::TypeCase::kInfiniteStraightFilament:
             // The magnetic vector potential diverges for an infinite straight
@@ -536,7 +536,7 @@ absl::Status VectorPotential(
             error_message << "current carrier type ";
             error_message << current_carrier.type_case();
             error_message << " not implemented yet.";
-            LOG(FATAL) << error_message.str();
+            return absl::InvalidArgumentError(error_message.str());
         }
       }  // CurrentCarrier
     }  // Coil
@@ -546,8 +546,8 @@ absl::Status VectorPotential(
 }  // VectorPotential for MagneticConfiguration
 
 absl::StatusOr<double> LinkingCurrent(
-    const MagneticConfiguration &magnetic_configuration,
-    const CurveRZFourier &axis_coefficients) {
+    const MagneticConfiguration& magnetic_configuration,
+    const CurveRZFourier& axis_coefficients) {
   static constexpr double kMu0 = 4.0e-7 * M_PI;
 
   // check that axis geometry is fully populated
@@ -592,9 +592,9 @@ absl::StatusOr<double> LinkingCurrent(
     double axis_tangent_z = 0.0;
     for (int coefficient_index = 0; coefficient_index < num_coefficients;
          ++coefficient_index) {
-      const FourierCoefficient1D &coeff_r =
+      const FourierCoefficient1D& coeff_r =
           axis_coefficients.r(coefficient_index);
-      const FourierCoefficient1D &coeff_z =
+      const FourierCoefficient1D& coeff_z =
           axis_coefficients.z(coefficient_index);
 
       // mode numbers have been checked to be the same for R and Z in


### PR DESCRIPTION
`LOG(FATAL) <<`  -> `return absl::InvalidArgumentError(` in a few places.
clang-tidy is enabled in pre-commit, so whitespace formatting changed.