### PR TITLE
Long double vmecpp to diagnose the amount of truncation errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-set(CMAKE_CXX_FLAGS "-fPIC -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "-fPIC -Wall -Wextra -fext-numeric-literals")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -fno-math-errno")
 
@@ -114,6 +114,7 @@ target_link_libraries(vmecpp_core PRIVATE ${netCDF_LIBRARIES})
 target_link_libraries(vmecpp_core PRIVATE nlohmann_json::nlohmann_json)
 target_link_libraries(vmecpp_core PRIVATE LAPACK::LAPACK)
 target_link_libraries(vmecpp_core PRIVATE absl::algorithm absl::base absl::synchronization absl::strings absl::str_format absl::log absl::string_view absl::check absl::status absl::statusor)
+target_link_libraries(vmecpp_core PRIVATE quadmath)
 
 if(OpenMP_CXX_FOUND)
   target_link_libraries(vmecpp_core PRIVATE OpenMP::OpenMP_CXX)

--- a/examples/compare_precision_convergence.py
+++ b/examples/compare_precision_convergence.py
@@ -1,0 +1,124 @@
+"""Compare force-balance convergence between double and long-double builds.
+
+Workflow:
+  1. On the `main` (double) branch:    python examples/compare_precision_convergence.py --save-as double
+  2. On this `long double` branch:     python examples/compare_precision_convergence.py --save-as long_double
+  3. Either of the above runs, with no --save-as, will plot whichever traces
+     have been saved so far (so step 3 is implicit if you run with --save-as
+     on the second branch).
+
+Each run drops a JSON next to this script with the four force-residual traces
+(R, Z, lambda, total). When more than one trace file is present, an overlay
+plot is shown.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import plotly.graph_objects as go
+
+import vmecpp
+
+INPUT_FILE = Path("examples/data/w7x.json")
+TRACE_DIR = Path(__file__).parent / "convergence_traces"
+
+
+def run_and_extract() -> dict:
+    indata = vmecpp.VmecInput.from_file(INPUT_FILE)
+    output = vmecpp.run(indata)
+    wout = output.wout
+    return {
+        "force_residual_r": np.asarray(wout.force_residual_r).flatten().tolist(),
+        "force_residual_z": np.asarray(wout.force_residual_z).flatten().tolist(),
+        "force_residual_lambda": (
+            np.asarray(wout.force_residual_lambda).flatten().tolist()
+        ),
+        "fsqt": np.asarray(wout.fsqt).flatten().tolist(),
+        "ftolv": float(wout.ftolv),
+    }
+
+
+def save_trace(label: str, trace: dict) -> Path:
+    TRACE_DIR.mkdir(exist_ok=True)
+    path = TRACE_DIR / f"{label}.json"
+    path.write_text(json.dumps(trace))
+    return path
+
+
+def plot_overlay() -> None:
+    if not TRACE_DIR.exists():
+        print("No traces saved yet.")
+        return
+    traces = sorted(TRACE_DIR.glob("*.json"))
+    if not traces:
+        print("No trace files in", TRACE_DIR)
+        return
+
+    components = [
+        ("force_residual_r", "FSQR"),
+        ("force_residual_z", "FSQZ"),
+        ("force_residual_lambda", "FSQL"),
+        ("fsqt", "FSQ_total"),
+    ]
+    fig = go.Figure()
+    for path in traces:
+        label = path.stem
+        data = json.loads(path.read_text())
+        for key, short in components:
+            fig.add_trace(
+                go.Scatter(
+                    y=data[key],
+                    mode="lines",
+                    name=f"{short} [{label}]",
+                    legendgroup=label,
+                )
+            )
+    # Use the smallest tolerance found across the saved runs as the reference
+    tols = [json.loads(p.read_text())["ftolv"] for p in traces]
+    fig.add_hline(
+        y=min(tols),
+        line={"color": "red", "dash": "dash"},
+        annotation_text="ftolv",
+        annotation_position="bottom right",
+    )
+    fig.update_yaxes(type="log", title="Force residual")
+    fig.update_xaxes(title="Iteration")
+    fig.update_layout(title="Force-residual convergence: double vs long double")
+    fig.show()
+    # out_html = TRACE_DIR / "convergence_overlay.html"
+    # fig.write_html(str(out_html))
+    # print(f"Overlay written to {out_html}")
+    print("Final residuals per run:")
+    for path in traces:
+        d = json.loads(path.read_text())
+        print(
+            f"  {path.stem:>15s}  "
+            f"FSQR={d['force_residual_r'][-1]:.3e}  "
+            f"FSQZ={d['force_residual_z'][-1]:.3e}  "
+            f"FSQL={d['force_residual_lambda'][-1]:.3e}  "
+            f"FSQt={d['fsqt'][-1]:.3e}  "
+            f"iters={len(d['fsqt'])}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--save-as",
+        help="Label to save this run's trace under (e.g. 'double', 'long_double').",
+    )
+    args = parser.parse_args()
+
+    if args.save_as:
+        trace = run_and_extract()
+        path = save_trace(args.save_as, trace)
+        print(f"Saved {len(trace['fsqt'])} iterations to {path}")
+    plot_overlay()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/vmecpp/cpp/util/hdf5_io/hdf5_io.h
+++ b/src/vmecpp/cpp/util/hdf5_io/hdf5_io.h
@@ -131,6 +131,65 @@ extern template void ReadH5Dataset(int& v, const std::string& dataset,
 extern template void ReadH5Dataset(bool& v, const std::string& dataset,
                                    H5::H5File& file);
 
+// Overloads for long double / real_t scalars and Eigen containers.
+// HDF5 storage stays as double (the file format); conversion happens here.
+inline void WriteH5Dataset(long double v, const std::string& name,
+                           H5::H5File& file) {
+  WriteH5Dataset(static_cast<double>(v), name, file);
+}
+
+inline void ReadH5Dataset(long double& v, const std::string& dataset,
+                          H5::H5File& file) {
+  double tmp = 0.0;
+  ReadH5Dataset(tmp, dataset, file);
+  v = static_cast<long double>(tmp);
+}
+
+using RowMatrixXld =
+    Eigen::Matrix<long double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+
+inline void WriteH5Dataset(const RowMatrixXld& m, const std::string& name,
+                           H5::H5File& file) {
+  RowMatrixXd tmp = m.cast<double>();
+  WriteH5Dataset(tmp, name, file);
+}
+
+inline void ReadH5Dataset(RowMatrixXld& m, const std::string& dataset,
+                          H5::H5File& file) {
+  RowMatrixXd tmp;
+  ReadH5Dataset(tmp, dataset, file);
+  m = tmp.cast<long double>();
+}
+
+// Eigen column vector of long double
+inline void WriteH5Dataset(
+    const Eigen::Matrix<long double, Eigen::Dynamic, 1>& v,
+    const std::string& name, H5::H5File& file) {
+  Eigen::VectorXd tmp = v.cast<double>();
+  WriteH5Dataset(tmp, name, file);
+}
+
+inline void ReadH5Dataset(Eigen::Matrix<long double, Eigen::Dynamic, 1>& v,
+                          const std::string& dataset, H5::H5File& file) {
+  Eigen::VectorXd tmp;
+  ReadH5Dataset(tmp, dataset, file);
+  v = tmp.cast<long double>();
+}
+
+// std::vector<long double>
+inline void WriteH5Dataset(const std::vector<long double>& v,
+                           const std::string& name, H5::H5File& file) {
+  std::vector<double> tmp(v.begin(), v.end());
+  WriteH5Dataset(tmp, name, file);
+}
+
+inline void ReadH5Dataset(std::vector<long double>& v,
+                          const std::string& dataset, H5::H5File& file) {
+  std::vector<double> tmp;
+  ReadH5Dataset(tmp, dataset, file);
+  v.assign(tmp.begin(), tmp.end());
+}
+
 // Determine the rank of a given HDF5 dataset,
 // i.e., the number of array dimensions
 int GetRank(const H5::DataSet& dataset);

--- a/src/vmecpp/cpp/vmecpp/common/flow_control/flow_control.cc
+++ b/src/vmecpp/cpp/vmecpp/common/flow_control/flow_control.cc
@@ -40,7 +40,7 @@ int get_max_threads(std::optional<int> max_threads) {
   return max_threads.value();
 }
 
-FlowControl::FlowControl(bool lfreeb, double delt, int num_grids,
+FlowControl::FlowControl(bool lfreeb, real_t delt, int num_grids,
                          std::optional<int> max_threads)
     : lfreeb(lfreeb), max_threads_(get_max_threads(max_threads)) {
   fsq = 1.0;

--- a/src/vmecpp/cpp/vmecpp/common/flow_control/flow_control.h
+++ b/src/vmecpp/cpp/vmecpp/common/flow_control/flow_control.h
@@ -10,6 +10,8 @@
 #include <optional>
 #include <vector>
 
+#include "vmecpp/common/util/real_type.h"
+
 namespace vmecpp {
 
 // enumerates values of `restart_reason`
@@ -37,7 +39,7 @@ class FlowControl {
   // ns4: number of iterations between update of radial preconditioner matrix
   static constexpr int kPreconditionerUpdateInterval = 25;
 
-  FlowControl(bool lfreeb, double delt, int num_grids,
+  FlowControl(bool lfreeb, real_t delt, int num_grids,
               std::optional<int> max_threads = std::nullopt);
 
   int max_threads() const;
@@ -65,10 +67,10 @@ class FlowControl {
   int nsval;
 
   // radial grid spacing of flux surfaces: 1.0 / (ns - 1.0)
-  double deltaS;
+  real_t deltaS;
 
   // current force tolerance
-  double ftolv;
+  real_t ftolv;
 
   // current maximum number of iterations
   int niterv;
@@ -81,33 +83,33 @@ class FlowControl {
   int ns_min;
   int ns_old;
 
-  double delt0r;
+  real_t delt0r;
 
   // Cumulative force residuals (radial, vertical and lambda)
   // Populated by `evalFResInvar`
-  double fsqr, fsqz, fsql;
+  real_t fsqr, fsqz, fsql;
 
   // Time-trace of the invariant force residuals during convergence
   // fsqt = (force_residual_r + force_residual_z + force_residual_lambda)
-  std::vector<double> force_residual_r;
-  std::vector<double> force_residual_z;
-  std::vector<double> force_residual_lambda;
+  std::vector<real_t> force_residual_r;
+  std::vector<real_t> force_residual_z;
+  std::vector<real_t> force_residual_lambda;
 
   // Preconditioned cumulative force residuals (radial, vertical and lambda)
   // Populated by `evalFResPrecd`
-  double fsqr1, fsqz1, fsql1;
-  double fsq;
+  real_t fsqr1, fsqz1, fsql1;
+  real_t fsq;
 
-  std::vector<double> mhd_energy;
+  std::vector<real_t> mhd_energy;
 
   // Time-trace of the force at the vacuum boundary (only for free-boundary)
-  std::vector<double> delbsq;
+  std::vector<real_t> delbsq;
   // Time-trace of the restart reasons, for debugging purposes. Each restart is
   // a pair of <iteration, reason> (e.g. to see how many jacobian resets
   // occurred)
   std::vector<RestartReason> restart_reasons;
 
-  double res0;
+  real_t res0;
 
   Eigen::Vector3d fResInvar;
   Eigen::Vector3d fResPrecd;

--- a/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_poloidal/fourier_basis_fast_poloidal.cc
+++ b/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_poloidal/fourier_basis_fast_poloidal.cc
@@ -134,9 +134,9 @@ void FourierBasisFastPoloidal::computeFourierBasisFastPoloidal(int nfp) {
 }
 
 // convert cos(xm[mn] theta - xn[mn] zeta) into 2D FC array form
-int FourierBasisFastPoloidal::cos_to_cc_ss(const std::span<const double> fcCos,
-                                           std::span<double> m_fcCC,
-                                           std::span<double> m_fcSS, int n_size,
+int FourierBasisFastPoloidal::cos_to_cc_ss(const std::span<const real_t> fcCos,
+                                           std::span<real_t> m_fcCC,
+                                           std::span<real_t> m_fcSS, int n_size,
                                            int m_size) const {
   // m = 0: n =  0, 1, ..., ntor --> ntor + 1
   // m > 0: n = -ntor, ..., ntor --> (mpol - 1) * (2 * ntor + 1)
@@ -185,9 +185,9 @@ int FourierBasisFastPoloidal::cos_to_cc_ss(const std::span<const double> fcCos,
   return mnmax;
 }
 
-int FourierBasisFastPoloidal::sin_to_sc_cs(const std::span<const double> fcSin,
-                                           std::span<double> m_fcSC,
-                                           std::span<double> m_fcCS, int n_size,
+int FourierBasisFastPoloidal::sin_to_sc_cs(const std::span<const real_t> fcSin,
+                                           std::span<real_t> m_fcSC,
+                                           std::span<real_t> m_fcCS, int n_size,
                                            int m_size) const {
   // m = 0: n =  0, 1, ..., ntor --> ntor + 1
   // m > 0: n = -ntor, ..., ntor --> (mpol - 1) * (2 * ntor + 1)
@@ -238,9 +238,9 @@ int FourierBasisFastPoloidal::sin_to_sc_cs(const std::span<const double> fcSin,
   return mnmax;
 }
 
-int FourierBasisFastPoloidal::cc_ss_to_cos(const std::span<const double> fcCC,
-                                           const std::span<const double> fcSS,
-                                           std::span<double> m_fcCos,
+int FourierBasisFastPoloidal::cc_ss_to_cos(const std::span<const real_t> fcCC,
+                                           const std::span<const real_t> fcSS,
+                                           std::span<real_t> m_fcCos,
                                            int n_size, int m_size) const {
   // m = 0: n =  0, 1, ..., ntor --> ntor + 1
   // m > 0: n = -ntor, ..., ntor --> (mpol - 1) * (2 * ntor + 1)
@@ -284,9 +284,9 @@ int FourierBasisFastPoloidal::cc_ss_to_cos(const std::span<const double> fcCC,
   return mnmax;
 }
 
-int FourierBasisFastPoloidal::sc_cs_to_sin(const std::span<const double> fcSC,
-                                           const std::span<const double> fcCS,
-                                           std::span<double> m_fcSin,
+int FourierBasisFastPoloidal::sc_cs_to_sin(const std::span<const real_t> fcSC,
+                                           const std::span<const real_t> fcCS,
+                                           std::span<real_t> m_fcSin,
                                            int n_size, int m_size) const {
   // m = 0: n =  0, 1, ..., ntor --> ntor + 1
   // m > 0: n = -ntor, ..., ntor --> (mpol - 1) * (2 * ntor + 1)

--- a/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_poloidal/fourier_basis_fast_poloidal.h
+++ b/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_poloidal/fourier_basis_fast_poloidal.h
@@ -9,6 +9,7 @@
 #include <span>
 
 #include "vmecpp/common/sizes/sizes.h"
+#include "vmecpp/common/util/real_type.h"
 
 namespace vmecpp {
 
@@ -43,13 +44,13 @@ class FourierBasisFastPoloidal {
   // Applied to cos(m*\theta) and sin(m*\theta) basis functions for DFT
   // normalization Enables proper normalization: 1/\pi for m>0 modes, 1/(2\pi)
   // for m=0 mode
-  Eigen::VectorXd mscale;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> mscale;
 
   // [nnyq2+1] Toroidal mode scaling factors: sqrt(2) for n>0, 1.0 for n=0
   // Applied to cos(n*\zeta) and sin(n*\zeta) basis functions for DFT
   // normalization Enables proper normalization: 1/\pi for n>0 modes, 1/(2\pi)
   // for n=0 mode
-  Eigen::VectorXd nscale;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> nscale;
 
   // ============================================================================
   // POLOIDAL BASIS FUNCTIONS (m-major layout: [m][l])
@@ -59,23 +60,23 @@ class FourierBasisFastPoloidal {
   // Layout: cosmu[m*nThetaReduced + l] = cos(m*\theta[l]) * mscale[m]
   // \theta[l] = 2*\pi*l/nThetaEven for l=0...nThetaReduced-1 (reduced [0,\pi]
   // interval)
-  Eigen::VectorXd cosmu;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> cosmu;
 
   // [nThetaReduced * (mnyq2+1)] Pre-scaled poloidal sine basis
   // Layout: sinmu[m*nThetaReduced + l] = sin(m*\theta[l]) * mscale[m]
-  Eigen::VectorXd sinmu;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sinmu;
 
   // [nThetaReduced * (mnyq2+1)] Pre-scaled poloidal cosine derivative
   // Layout: cosmum[m*nThetaReduced + l] = m * cos(m*\theta[l]) * mscale[m]
   // Used for computing \partial/\partial\theta derivatives in force
   // calculations
-  Eigen::VectorXd cosmum;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> cosmum;
 
   // [nThetaReduced * (mnyq2+1)] Pre-scaled poloidal sine derivative
   // Layout: sinmum[m*nThetaReduced + l] = -m * sin(m*\theta[l]) * mscale[m]
   // Used for computing \partial/\partial\theta derivatives in force
   // calculations
-  Eigen::VectorXd sinmum;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sinmum;
 
   // ============================================================================
   // POLOIDAL BASIS WITH INTEGRATION WEIGHTS
@@ -84,21 +85,21 @@ class FourierBasisFastPoloidal {
   // [nThetaReduced * (mnyq2+1)] Integration-weighted poloidal cosine basis
   // Layout: cosmui[m*nThetaReduced + l] = cosmu[m*nThetaReduced + l] * intNorm
   // intNorm = 1/(nZeta*(nThetaReduced-1)), with boundary point factor 1/2
-  Eigen::VectorXd cosmui;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> cosmui;
 
   // [nThetaReduced * (mnyq2+1)] Integration-weighted poloidal sine basis
   // Layout: sinmui[m*nThetaReduced + l] = sinmu[m*nThetaReduced + l] * intNorm
-  Eigen::VectorXd sinmui;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sinmui;
 
   // [nThetaReduced * (mnyq2+1)] Integration-weighted poloidal cosine derivative
   // Layout: cosmumi[m*nThetaReduced + l] = cosmum[m*nThetaReduced + l] *
   // intNorm
-  Eigen::VectorXd cosmumi;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> cosmumi;
 
   // [nThetaReduced * (mnyq2+1)] Integration-weighted poloidal sine derivative
   // Layout: sinmumi[m*nThetaReduced + l] = sinmum[m*nThetaReduced + l] *
   // intNorm
-  Eigen::VectorXd sinmumi;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sinmumi;
 
   // ============================================================================
   // TOROIDAL BASIS FUNCTIONS (zeta-major layout: [k][n])
@@ -107,23 +108,23 @@ class FourierBasisFastPoloidal {
   // [(nnyq2+1) * nZeta] Pre-scaled toroidal cosine basis
   // Layout: cosnv[k*(nnyq2+1) + n] = cos(n*\zeta[k]) * nscale[n]
   // \zeta[k] = 2*\pi*k/nZeta for k=0...nZeta-1 (full [0,2\pi] interval)
-  Eigen::VectorXd cosnv;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> cosnv;
 
   // [(nnyq2+1) * nZeta] Pre-scaled toroidal sine basis
   // Layout: sinnv[k*(nnyq2+1) + n] = sin(n*\zeta[k]) * nscale[n]
-  Eigen::VectorXd sinnv;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sinnv;
 
   // [(nnyq2+1) * nZeta] Pre-scaled toroidal cosine derivative with nfp factor
   // Layout: cosnvn[k*(nnyq2+1) + n] = n*nfp * cos(n*\zeta[k]) * nscale[n]
   // Factor nfp converts \partial/\partial\zeta to \partial/\partial\phi
   // derivatives
-  Eigen::VectorXd cosnvn;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> cosnvn;
 
   // [(nnyq2+1) * nZeta] Pre-scaled toroidal sine derivative with nfp factor
   // Layout: sinnvn[k*(nnyq2+1) + n] = -n*nfp * sin(n*\zeta[k]) * nscale[n]
   // Factor nfp converts \partial/\partial\zeta to \partial/\partial\phi
   // derivatives
-  Eigen::VectorXd sinnvn;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sinnvn;
 
   // ============================================================================
   // FOURIER BASIS CONVERSION FUNCTIONS
@@ -178,8 +179,8 @@ class FourierBasisFastPoloidal {
    * @param m_size Poloidal mode range: m in [0, m_size-1]
    * @return Total number of modes processed (mnmax)
    */
-  int cos_to_cc_ss(const std::span<const double> fcCos,
-                   std::span<double> m_fcCC, std::span<double> m_fcSS,
+  int cos_to_cc_ss(const std::span<const real_t> fcCos,
+                   std::span<real_t> m_fcCC, std::span<real_t> m_fcSS,
                    int n_size, int m_size) const;
 
   /**
@@ -207,8 +208,8 @@ class FourierBasisFastPoloidal {
    * @param m_size Poloidal mode range: m in [0, m_size-1]
    * @return Total number of modes processed (mnmax)
    */
-  int sin_to_sc_cs(const std::span<const double> fcSin,
-                   std::span<double> m_fcSC, std::span<double> m_fcCS,
+  int sin_to_sc_cs(const std::span<const real_t> fcSin,
+                   std::span<real_t> m_fcSC, std::span<real_t> m_fcCS,
                    int n_size, int m_size) const;
 
   /**
@@ -236,9 +237,9 @@ class FourierBasisFastPoloidal {
    * @param m_size Poloidal mode range: m in [0, m_size-1]
    * @return Total number of modes processed (mnmax)
    */
-  int cc_ss_to_cos(const std::span<const double> fcCC,
-                   const std::span<const double> fcSS,
-                   std::span<double> m_fcCos, int n_size, int m_size) const;
+  int cc_ss_to_cos(const std::span<const real_t> fcCC,
+                   const std::span<const real_t> fcSS,
+                   std::span<real_t> m_fcCos, int n_size, int m_size) const;
 
   /**
    * Convert coefficients from separable product basis back to combined sine
@@ -265,9 +266,9 @@ class FourierBasisFastPoloidal {
    * @param m_size Poloidal mode range: m in [0, m_size-1]
    * @return Total number of modes processed (mnmax)
    */
-  int sc_cs_to_sin(const std::span<const double> fcSC,
-                   const std::span<const double> fcCS,
-                   std::span<double> m_fcSin, int n_size, int m_size) const;
+  int sc_cs_to_sin(const std::span<const real_t> fcSC,
+                   const std::span<const real_t> fcCS,
+                   std::span<real_t> m_fcSin, int n_size, int m_size) const;
 
   int mnIdx(int m, int n) const;
   int mnMax(int m_size, int n_size) const;

--- a/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_toroidal/fourier_basis_fast_toroidal.cc
+++ b/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_toroidal/fourier_basis_fast_toroidal.cc
@@ -134,9 +134,9 @@ void FourierBasisFastToroidal::computeFourierBasisFastToroidal(int nfp) {
 }
 
 // convert cos(xm[mn] theta - xn[mn] zeta) into 2D FC array form
-int FourierBasisFastToroidal::cos_to_cc_ss(const std::span<const double> fcCos,
-                                           std::span<double> m_fcCC,
-                                           std::span<double> m_fcSS, int n_size,
+int FourierBasisFastToroidal::cos_to_cc_ss(const std::span<const real_t> fcCos,
+                                           std::span<real_t> m_fcCC,
+                                           std::span<real_t> m_fcSS, int n_size,
                                            int m_size) const {
   // m = 0: n =  0, 1, ..., ntor --> ntor + 1
   // m > 0: n = -ntor, ..., ntor --> (mpol - 1) * (2 * ntor + 1)
@@ -185,9 +185,9 @@ int FourierBasisFastToroidal::cos_to_cc_ss(const std::span<const double> fcCos,
   return mnmax;
 }
 
-int FourierBasisFastToroidal::sin_to_sc_cs(const std::span<const double> fcSin,
-                                           std::span<double> m_fcSC,
-                                           std::span<double> m_fcCS, int n_size,
+int FourierBasisFastToroidal::sin_to_sc_cs(const std::span<const real_t> fcSin,
+                                           std::span<real_t> m_fcSC,
+                                           std::span<real_t> m_fcCS, int n_size,
                                            int m_size) const {
   // m = 0: n =  0, 1, ..., ntor --> ntor + 1
   // m > 0: n = -ntor, ..., ntor --> (mpol - 1) * (2 * ntor + 1)
@@ -238,9 +238,9 @@ int FourierBasisFastToroidal::sin_to_sc_cs(const std::span<const double> fcSin,
   return mnmax;
 }
 
-int FourierBasisFastToroidal::cc_ss_to_cos(const std::span<const double> fcCC,
-                                           const std::span<const double> fcSS,
-                                           std::span<double> m_fcCos,
+int FourierBasisFastToroidal::cc_ss_to_cos(const std::span<const real_t> fcCC,
+                                           const std::span<const real_t> fcSS,
+                                           std::span<real_t> m_fcCos,
                                            int n_size, int m_size) const {
   // m = 0: n =  0, 1, ..., ntor --> ntor + 1
   // m > 0: n = -ntor, ..., ntor --> (mpol - 1) * (2 * ntor + 1)
@@ -286,9 +286,9 @@ int FourierBasisFastToroidal::cc_ss_to_cos(const std::span<const double> fcCC,
   return mnmax;
 }
 
-int FourierBasisFastToroidal::sc_cs_to_sin(const std::span<const double> fcSC,
-                                           const std::span<const double> fcCS,
-                                           std::span<double> m_fcSin,
+int FourierBasisFastToroidal::sc_cs_to_sin(const std::span<const real_t> fcSC,
+                                           const std::span<const real_t> fcCS,
+                                           std::span<real_t> m_fcSin,
                                            int n_size, int m_size) const {
   // m = 0: n =  0, 1, ..., ntor --> ntor + 1
   // m > 0: n = -ntor, ..., ntor --> (mpol - 1) * (2 * ntor + 1)

--- a/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_toroidal/fourier_basis_fast_toroidal.h
+++ b/src/vmecpp/cpp/vmecpp/common/fourier_basis_fast_toroidal/fourier_basis_fast_toroidal.h
@@ -9,6 +9,7 @@
 #include <span>
 
 #include "vmecpp/common/sizes/sizes.h"
+#include "vmecpp/common/util/real_type.h"
 
 namespace vmecpp {
 
@@ -44,13 +45,13 @@ class FourierBasisFastToroidal {
   // Applied to cos(m*\theta) and sin(m*\theta) basis functions for DFT
   // normalization Enables proper normalization: 1/\pi for m>0 modes, 1/(2\pi)
   // for m=0 mode
-  Eigen::VectorXd mscale;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> mscale;
 
   // [nnyq2+1] Toroidal mode scaling factors: sqrt(2) for n>0, 1.0 for n=0
   // Applied to cos(n*\zeta) and sin(n*\zeta) basis functions for DFT
   // normalization Enables proper normalization: 1/\pi for n>0 modes, 1/(2\pi)
   // for n=0 mode
-  Eigen::VectorXd nscale;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> nscale;
 
   // ============================================================================
   // POLOIDAL BASIS FUNCTIONS (l-major layout: [l][m])
@@ -60,23 +61,23 @@ class FourierBasisFastToroidal {
   // Layout: cosmu[l*(mnyq2+1) + m] = cos(m*\theta[l]) * mscale[m]
   // \theta[l] = 2*\pi*l/nThetaEven for l=0...nThetaReduced-1 (reduced [0,\pi]
   // interval)
-  Eigen::VectorXd cosmu;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> cosmu;
 
   // [nThetaReduced * (mnyq2+1)] Pre-scaled poloidal sine basis
   // Layout: sinmu[l*(mnyq2+1) + m] = sin(m*\theta[l]) * mscale[m]
-  Eigen::VectorXd sinmu;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sinmu;
 
   // [nThetaReduced * (mnyq2+1)] Pre-scaled poloidal cosine derivative
   // Layout: cosmum[l*(mnyq2+1) + m] = m * cos(m*\theta[l]) * mscale[m]
   // Used for computing \partial/\partial\theta derivatives in force
   // calculations
-  Eigen::VectorXd cosmum;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> cosmum;
 
   // [nThetaReduced * (mnyq2+1)] Pre-scaled poloidal sine derivative
   // Layout: sinmum[l*(mnyq2+1) + m] = -m * sin(m*\theta[l]) * mscale[m]
   // Used for computing \partial/\partial\theta derivatives in force
   // calculations
-  Eigen::VectorXd sinmum;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sinmum;
 
   // ============================================================================
   // POLOIDAL BASIS WITH INTEGRATION WEIGHTS
@@ -85,19 +86,19 @@ class FourierBasisFastToroidal {
   // [nThetaReduced * (mnyq2+1)] Integration-weighted poloidal cosine basis
   // Layout: cosmui[l*(mnyq2+1) + m] = cosmu[l*(mnyq2+1) + m] * intNorm
   // intNorm = 1/(nZeta*(nThetaReduced-1)), with boundary point factor 1/2
-  Eigen::VectorXd cosmui;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> cosmui;
 
   // [nThetaReduced * (mnyq2+1)] Integration-weighted poloidal sine basis
   // Layout: sinmui[l*(mnyq2+1) + m] = sinmu[l*(mnyq2+1) + m] * intNorm
-  Eigen::VectorXd sinmui;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sinmui;
 
   // [nThetaReduced * (mnyq2+1)] Integration-weighted poloidal cosine derivative
   // Layout: cosmumi[l*(mnyq2+1) + m] = cosmum[l*(mnyq2+1) + m] * intNorm
-  Eigen::VectorXd cosmumi;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> cosmumi;
 
   // [nThetaReduced * (mnyq2+1)] Integration-weighted poloidal sine derivative
   // Layout: sinmumi[l*(mnyq2+1) + m] = sinmum[l*(mnyq2+1) + m] * intNorm
-  Eigen::VectorXd sinmumi;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sinmumi;
 
   // ============================================================================
   // TOROIDAL BASIS FUNCTIONS (n-major layout: [n][k])
@@ -106,23 +107,23 @@ class FourierBasisFastToroidal {
   // [(nnyq2+1) * nZeta] Pre-scaled toroidal cosine basis
   // Layout: cosnv[n*nZeta + k] = cos(n*\zeta[k]) * nscale[n]
   // \zeta[k] = 2*\pi*k/nZeta for k=0...nZeta-1 (full [0,2\pi] interval)
-  Eigen::VectorXd cosnv;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> cosnv;
 
   // [(nnyq2+1) * nZeta] Pre-scaled toroidal sine basis
   // Layout: sinnv[n*nZeta + k] = sin(n*\zeta[k]) * nscale[n]
-  Eigen::VectorXd sinnv;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sinnv;
 
   // [(nnyq2+1) * nZeta] Pre-scaled toroidal cosine derivative with nfp factor
   // Layout: cosnvn[n*nZeta + k] = n*nfp * cos(n*\zeta[k]) * nscale[n]
   // Factor nfp converts \partial/\partial\zeta to \partial/\partial\phi
   // derivatives
-  Eigen::VectorXd cosnvn;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> cosnvn;
 
   // [(nnyq2+1) * nZeta] Pre-scaled toroidal sine derivative with nfp factor
   // Layout: sinnvn[n*nZeta + k] = -n*nfp * sin(n*\zeta[k]) * nscale[n]
   // Factor nfp converts \partial/\partial\zeta to \partial/\partial\phi
   // derivatives
-  Eigen::VectorXd sinnvn;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sinnvn;
 
   // ============================================================================
   // FOURIER BASIS CONVERSION FUNCTIONS
@@ -177,8 +178,8 @@ class FourierBasisFastToroidal {
    * @param m_size Poloidal mode range: m in [0, m_size-1]
    * @return Total number of modes processed (mnmax)
    */
-  int cos_to_cc_ss(const std::span<const double> fcCos,
-                   std::span<double> m_fcCC, std::span<double> m_fcSS,
+  int cos_to_cc_ss(const std::span<const real_t> fcCos,
+                   std::span<real_t> m_fcCC, std::span<real_t> m_fcSS,
                    int n_size, int m_size) const;
 
   /**
@@ -206,8 +207,8 @@ class FourierBasisFastToroidal {
    * @param m_size Poloidal mode range: m in [0, m_size-1]
    * @return Total number of modes processed (mnmax)
    */
-  int sin_to_sc_cs(const std::span<const double> fcSin,
-                   std::span<double> m_fcSC, std::span<double> m_fcCS,
+  int sin_to_sc_cs(const std::span<const real_t> fcSin,
+                   std::span<real_t> m_fcSC, std::span<real_t> m_fcCS,
                    int n_size, int m_size) const;
 
   /**
@@ -235,9 +236,9 @@ class FourierBasisFastToroidal {
    * @param m_size Poloidal mode range: m in [0, m_size-1]
    * @return Total number of modes processed (mnmax)
    */
-  int cc_ss_to_cos(const std::span<const double> fcCC,
-                   const std::span<const double> fcSS,
-                   std::span<double> m_fcCos, int n_size, int m_size) const;
+  int cc_ss_to_cos(const std::span<const real_t> fcCC,
+                   const std::span<const real_t> fcSS,
+                   std::span<real_t> m_fcCos, int n_size, int m_size) const;
 
   /**
    * Convert coefficients from separable product basis back to combined sine
@@ -264,9 +265,9 @@ class FourierBasisFastToroidal {
    * @param m_size Poloidal mode range: m in [0, m_size-1]
    * @return Total number of modes processed (mnmax)
    */
-  int sc_cs_to_sin(const std::span<const double> fcSC,
-                   const std::span<const double> fcCS,
-                   std::span<double> m_fcSin, int n_size, int m_size) const;
+  int sc_cs_to_sin(const std::span<const real_t> fcSC,
+                   const std::span<const real_t> fcCS,
+                   std::span<real_t> m_fcSin, int n_size, int m_size) const;
 
   int mnIdx(int m, int n) const;
   int mnMax(int m_size, int n_size) const;

--- a/src/vmecpp/cpp/vmecpp/common/sizes/sizes.h
+++ b/src/vmecpp/cpp/vmecpp/common/sizes/sizes.h
@@ -58,7 +58,7 @@ class Sizes {
   int nZnT;
 
   // [nThetaEff] poloidal integration weights
-  Eigen::VectorXd wInt;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> wInt;
 
   // number of Fourier coefficients in one of the 2D arrays (cc, ss, ...)
   int mnsize;

--- a/src/vmecpp/cpp/vmecpp/common/util/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/common/util/BUILD.bazel
@@ -4,7 +4,7 @@
 cc_library(
     name = "util",
     srcs = ["util.cc"],
-    hdrs = ["util.h"],
+    hdrs = ["util.h", "real_type.h"],
     visibility = ["//visibility:public"],
     deps = [
         "@abseil-cpp//absl/log:check",

--- a/src/vmecpp/cpp/vmecpp/common/util/real_type.h
+++ b/src/vmecpp/cpp/vmecpp/common/util/real_type.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+// <info@proximafusion.com>
+//
+// SPDX-License-Identifier: MIT
+#ifndef VMECPP_COMMON_UTIL_REAL_TYPE_H_
+#define VMECPP_COMMON_UTIL_REAL_TYPE_H_
+
+#include <Eigen/Dense>
+
+namespace vmecpp {
+
+// Primary floating-point type used throughout all physics computations.
+// On x86-64 Linux with GCC/Clang this is 80-bit extended precision
+// (16 bytes, ~18-19 significant decimal digits), providing ~3 extra digits
+// of precision beyond double.
+using real_t = long double;
+
+// Row-major dynamic Eigen matrix of real_t, used pervasively for 2-D Fourier
+// coefficient arrays and geometry data. Row-major matches numpy's default
+// memory layout for efficient pybind11 array transfers after conversion.
+using RowMatrixXr =
+    Eigen::Matrix<real_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+
+}  // namespace vmecpp
+
+#endif  // VMECPP_COMMON_UTIL_REAL_TYPE_H_

--- a/src/vmecpp/cpp/vmecpp/common/util/util.cc
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.cc
@@ -9,6 +9,11 @@
 #include <string>
 #include <vector>
 
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/str_format.h"
+
 namespace vmecpp {
 
 int VmecStatusCode(const VmecStatus vmec_status) {
@@ -43,11 +48,11 @@ int signum(int x) {
   return (x > 0) - (x < 0);
 }
 
-void TridiagonalSolveSerial(std::span<double> m_a, std::span<double> m_d,
-                            std::span<double> m_b, double* m_c_data,
+void TridiagonalSolveSerial(std::span<real_t> m_a, std::span<real_t> m_d,
+                            std::span<real_t> m_b, real_t *m_c_data,
                             int c_stride, int jMin, int jMax, int nRHS) {
   // Helper lambda to access c[k][j] in the flat layout
-  auto c = [m_c_data, c_stride](int k, int j) -> double& {
+  auto c = [m_c_data, c_stride](int k, int j) -> real_t & {
     return m_c_data[k * c_stride + j];
   };
 
@@ -69,12 +74,16 @@ void TridiagonalSolveSerial(std::span<double> m_a, std::span<double> m_d,
   // https://en.wikipedia.org/wiki/Tridiagonal_matrix_algorithm
   // This works in-place and does not need extra arrays !
 
-  // Division by zero may produce NaN, this is handled elsewhere.
+  // if (m_d[jMin] == 0.0) {
+  //   LOG(FATAL) << "d[jMin] == 0.0 at jMin = " << jMin;
+  // }
   m_a[jMin] /= m_d[jMin];
 
   for (int j = jMin + 1; j < jMax - 1; ++j) {
-    const double denominator = m_d[j] - m_a[j - 1] * m_b[j];
-    // Division by zero may produce NaN, this is handled elsewhere.
+    const real_t denominator = m_d[j] - m_a[j - 1] * m_b[j];
+    // if (denominator == 0.0) {
+    //   LOG(FATAL) << "d[j] - a[j - 1] * b[j] == 0.0 at j = " << j;
+    // }
     m_a[j] /= denominator;
   }  // j
 
@@ -83,8 +92,10 @@ void TridiagonalSolveSerial(std::span<double> m_a, std::span<double> m_d,
     c(k, jMin) /= m_d[jMin];
 
     for (int j = jMin + 1; j < jMax; ++j) {
-      const double denominator = m_d[j] - m_a[j - 1] * m_b[j];
-      // Division by zero may produce NaN, this is handled elsewhere.
+      const real_t denominator = m_d[j] - m_a[j - 1] * m_b[j];
+      // if (denominator == 0.0) {
+      //   LOG(FATAL) << "d[j] - a[j - 1] * b[j] == 0.0 at j = " << j;
+      // }
       c(k, j) = (c(k, j) - c(k, j - 1) * m_b[j]) / denominator;
     }  // j
 
@@ -95,16 +106,16 @@ void TridiagonalSolveSerial(std::span<double> m_a, std::span<double> m_d,
 }
 
 void TridiagonalSolveOpenMP(
-    std::vector<double>& m_ar, std::vector<double>& m_dr,
-    std::vector<double>& m_br, std::vector<std::span<double>>& m_cr,
-    std::vector<double>& m_az, std::vector<double>& m_dz,
-    std::vector<double>& m_bz, std::vector<std::span<double>>& m_cz,
-    const std::vector<int>& jMin, int jMax, int mnmax, int nRHS,
-    std::vector<std::mutex>& m_mutices, int ncpu, int myid, int nsMinF,
-    int nsMaxF, std::vector<double>& m_handover_ar,
-    std::vector<std::vector<double>>& m_handover_cr,
-    std::vector<double>& m_handover_az,
-    std::vector<std::vector<double>>& m_handover_cz) {
+    std::vector<real_t> &m_ar, std::vector<real_t> &m_dr,
+    std::vector<real_t> &m_br, std::vector<std::span<real_t>> &m_cr,
+    std::vector<real_t> &m_az, std::vector<real_t> &m_dz,
+    std::vector<real_t> &m_bz, std::vector<std::span<real_t>> &m_cz,
+    const std::vector<int> &jMin, int jMax, int mnmax, int nRHS,
+    std::vector<std::mutex> &m_mutices, int ncpu, int myid, int nsMinF,
+    int nsMaxF, std::vector<real_t> &m_handover_ar,
+    std::vector<std::vector<real_t>> &m_handover_cr,
+    std::vector<real_t> &m_handover_az,
+    std::vector<std::vector<real_t>> &m_handover_cz) {
 #ifdef _OPENMP
 #pragma omp barrier
 #endif  // _OPENMP
@@ -141,7 +152,14 @@ void TridiagonalSolveOpenMP(
     // compute a[jMin] /= d[jMin] and c[*][jMin] /= d[jMin]
     for (int mn = 0; mn < mnmax; ++mn) {
       int idx_mn = (jMin[mn] - nsMinF) * mnmax + mn;
-      // Division by zero may produce NaN, this is handled elsewhere.
+      // if (m_dr[idx_mn] == 0.0) {
+      //   LOG(FATAL) << absl::StrFormat("m_dr[jMin=%d, mn=%d] == 0", jMin[mn],
+      //                                 mn);
+      // }
+      // if (m_dz[idx_mn] == 0.0) {
+      //   LOG(FATAL) << absl::StrFormat("m_dz[jMin=%d, mn=%d] == 0", jMin[mn],
+      //                                 mn);
+      // }
       m_ar[idx_mn] /= m_dr[idx_mn];
       m_az[idx_mn] /= m_dz[idx_mn];
       for (int k = 0; k < nRHS; ++k) {
@@ -173,10 +191,10 @@ void TridiagonalSolveOpenMP(
       int idx_mn_0 = (j - nsMinF) * mnmax + mn;      //  0
       int idx_mn_m = (j - 1 - nsMinF) * mnmax + mn;  // -1
 
-      double prev_m_ar;
-      double prev_az;
-      std::vector<std::span<double>> prev_cr(m_handover_cr.size());
-      std::vector<std::span<double>> prev_cz(m_handover_cz.size());
+      real_t prev_m_ar;
+      real_t prev_az;
+      std::vector<std::span<real_t>> prev_cr(m_handover_cr.size());
+      std::vector<std::span<real_t>> prev_cz(m_handover_cz.size());
       int prev_c_idx;
       if (j == nsMinF) {
         // j-1 is within rank myid-1
@@ -200,10 +218,17 @@ void TridiagonalSolveOpenMP(
         }
       }
 
-      double denom_r = m_dr[idx_mn_0] - prev_m_ar * m_br[idx_mn_0];
-      double denom_z = m_dz[idx_mn_0] - prev_az * m_bz[idx_mn_0];
+      real_t denom_r = m_dr[idx_mn_0] - prev_m_ar * m_br[idx_mn_0];
+      real_t denom_z = m_dz[idx_mn_0] - prev_az * m_bz[idx_mn_0];
 
-      // Division by zero may produce NaN, this is handled elsewhere.
+      // make sure to not divide by zero in the following
+      // if (denom_r == 0.0) {
+      //   LOG(FATAL) << absl::StrFormat("denom_r at j=%d, mn=%d is 0", j, mn);
+      // }
+      // if (denom_z == 0.0) {
+      //   LOG(FATAL) << absl::StrFormat("denom_z at j=%d, mn=%d is 0", j, mn);
+      // }
+
       if (j < jMax - 1) {
         m_ar[idx_mn_0] /= denom_r;
         m_az[idx_mn_0] /= denom_z;
@@ -258,8 +283,8 @@ void TridiagonalSolveOpenMP(
       int idx_mn_p = (j + 1 - nsMinF) * mnmax + mn;  // +1
       int idx_mn_0 = (j - nsMinF) * mnmax + mn;      //  0
 
-      std::vector<std::span<double>> prev_cr(m_handover_cr.size());
-      std::vector<std::span<double>> prev_cz(m_handover_cz.size());
+      std::vector<std::span<real_t>> prev_cr(m_handover_cr.size());
+      std::vector<std::span<real_t>> prev_cz(m_handover_cz.size());
       int prev_c_idx;
       if (j == nsMaxF - 1) {
         // j+1 is within rank myid+1

--- a/src/vmecpp/cpp/vmecpp/common/util/util.h
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.h
@@ -5,7 +5,7 @@
 #ifndef VMECPP_COMMON_UTIL_UTIL_H_
 #define VMECPP_COMMON_UTIL_UTIL_H_
 
-#include <Eigen/Dense>  // VectorXd, Matrix
+#include <Eigen/Dense>
 #include <cassert>
 #include <cmath>
 #include <cstdio>
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "absl/log/check.h"
+#include "vmecpp/common/util/real_type.h"
 #include "vmecpp/vmec/vmec_constants/vmec_algorithm_constants.h"
 
 #ifdef _OPENMP
@@ -26,18 +27,15 @@
 
 namespace vmecpp {
 
-// Eigen defaults to column-major ordering, but we prefer row-major for two
-// reasons:
-// - the data will be mostly handled as numpy arrays via pybind11, and numpy's
-// default is row-major
-// - lots of code in output_quantities.cc expects row-major when iterating over
-// elements with a linear index
+// Row-major double matrix used at I/O boundaries (JSON parsing, pybind11
+// numpy arrays). Internal physics code uses RowMatrixXr (real_t / long double).
 using RowMatrixXd =
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
 
-inline Eigen::VectorXd ToEigenVector(const std::vector<double> &v) {
-  return Eigen::Map<const Eigen::VectorXd>(v.data(),
-                                           static_cast<Eigen::Index>(v.size()));
+inline Eigen::Matrix<real_t, Eigen::Dynamic, 1> ToEigenVector(
+    const std::vector<real_t> &v) {
+  return Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+      v.data(), static_cast<Eigen::Index>(v.size()));
 }
 
 inline Eigen::VectorXi ToEigenVector(const std::vector<int> &v) {
@@ -45,13 +43,21 @@ inline Eigen::VectorXi ToEigenVector(const std::vector<int> &v) {
                                            static_cast<Eigen::Index>(v.size()));
 }
 
+inline vmecpp::RowMatrixXr ToEigenMatrix(const std::vector<real_t> &v,
+                                         Eigen::Index size1,
+                                         Eigen::Index size2) {
+  return Eigen::Map<const vmecpp::RowMatrixXr>(v.data(), size1, size2);
+}
+
+// I/O boundary overload: convert flat double vector to row-major double matrix
 inline vmecpp::RowMatrixXd ToEigenMatrix(const std::vector<double> &v,
                                          Eigen::Index size1,
                                          Eigen::Index size2) {
   return Eigen::Map<const vmecpp::RowMatrixXd>(v.data(), size1, size2);
 }
 
-// Convert a rectangular nested STL vector to the corresponding Eigen matrix
+// I/O boundary overload: convert nested double vector to double row-major
+// matrix
 inline vmecpp::RowMatrixXd ToEigenMatrix(
     const std::vector<std::vector<double>> &v) {
   const std::size_t outer_size = v.size();
@@ -60,8 +66,26 @@ inline vmecpp::RowMatrixXd ToEigenMatrix(
   for (const auto &row : v) {
     CHECK_EQ(row.size(), inner_size);
   }
-
   vmecpp::RowMatrixXd m(outer_size, inner_size);
+  for (int i = 0; i < m.rows(); ++i) {
+    for (int j = 0; j < m.cols(); ++j) {
+      m(i, j) = v[i][j];
+    }
+  }
+  return m;
+}
+
+// Convert a rectangular nested STL vector to the corresponding Eigen matrix
+inline vmecpp::RowMatrixXr ToEigenMatrix(
+    const std::vector<std::vector<real_t>> &v) {
+  const std::size_t outer_size = v.size();
+  CHECK_GT(outer_size, 0u);
+  const std::size_t inner_size = v[0].size();
+  for (const auto &row : v) {
+    CHECK_EQ(row.size(), inner_size);
+  }
+
+  vmecpp::RowMatrixXr m(outer_size, inner_size);
 
   for (int i = 0; i < m.rows(); ++i) {
     for (int j = 0; j < m.cols(); ++j) {
@@ -181,8 +205,8 @@ std::string VmecStatusAsString(const VmecStatus vmec_status);
 // as it is the official value after re-definition of the SI system.
 // However, for now, use the old definition for 1:1 comparison against Fortran
 // VMEC.
-// static constexpr double MU_0 = 1.25663706212e-6;
-static constexpr double MU_0 = 4.0e-7 * M_PI;
+// static constexpr real_t MU_0 = 1.25663706212e-6L;
+static constexpr real_t MU_0 = 4.0e-7L * M_PI;
 
 // ----------------------
 // simple math
@@ -200,8 +224,8 @@ int signum(int x);
 // a,d,b contain the tri-diagonal matrix and are modified in-place
 // m_c_data: RHS on entry, solution on exit. Layout: [k * c_stride + j]
 // Access: c[k][j] = m_c_data[k * c_stride + j], c_stride typically = ns
-void TridiagonalSolveSerial(std::span<double> m_a, std::span<double> m_d,
-                            std::span<double> m_b, double *m_c_data,
+void TridiagonalSolveSerial(std::span<real_t> m_a, std::span<real_t> m_d,
+                            std::span<real_t> m_b, real_t *m_c_data,
                             int c_stride, int jMin, int jMax, int nRHS);
 
 // OpenMP-enabled tri-diagonal solver
@@ -219,16 +243,16 @@ void TridiagonalSolveSerial(std::span<double> m_a, std::span<double> m_d,
 // a,d,b contain the tri-diagonal matrix and is modified in-place
 // c     contains the RHS on entry and the solution vectors on exit
 void TridiagonalSolveOpenMP(
-    std::vector<double> &m_ar, std::vector<double> &m_dr,
-    std::vector<double> &m_br, std::vector<std::span<double>> &m_cr,
-    std::vector<double> &m_az, std::vector<double> &m_dz,
-    std::vector<double> &m_bz, std::vector<std::span<double>> &m_cz,
+    std::vector<real_t> &m_ar, std::vector<real_t> &m_dr,
+    std::vector<real_t> &m_br, std::vector<std::span<real_t>> &m_cr,
+    std::vector<real_t> &m_az, std::vector<real_t> &m_dz,
+    std::vector<real_t> &m_bz, std::vector<std::span<real_t>> &m_cz,
     const std::vector<int> &jMin, int jMax, int mnmax, int nRHS,
     std::vector<std::mutex> &m_mutices, int ncpu, int myid, int nsMinF,
-    int nsMaxF, std::vector<double> &m_handover_ar,
-    std::vector<std::vector<double>> &m_handover_cr,
-    std::vector<double> &m_handover_az,
-    std::vector<std::vector<double>> &m_handover_cz);
+    int nsMaxF, std::vector<real_t> &m_handover_ar,
+    std::vector<std::vector<real_t>> &m_handover_cr,
+    std::vector<real_t> &m_handover_az,
+    std::vector<std::vector<real_t>> &m_handover_cz);
 
 // ----------------------
 // VMEC-specific

--- a/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.cc
@@ -38,15 +38,27 @@ ExternalMagneticField::ExternalMagneticField(const Sizes* s,
 }
 
 // rAxis, zAxis are provided over a single module
-void ExternalMagneticField::update(const std::span<const double> rAxis,
-                                   const std::span<const double> zAxis,
-                                   double netToroidalCurrent) {
+void ExternalMagneticField::update(const std::span<const real_t> rAxis,
+                                   const std::span<const real_t> zAxis,
+                                   real_t netToroidalCurrent) {
 #ifdef _OPENMP
 #pragma omp barrier
 #endif  // _OPENMP
 
-  mgrid_.interpolate(tp_.ztMin, tp_.ztMax, s_.nZeta, sg_.r1b, sg_.z1b, interpBr,
-                     interpBp, interpBz);
+  // mgrid is an I/O-boundary type and operates in double precision.
+  // Convert real_t buffers to double, call, then convert results back.
+  {
+    std::vector<double> r1b_d(sg_.r1b.begin(), sg_.r1b.end());
+    std::vector<double> z1b_d(sg_.z1b.begin(), sg_.z1b.end());
+    std::vector<double> interpBr_d(interpBr.size());
+    std::vector<double> interpBp_d(interpBp.size());
+    std::vector<double> interpBz_d(interpBz.size());
+    mgrid_.interpolate(tp_.ztMin, tp_.ztMax, s_.nZeta, r1b_d, z1b_d, interpBr_d,
+                       interpBp_d, interpBz_d);
+    std::copy(interpBr_d.begin(), interpBr_d.end(), interpBr.begin());
+    std::copy(interpBp_d.begin(), interpBp_d.end(), interpBp.begin());
+    std::copy(interpBz_d.begin(), interpBz_d.end(), interpBz.begin());
+  }
 
 #ifdef _OPENMP
 #pragma omp barrier
@@ -71,8 +83,8 @@ void ExternalMagneticField::update(const std::span<const double> rAxis,
 
 // add in contribution from net toroidal current along magnetic axis
 void ExternalMagneticField::AddAxisCurrentFieldAbscab(
-    const std::span<const double> rAxis, const std::span<const double> zAxis,
-    double netToroidalCurrent) {
+    const std::span<const real_t> rAxis, const std::span<const real_t> zAxis,
+    real_t netToroidalCurrent) {
   // copy over axis geometry in first module
   // and convert to Cartesian coordinates
   for (int k = 0; k < s_.nZeta; ++k) {
@@ -127,21 +139,22 @@ void ExternalMagneticField::AddAxisCurrentFieldAbscab(
 
   // compute magnetic field due to line current along magnetic axis
   int numProcessors = 1;  // Nestor itself is already parallelized via OpenMP
-  abscab::magneticFieldPolygonFilament(s_.nZeta * s_.nfp + 1, axisXYZ.data(),
-                                       axis_current, tp_.ztMax - tp_.ztMin,
-                                       surfaceXYZ.data(), bCoilsXYZ.data(),
-                                       numProcessors);
+  abscab::magneticFieldPolygonFilament(
+      s_.nZeta * s_.nfp + 1, reinterpret_cast<double*>(axisXYZ.data()),
+      static_cast<double>(axis_current), tp_.ztMax - tp_.ztMin,
+      reinterpret_cast<double*>(surfaceXYZ.data()),
+      reinterpret_cast<double*>(bCoilsXYZ.data()), numProcessors);
 
   // transform bCoilsXYZ into cylindrical coordinates
   for (int kl = tp_.ztMin; kl < tp_.ztMax; ++kl) {
     int k = kl % s_.nZeta;
 
-    double _bX = bCoilsXYZ[3 * (kl - tp_.ztMin) + 0];
-    double _bY = bCoilsXYZ[3 * (kl - tp_.ztMin) + 1];
-    double _bZ = bCoilsXYZ[3 * (kl - tp_.ztMin) + 2];
+    real_t _bX = bCoilsXYZ[3 * (kl - tp_.ztMin) + 0];
+    real_t _bY = bCoilsXYZ[3 * (kl - tp_.ztMin) + 1];
+    real_t _bZ = bCoilsXYZ[3 * (kl - tp_.ztMin) + 2];
 
-    double _bR = sg_.cos_phi[k] * _bX + sg_.sin_phi[k] * _bY;
-    double _bP = sg_.cos_phi[k] * _bY - sg_.sin_phi[k] * _bX;
+    real_t _bR = sg_.cos_phi[k] * _bX + sg_.sin_phi[k] * _bY;
+    real_t _bP = sg_.cos_phi[k] * _bY - sg_.sin_phi[k] * _bX;
 
     curtorBr[kl - tp_.ztMin] = _bR;
     curtorBp[kl - tp_.ztMin] = _bP;
@@ -150,8 +163,8 @@ void ExternalMagneticField::AddAxisCurrentFieldAbscab(
 }
 
 void ExternalMagneticField::AddAxisCurrentFieldSimple(
-    const std::span<const double> rAxis, const std::span<const double> zAxis,
-    double netToroidalCurrent) {
+    const std::span<const real_t> rAxis, const std::span<const real_t> zAxis,
+    real_t netToroidalCurrent) {
   // copy over axis geometry in first module
   // and convert to Cartesian coordinates
   for (int k = 0; k < s_.nZeta; ++k) {
@@ -209,44 +222,44 @@ void ExternalMagneticField::AddAxisCurrentFieldSimple(
   // 1.0e-7 == mu0/4 pi
   // NOTE: The factor of 2 comes from the Hanson-Hirshman Biot-Savart formula,
   // which is Eqn. (8) in Hanson & Hirshman (2002) [Physics of Plasmas 9, 4410].
-  const double magnetic_field_scale = 1.0e-7 * netToroidalCurrent * 2.0;
+  const real_t magnetic_field_scale = 1.0e-7 * netToroidalCurrent * 2.0;
 
   for (int source_index = 0; source_index < s_.nZeta * s_.nfp; ++source_index) {
-    const double segment_dx =
+    const real_t segment_dx =
         axisXYZ[(source_index + 1) * 3 + 0] - axisXYZ[source_index * 3 + 0];
-    const double segment_dy =
+    const real_t segment_dy =
         axisXYZ[(source_index + 1) * 3 + 1] - axisXYZ[source_index * 3 + 1];
-    const double segment_dz =
+    const real_t segment_dz =
         axisXYZ[(source_index + 1) * 3 + 2] - axisXYZ[source_index * 3 + 2];
 
-    const double segment_length =
+    const real_t segment_length =
         std::sqrt(segment_dx * segment_dx + segment_dy * segment_dy +
                   segment_dz * segment_dz);
 
     for (int kl = tp_.ztMin; kl < tp_.ztMax; ++kl) {
       const int kl_local = kl - tp_.ztMin;
 
-      const double r_i_x =
+      const real_t r_i_x =
           surfaceXYZ[kl_local * 3 + 0] - axisXYZ[source_index * 3 + 0];
-      const double r_i_y =
+      const real_t r_i_y =
           surfaceXYZ[kl_local * 3 + 1] - axisXYZ[source_index * 3 + 1];
-      const double r_i_z =
+      const real_t r_i_z =
           surfaceXYZ[kl_local * 3 + 2] - axisXYZ[source_index * 3 + 2];
-      const double r_i =
+      const real_t r_i =
           std::sqrt(r_i_x * r_i_x + r_i_y * r_i_y + r_i_z * r_i_z);
 
-      const double r_f_x =
+      const real_t r_f_x =
           surfaceXYZ[kl_local * 3 + 0] - axisXYZ[(source_index + 1) * 3 + 0];
-      const double r_f_y =
+      const real_t r_f_y =
           surfaceXYZ[kl_local * 3 + 1] - axisXYZ[(source_index + 1) * 3 + 1];
-      const double r_f_z =
+      const real_t r_f_z =
           surfaceXYZ[kl_local * 3 + 2] - axisXYZ[(source_index + 1) * 3 + 2];
-      const double r_f =
+      const real_t r_f =
           std::sqrt(r_f_x * r_f_x + r_f_y * r_f_y + r_f_z * r_f_z);
 
-      const double r_i_plus_r_f = r_i + r_f;
+      const real_t r_i_plus_r_f = r_i + r_f;
 
-      const double magnetic_field_magnitude =
+      const real_t magnetic_field_magnitude =
           magnetic_field_scale * r_i_plus_r_f /
           (r_i * r_f *
            (r_i_plus_r_f * r_i_plus_r_f - segment_length * segment_length));
@@ -270,12 +283,12 @@ void ExternalMagneticField::AddAxisCurrentFieldSimple(
   for (int kl = tp_.ztMin; kl < tp_.ztMax; ++kl) {
     int k = kl % s_.nZeta;
 
-    double _bX = bCoilsXYZ[3 * (kl - tp_.ztMin) + 0];
-    double _bY = bCoilsXYZ[3 * (kl - tp_.ztMin) + 1];
-    double _bZ = bCoilsXYZ[3 * (kl - tp_.ztMin) + 2];
+    real_t _bX = bCoilsXYZ[3 * (kl - tp_.ztMin) + 0];
+    real_t _bY = bCoilsXYZ[3 * (kl - tp_.ztMin) + 1];
+    real_t _bZ = bCoilsXYZ[3 * (kl - tp_.ztMin) + 2];
 
-    double _bR = sg_.cos_phi[k] * _bX + sg_.sin_phi[k] * _bY;
-    double _bP = sg_.cos_phi[k] * _bY - sg_.sin_phi[k] * _bX;
+    real_t _bR = sg_.cos_phi[k] * _bX + sg_.sin_phi[k] * _bY;
+    real_t _bP = sg_.cos_phi[k] * _bY - sg_.sin_phi[k] * _bX;
 
     curtorBr[kl - tp_.ztMin] = _bR;
     curtorBp[kl - tp_.ztMin] = _bP;
@@ -289,9 +302,9 @@ void ExternalMagneticField::covariantAndNormalComponents() {
   for (int kl = tp_.ztMin; kl < tp_.ztMax; ++kl) {
     // add contributions together
     // --> helps in debugging to have them separate until here
-    double fullBr = interpBr[kl - tp_.ztMin] + curtorBr[kl - tp_.ztMin];
-    double fullBp = interpBp[kl - tp_.ztMin] + curtorBp[kl - tp_.ztMin];
-    double fullBz = interpBz[kl - tp_.ztMin] + curtorBz[kl - tp_.ztMin];
+    real_t fullBr = interpBr[kl - tp_.ztMin] + curtorBr[kl - tp_.ztMin];
+    real_t fullBp = interpBp[kl - tp_.ztMin] + curtorBp[kl - tp_.ztMin];
+    real_t fullBz = interpBz[kl - tp_.ztMin] + curtorBz[kl - tp_.ztMin];
 
     // covariant components
     bSubU[kl - tp_.ztMin] =

--- a/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.h
@@ -21,29 +21,29 @@ class ExternalMagneticField {
   ExternalMagneticField(const Sizes* s, const TangentialPartitioning* tp,
                         const SurfaceGeometry* sg, const MGridProvider* mgrid);
 
-  void update(const std::span<const double> rAxis,
-              const std::span<const double> zAxis, double netToroidalCurrent);
+  void update(const std::span<const real_t> rAxis,
+              const std::span<const real_t> zAxis, real_t netToroidalCurrent);
 
   // axis geometry around whole machine
-  std::vector<double> axisXYZ;
-  std::vector<double> surfaceXYZ;
-  std::vector<double> bCoilsXYZ;
+  std::vector<real_t> axisXYZ;
+  std::vector<real_t> surfaceXYZ;
+  std::vector<real_t> bCoilsXYZ;
 
   // interpolated magnetic field from mgrid
-  std::vector<double> interpBr;
-  std::vector<double> interpBp;
-  std::vector<double> interpBz;
+  std::vector<real_t> interpBr;
+  std::vector<real_t> interpBp;
+  std::vector<real_t> interpBz;
 
   // interpolated magnetic field from mgrid
-  double axis_current;
-  std::vector<double> curtorBr;
-  std::vector<double> curtorBp;
-  std::vector<double> curtorBz;
+  real_t axis_current;
+  std::vector<real_t> curtorBr;
+  std::vector<real_t> curtorBp;
+  std::vector<real_t> curtorBz;
 
   // outputs to Nestor
-  std::vector<double> bSubU;
-  std::vector<double> bSubV;
-  std::vector<double> bDotN;
+  std::vector<real_t> bSubU;
+  std::vector<real_t> bSubV;
+  std::vector<real_t> bDotN;
 
  private:
   // We /can/ use ABSCAB to compute the magnetic field due to the axis current,
@@ -72,16 +72,16 @@ class ExternalMagneticField {
   // Compute the contribution to the external magnetic field from net toroidal
   // current along magnetic axis. Here, the contribution is computed using
   // ABSCAB.
-  void AddAxisCurrentFieldAbscab(const std::span<const double> rAxis,
-                                 const std::span<const double> zAxis,
-                                 double netToroidalCurrent);
+  void AddAxisCurrentFieldAbscab(const std::span<const real_t> rAxis,
+                                 const std::span<const real_t> zAxis,
+                                 real_t netToroidalCurrent);
 
   // Compute the contribution to the external magnetic field from net toroidal
   // current along magnetic axis. Here, this contribution is computed using a
   // straightforward implementation of the Hanson-Hirshman 2002 paper.
-  void AddAxisCurrentFieldSimple(const std::span<const double> rAxis,
-                                 const std::span<const double> zAxis,
-                                 double netToroidalCurrent);
+  void AddAxisCurrentFieldSimple(const std::span<const real_t> rAxis,
+                                 const std::span<const real_t> zAxis,
+                                 real_t netToroidalCurrent);
 
   void covariantAndNormalComponents();
 };

--- a/src/vmecpp/cpp/vmecpp/free_boundary/free_boundary_base/free_boundary_base.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/free_boundary_base/free_boundary_base.h
@@ -22,10 +22,10 @@ class FreeBoundaryBase {
   virtual ~FreeBoundaryBase() = default;
 
   FreeBoundaryBase(const Sizes* s, const TangentialPartitioning* tp,
-                   const MGridProvider* mgrid, std::span<double> bSqVacShare,
-                   std::span<double> vacuum_b_r_share,
-                   std::span<double> vacuum_b_phi_share,
-                   std::span<double> vacuum_b_z_share)
+                   const MGridProvider* mgrid, std::span<real_t> bSqVacShare,
+                   std::span<real_t> vacuum_b_r_share,
+                   std::span<real_t> vacuum_b_phi_share,
+                   std::span<real_t> vacuum_b_z_share)
       : s_(*s),
         fb_(&s_),
         tp_(*tp),
@@ -37,13 +37,13 @@ class FreeBoundaryBase {
         vacuum_b_z_share_(vacuum_b_z_share) {}
 
   virtual bool update(
-      const std::span<const double> rCC, const std::span<const double> rSS,
-      const std::span<const double> rSC, const std::span<const double> rCS,
-      const std::span<const double> zSC, const std::span<const double> zCS,
-      const std::span<const double> zCC, const std::span<const double> zSS,
-      int signOfJacobian, const std::span<const double> rAxis,
-      const std::span<const double> zAxis, double* bSubUVac, double* bSubVVac,
-      double netToroidalCurrent, int m_ivacskip,
+      const std::span<const real_t> rCC, const std::span<const real_t> rSS,
+      const std::span<const real_t> rSC, const std::span<const real_t> rCS,
+      const std::span<const real_t> zSC, const std::span<const real_t> zCS,
+      const std::span<const real_t> zCC, const std::span<const real_t> zSS,
+      int signOfJacobian, const std::span<const real_t> rAxis,
+      const std::span<const real_t> zAxis, real_t* bSubUVac, real_t* bSubVVac,
+      real_t netToroidalCurrent, int m_ivacskip,
       const VmecCheckpoint& vmec_checkpoint = VmecCheckpoint::NONE,
       bool at_checkpoint_iteration = false) = 0;
 
@@ -60,17 +60,17 @@ class FreeBoundaryBase {
 
   // [nZnT] vacuum magnetic pressure |B_vac^2|/2 at the plasma boundary
   // Points to vacuum_magnetic_pressure in HandoverStorage
-  std::span<double> bSqVacShare;
+  std::span<real_t> bSqVacShare;
 
   // [nZnT] cylindrical B^R of Nestor's vacuum magnetic field
   // Points to vacuum_b_r in HandoverStorage
-  std::span<double> vacuum_b_r_share_;
+  std::span<real_t> vacuum_b_r_share_;
   // [nZnT] cylindrical B^phi of Nestor's vacuum magnetic field
   // Points to vacuum_b_phi in HandoverStorage
-  std::span<double> vacuum_b_phi_share_;
+  std::span<real_t> vacuum_b_phi_share_;
   // [nZnT] cylindrical B^Z of Nestor's vacuum magnetic field
   // Points to vacuum_b_z in HandoverStorage
-  std::span<double> vacuum_b_z_share_;
+  std::span<real_t> vacuum_b_z_share_;
 };  // FreeBoundaryBase
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.cc
@@ -22,8 +22,8 @@ namespace vmecpp {
 
 LaplaceSolver::LaplaceSolver(const Sizes *s, const FourierBasisFastToroidal *fb,
                              const TangentialPartitioning *tp, int nf, int mf,
-                             std::span<double> matrixShare, std::span<int> iPiv,
-                             std::span<double> bvecShare)
+                             std::span<real_t> matrixShare, std::span<int> iPiv,
+                             std::span<real_t> bvecShare)
     : s_(*s),
       fb_(*fb),
       tp_(*tp),
@@ -62,7 +62,7 @@ LaplaceSolver::LaplaceSolver(const Sizes *s, const FourierBasisFastToroidal *fb,
 
 // fourp()-equivalent
 void LaplaceSolver::TransformGreensFunctionDerivative(
-    const std::vector<double> &greenp) {
+    const std::vector<real_t> &greenp) {
   const int mnpd = (2 * nf + 1) * (mf + 1);
   absl::c_fill_n(grpmn_sin, mnpd * numLocal, 0);
 
@@ -71,8 +71,8 @@ void LaplaceSolver::TransformGreensFunctionDerivative(
     for (int l = 0; l < s_.nThetaReduced; ++l) {
       const int lRev = (s_.nThetaEven - l) % s_.nThetaEven;
 
-      std::vector<double> g1_symm(nf + 1);
-      std::vector<double> g2_symm(nf + 1);
+      std::vector<real_t> g1_symm(nf + 1);
+      std::vector<real_t> g2_symm(nf + 1);
 
       for (int k = 0; k < s_.nZeta; ++k) {
         const int kRev = (s_.nZeta - k) % s_.nZeta;
@@ -85,10 +85,10 @@ void LaplaceSolver::TransformGreensFunctionDerivative(
 
           const int klpOff = (klp - tp_.ztMin) * s_.nThetaEven * s_.nZeta;
 
-          const double cosn = fb_.cosnv[idx_nk] / fb_.nscale[n];
-          const double sinn = fb_.sinnv[idx_nk] / fb_.nscale[n];
+          const real_t cosn = fb_.cosnv[idx_nk] / fb_.nscale[n];
+          const real_t sinn = fb_.sinnv[idx_nk] / fb_.nscale[n];
 
-          const double kernel_odd =
+          const real_t kernel_odd =
               (greenp[klpOff + kl] - greenp[klpOff + klRev]) * 0.5;
 
           // TODO(jons): finish this when implementing non-stellarator-symmetric
@@ -105,15 +105,15 @@ void LaplaceSolver::TransformGreensFunctionDerivative(
       for (int m = 0; m < mf + 1; ++m) {
         const int idx_lm = l * (s_.mnyq2 + 1) + m;
 
-        double cosmui = fb_.cosmui[idx_lm] / fb_.mscale[m];
-        double sinmui = fb_.sinmui[idx_lm] / fb_.mscale[m];
+        real_t cosmui = fb_.cosmui[idx_lm] / fb_.mscale[m];
+        real_t sinmui = fb_.sinmui[idx_lm] / fb_.mscale[m];
 
         for (int n = 0; n < nf + 1; ++n) {
           const int idx_m_posn = (nf + n) * (mf + 1) + m;
           const int idx_m_negn = (nf - n) * (mf + 1) + m;
 
-          const double gcos_symm = g1_symm[n] * sinmui;
-          const double gsin_symm = g2_symm[n] * cosmui;
+          const real_t gcos_symm = g1_symm[n] * sinmui;
+          const real_t gsin_symm = g2_symm[n] * cosmui;
 
           grpmn_sin[idx_m_posn * numLocal + klpRel] += gcos_symm - gsin_symm;
           if (n > 0) {
@@ -125,7 +125,7 @@ void LaplaceSolver::TransformGreensFunctionDerivative(
   }  // kl'
 }  // TransformGreensFunctionDerivative
 
-void LaplaceSolver::SymmetriseSourceTerm(const std::vector<double> &gstore) {
+void LaplaceSolver::SymmetriseSourceTerm(const std::vector<real_t> &gstore) {
   for (int l = 0; l < s_.nThetaReduced; ++l) {
     int lRev = (s_.nThetaEven - l) % s_.nThetaEven;
     for (int k = 0; k < s_.nZeta; ++k) {
@@ -141,7 +141,7 @@ void LaplaceSolver::SymmetriseSourceTerm(const std::vector<double> &gstore) {
 }  // SymmetriseSourceTerm
 
 void LaplaceSolver::AccumulateFullGrpmn(
-    const std::vector<double> &grpmn_sin_singular) {
+    const std::vector<real_t> &grpmn_sin_singular) {
   const int mnpd = (mf + 1) * (2 * nf + 1);
   for (int mn = 0; mn < mnpd; ++mn) {
     for (int klp = tp_.ztMin; klp < tp_.ztMax; ++klp) {
@@ -166,8 +166,8 @@ void LaplaceSolver::PerformToroidalFourierTransforms() {
       for (int k = 0; k < s_.nZeta; ++k) {
         const int idx_nk = n * s_.nZeta + k;
 
-        const double cosn = fb_.cosnv[idx_nk] / fb_.nscale[n];
-        const double sinn = fb_.sinnv[idx_nk] / fb_.nscale[n];
+        const real_t cosn = fb_.cosnv[idx_nk] / fb_.nscale[n];
+        const real_t sinn = fb_.sinnv[idx_nk] / fb_.nscale[n];
 
         const int idx_kl = l * s_.nZeta + k;
 
@@ -206,8 +206,8 @@ void LaplaceSolver::PerformToroidalFourierTransforms() {
         const int idx_a_posn =
             (mn * (2 * nf + 1) + (nf + n)) * s_.nThetaEff + l;
 
-        const double cosn = fb_.cosnv[idx_nk] / fb_.nscale[n];
-        const double sinn = fb_.sinnv[idx_nk] / fb_.nscale[n];
+        const real_t cosn = fb_.cosnv[idx_nk] / fb_.nscale[n];
+        const real_t sinn = fb_.sinnv[idx_nk] / fb_.nscale[n];
 
         actemp[idx_a_posn] += cosn * grpmn_sin[mn * numLocal + klpRel];
         astemp[idx_a_posn] += sinn * grpmn_sin[mn * numLocal + klpRel];
@@ -243,8 +243,8 @@ void LaplaceSolver::PerformPoloidalFourierTransforms() {
       for (int l = 0; l < s_.nThetaReduced; ++l) {
         const int idx_lm = l * (s_.mnyq2 + 1) + m;
 
-        double cosmui = fb_.cosmui[idx_lm] / fb_.mscale[m];
-        double sinmui = fb_.sinmui[idx_lm] / fb_.mscale[m];
+        real_t cosmui = fb_.cosmui[idx_lm] / fb_.mscale[m];
+        real_t sinmui = fb_.sinmui[idx_lm] / fb_.mscale[m];
 
         const int idx_l_all_n = all_n * s_.nThetaReduced + l;
         bvec_sin[all_n * (mf + 1) + m] +=
@@ -264,8 +264,8 @@ void LaplaceSolver::PerformPoloidalFourierTransforms() {
         for (int m = 0; m < mf + 1; ++m) {
           const int idx_lm = l * (s_.mnyq2 + 1) + m;
 
-          const double cosmui = fb_.cosmui[idx_lm] / fb_.mscale[m];
-          const double sinmui = fb_.sinmui[idx_lm] / fb_.mscale[m];
+          const real_t cosmui = fb_.cosmui[idx_lm] / fb_.mscale[m];
+          const real_t sinmui = fb_.sinmui[idx_lm] / fb_.mscale[m];
 
           const int idx_atemp = (mn * (2 * nf + 1) + all_n) * s_.nThetaEff + l;
 
@@ -344,7 +344,8 @@ void LaplaceSolver::DecomposeMatrix() {
   // perform LU factorization of the matrix
   // (only needed when matrix is updated --> every nvacskip iterations)
   int info;
-  dgetrf_(&mnpd, &mnpd, matrixShare.data(), &mnpd, iPiv.data(), &info);
+  dgetrf_(&mnpd, &mnpd, reinterpret_cast<double *>(matrixShare.data()), &mnpd,
+          iPiv.data(), &info);
 
   if (info < 0) {
     std::cout << -info << "-th argument to dgetrf is wrong\n";
@@ -358,7 +359,7 @@ void LaplaceSolver::DecomposeMatrix() {
 }  // DecomposeMatrix
 
 void LaplaceSolver::SolveForPotential(
-    const std::vector<double> &bvec_sin_singular) {
+    const std::vector<real_t> &bvec_sin_singular) {
   int mnpd = (mf + 1) * (2 * nf + 1);
 #ifdef _OPENMP
 #pragma omp single
@@ -399,8 +400,9 @@ void LaplaceSolver::SolveForPotential(
     int one = 1;
     int info;
     char no_transpose = 'N';
-    dgetrs_(&no_transpose, &mnpd, &one, matrixShare.data(), &mnpd, iPiv.data(),
-            bvecShare.data(), &mnpd, &info);
+    dgetrs_(&no_transpose, &mnpd, &one,
+            reinterpret_cast<double *>(matrixShare.data()), &mnpd, iPiv.data(),
+            reinterpret_cast<double *>(bvecShare.data()), &mnpd, &info);
 
     if (info < 0) {
       std::cout << -info << "-th argument to dgetrs wrong\n";

--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.h
@@ -18,39 +18,39 @@ class LaplaceSolver {
  public:
   LaplaceSolver(const Sizes* s, const FourierBasisFastToroidal* fb,
                 const TangentialPartitioning* tp, int nf, int mf,
-                std::span<double> matrixShare, std::span<int> iPiv,
-                std::span<double> bvecShare);
+                std::span<real_t> matrixShare, std::span<int> iPiv,
+                std::span<real_t> bvecShare);
 
-  void TransformGreensFunctionDerivative(const std::vector<double>& greenp);
-  void SymmetriseSourceTerm(const std::vector<double>& gstore);
-  void AccumulateFullGrpmn(const std::vector<double>& grpmn_sin_singular);
+  void TransformGreensFunctionDerivative(const std::vector<real_t>& greenp);
+  void SymmetriseSourceTerm(const std::vector<real_t>& gstore);
+  void AccumulateFullGrpmn(const std::vector<real_t>& grpmn_sin_singular);
   void PerformToroidalFourierTransforms();
   void PerformPoloidalFourierTransforms();
 
   void BuildMatrix();
   void DecomposeMatrix();
-  void SolveForPotential(const std::vector<double>& bvec_sin_singular);
+  void SolveForPotential(const std::vector<real_t>& bvec_sin_singular);
 
   // Green's function derivative Fourier transform, non-singular part,
   // stellarator-symmetric
-  std::vector<double> grpmn_sin;
+  std::vector<real_t> grpmn_sin;
 
   // Green's function derivative Fourier transform, non-singular part,
   // non-stellarator-symmetric
-  std::vector<double> grpmn_cos;
+  std::vector<real_t> grpmn_cos;
 
   // symmetrized source term, stellarator-symmetric
-  std::vector<double> gstore_symm;
+  std::vector<real_t> gstore_symm;
 
-  std::vector<double> bcos;
-  std::vector<double> bsin;
+  std::vector<real_t> bcos;
+  std::vector<real_t> bsin;
 
-  std::vector<double> actemp;
-  std::vector<double> astemp;
+  std::vector<real_t> actemp;
+  std::vector<real_t> astemp;
 
   // linear system to be solved
-  std::vector<double> bvec_sin;
-  std::vector<double> amat_sin_sin;
+  std::vector<real_t> bvec_sin;
+  std::vector<real_t> amat_sin_sin;
 
  private:
   const Sizes& s_;
@@ -62,16 +62,16 @@ class LaplaceSolver {
 
   // needed for LAPACK's dgetrf
   // non-owning pointers
-  std::span<double> matrixShare;
+  std::span<real_t> matrixShare;
   std::span<int> iPiv;
-  std::span<double> bvecShare;
+  std::span<real_t> bvecShare;
 
   // ----------------
 
   int numLocal;
 
-  std::vector<double> grpOdd;
-  std::vector<double> grpEvn;
+  std::vector<real_t> grpOdd;
+  std::vector<real_t> grpEvn;
 };
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.cc
@@ -7,11 +7,11 @@
 namespace vmecpp {
 
 Nestor::Nestor(const Sizes* s, const TangentialPartitioning* tp,
-               const MGridProvider* mgrid, std::span<double> matrixShare,
-               std::span<double> bvecShare, std::span<double> bSqVacShare,
-               std::span<int> iPiv, std::span<double> vacuum_b_r_share,
-               std::span<double> vacuum_b_phi_share,
-               std::span<double> vacuum_b_z_share)
+               const MGridProvider* mgrid, std::span<real_t> matrixShare,
+               std::span<real_t> bvecShare, std::span<real_t> bSqVacShare,
+               std::span<int> iPiv, std::span<real_t> vacuum_b_r_share,
+               std::span<real_t> vacuum_b_phi_share,
+               std::span<real_t> vacuum_b_z_share)
     : FreeBoundaryBase(s, tp, mgrid, bSqVacShare, vacuum_b_r_share,
                        vacuum_b_phi_share, vacuum_b_z_share),
       nf(s_.ntor),
@@ -30,13 +30,13 @@ Nestor::Nestor(const Sizes* s, const TangentialPartitioning* tp,
 }
 
 bool Nestor::update(
-    const std::span<const double> rCC, const std::span<const double> rSS,
-    const std::span<const double> rSC, const std::span<const double> rCS,
-    const std::span<const double> zSC, const std::span<const double> zCS,
-    const std::span<const double> zCC, const std::span<const double> zSS,
-    int signOfJacobian, const std::span<const double> rAxis,
-    const std::span<const double> zAxis, double* bSubUVac, double* bSubVVac,
-    double netToroidalCurrent, int ivacskip,
+    const std::span<const real_t> rCC, const std::span<const real_t> rSS,
+    const std::span<const real_t> rSC, const std::span<const real_t> rCS,
+    const std::span<const real_t> zSC, const std::span<const real_t> zCS,
+    const std::span<const real_t> zCC, const std::span<const real_t> zSS,
+    int signOfJacobian, const std::span<const real_t> rAxis,
+    const std::span<const real_t> zAxis, real_t* bSubUVac, real_t* bSubVVac,
+    real_t netToroidalCurrent, int ivacskip,
     const VmecCheckpoint& vmec_checkpoint, bool at_checkpoint_iteration) {
   if (vmec_checkpoint == VmecCheckpoint::VAC1_VACUUM &&
       at_checkpoint_iteration) {

--- a/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.h
@@ -24,20 +24,20 @@ namespace vmecpp {
 class Nestor : public FreeBoundaryBase {
  public:
   Nestor(const Sizes* s, const TangentialPartitioning* tp,
-         const MGridProvider* mgrid, std::span<double> matrixShare,
-         std::span<double> bvecShare, std::span<double> bSqVacShare,
-         std::span<int> iPiv, std::span<double> vacuum_b_r_share,
-         std::span<double> vacuum_b_phi_share,
-         std::span<double> vacuum_b_z_share);
+         const MGridProvider* mgrid, std::span<real_t> matrixShare,
+         std::span<real_t> bvecShare, std::span<real_t> bSqVacShare,
+         std::span<int> iPiv, std::span<real_t> vacuum_b_r_share,
+         std::span<real_t> vacuum_b_phi_share,
+         std::span<real_t> vacuum_b_z_share);
 
   bool update(
-      const std::span<const double> rCC, const std::span<const double> rSS,
-      const std::span<const double> rSC, const std::span<const double> rCS,
-      const std::span<const double> zSC, const std::span<const double> zCS,
-      const std::span<const double> zCC, const std::span<const double> zSS,
-      int signOfJacobian, const std::span<const double> rAxis,
-      const std::span<const double> zAxis, double* bSubUVac, double* bSubVVac,
-      double netToroidalCurrent, int ivacskip,
+      const std::span<const real_t> rCC, const std::span<const real_t> rSS,
+      const std::span<const real_t> rSC, const std::span<const real_t> rCS,
+      const std::span<const real_t> zSC, const std::span<const real_t> zCS,
+      const std::span<const real_t> zCC, const std::span<const real_t> zSS,
+      int signOfJacobian, const std::span<const real_t> rAxis,
+      const std::span<const real_t> zAxis, real_t* bSubUVac, real_t* bSubVVac,
+      real_t netToroidalCurrent, int ivacskip,
       const VmecCheckpoint& vmec_checkpoint = VmecCheckpoint::NONE,
       bool at_checkpoint_iteration = false) final;
 
@@ -46,12 +46,12 @@ class Nestor : public FreeBoundaryBase {
   const LaplaceSolver& GetLaplaceSolver() const;
 
   // tangential derivatives of scalar magnetic potential
-  Eigen::VectorXd potU;
-  Eigen::VectorXd potV;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> potU;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> potV;
 
   // covariant magnetic field components on surface
-  Eigen::VectorXd bSubU;
-  Eigen::VectorXd bSubV;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bSubU;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bSubV;
 
  private:
   // tangential Fourier resolution
@@ -64,7 +64,7 @@ class Nestor : public FreeBoundaryBase {
   RegularizedIntegrals ri_;
   LaplaceSolver ls_;
 
-  std::span<double> bvecShare;
+  std::span<real_t> bvecShare;
 };
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.cc
@@ -7,21 +7,21 @@
 namespace vmecpp {
 
 OnlyCoils::OnlyCoils(const Sizes* s, const TangentialPartitioning* tp,
-                     const MGridProvider* mgrid, std::span<double> bSqVacShare,
-                     std::span<double> vacuum_b_r_share,
-                     std::span<double> vacuum_b_phi_share,
-                     std::span<double> vacuum_b_z_share)
+                     const MGridProvider* mgrid, std::span<real_t> bSqVacShare,
+                     std::span<real_t> vacuum_b_r_share,
+                     std::span<real_t> vacuum_b_phi_share,
+                     std::span<real_t> vacuum_b_z_share)
     : FreeBoundaryBase(s, tp, mgrid, bSqVacShare, vacuum_b_r_share,
                        vacuum_b_phi_share, vacuum_b_z_share) {}  // OnlyCoils
 
 bool OnlyCoils::update(
-    const std::span<const double> rCC, const std::span<const double> rSS,
-    const std::span<const double> rSC, const std::span<const double> rCS,
-    const std::span<const double> zSC, const std::span<const double> zCS,
-    const std::span<const double> zCC, const std::span<const double> zSS,
-    int signOfJacobian, const std::span<const double> rAxis,
-    const std::span<const double> zAxis, double* bSubUVac, double* bSubVVac,
-    double netToroidalCurrent, int ivacskip,
+    const std::span<const real_t> rCC, const std::span<const real_t> rSS,
+    const std::span<const real_t> rSC, const std::span<const real_t> rCS,
+    const std::span<const real_t> zSC, const std::span<const real_t> zCS,
+    const std::span<const real_t> zCC, const std::span<const real_t> zSS,
+    int signOfJacobian, const std::span<const real_t> rAxis,
+    const std::span<const real_t> zAxis, real_t* bSubUVac, real_t* bSubVVac,
+    real_t netToroidalCurrent, int ivacskip,
     const VmecCheckpoint& vmec_checkpoint, bool at_checkpoint_iteration) {
   // only need surface geometry, not all derived quantities
   bool full_update = false;
@@ -34,8 +34,8 @@ bool OnlyCoils::update(
   ef_.update(rAxis, zAxis, 0.0);
 
   // compute net covariant magnetic field components on surface
-  double local_bsubuvac = 0.0;
-  double local_bsubvvac = 0.0;
+  real_t local_bsubuvac = 0.0;
+  real_t local_bsubvvac = 0.0;
   for (int kl = tp_.ztMin; kl < tp_.ztMax; ++kl) {
     int l = kl / s_.nZeta;
     local_bsubuvac += ef_.bSubU[kl - tp_.ztMin] * s_.wInt[l];

--- a/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.h
@@ -18,19 +18,19 @@ namespace vmecpp {
 class OnlyCoils : public FreeBoundaryBase {
  public:
   OnlyCoils(const Sizes* s, const TangentialPartitioning* tp,
-            const MGridProvider* mgrid, std::span<double> bSqVacShare,
-            std::span<double> vacuum_b_r_share,
-            std::span<double> vacuum_b_phi_share,
-            std::span<double> vacuum_b_z_share);
+            const MGridProvider* mgrid, std::span<real_t> bSqVacShare,
+            std::span<real_t> vacuum_b_r_share,
+            std::span<real_t> vacuum_b_phi_share,
+            std::span<real_t> vacuum_b_z_share);
 
   bool update(
-      const std::span<const double> rCC, const std::span<const double> rSS,
-      const std::span<const double> rSC, const std::span<const double> rCS,
-      const std::span<const double> zSC, const std::span<const double> zCS,
-      const std::span<const double> zCC, const std::span<const double> zSS,
-      int signOfJacobian, const std::span<const double> rAxis,
-      const std::span<const double> zAxis, double* bSubUVac, double* bSubVVac,
-      double netToroidalCurrent, int ivacskip,
+      const std::span<const real_t> rCC, const std::span<const real_t> rSS,
+      const std::span<const real_t> rSC, const std::span<const real_t> rCS,
+      const std::span<const real_t> zSC, const std::span<const real_t> zCS,
+      const std::span<const real_t> zCC, const std::span<const real_t> zSS,
+      int signOfJacobian, const std::span<const real_t> rAxis,
+      const std::span<const real_t> zAxis, real_t* bSubUVac, real_t* bSubVVac,
+      real_t netToroidalCurrent, int ivacskip,
       const VmecCheckpoint& vmec_checkpoint = VmecCheckpoint::NONE,
       bool at_checkpoint_iteration = false) final;
 };

--- a/src/vmecpp/cpp/vmecpp/free_boundary/regularized_integrals/regularized_integrals.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/regularized_integrals/regularized_integrals.cc
@@ -34,11 +34,11 @@ RegularizedIntegrals::RegularizedIntegrals(const Sizes* s,
 }
 
 void RegularizedIntegrals::computeConstants() {
-  const double epsTan = 1.0e-15;
-  const double bigNo = 1.0e50;
+  const real_t epsTan = 1.0e-15;
+  const real_t bigNo = 1.0e50;
 
   for (int l = 0; l < s_.nThetaEven; ++l) {
-    const double argu = M_PI / s_.nThetaEven * l;
+    const real_t argu = M_PI / s_.nThetaEven * l;
     if (std::abs(argu - 0.5 * M_PI) < epsTan) {
       // mask singularities at pi/2
       tanu[l] = bigNo;
@@ -48,7 +48,7 @@ void RegularizedIntegrals::computeConstants() {
   }  // l
 
   for (int k = 0; k < s_.nZeta; ++k) {
-    const double argv = M_PI / s_.nZeta * k;
+    const real_t argv = M_PI / s_.nZeta * k;
     if (std::abs(argv - 0.5 * M_PI) < epsTan) {
       // mask singularity at pi/2
       tanv[k] = bigNo;
@@ -58,30 +58,30 @@ void RegularizedIntegrals::computeConstants() {
   }  // k
 }
 
-void RegularizedIntegrals::update(const std::vector<double>& bDotN) {
+void RegularizedIntegrals::update(const std::vector<real_t>& bDotN) {
   // thread-local tangential grid point range
   const int numLocal = tp_.ztMax - tp_.ztMin;
   const int theta_by_nzeta = s_.nThetaEven * s_.nZeta;
-  const double twopidivnfp = 2.0 * M_PI / s_.nfp;
+  const real_t twopidivnfp = 2.0 * M_PI / s_.nfp;
 
   absl::c_fill_n(greenp, numLocal * theta_by_nzeta, 0);
   absl::c_fill_n(gstore, theta_by_nzeta, 0);
 
   // storage for intermediate results
-  std::vector<double> ga1_buf(s_.nZeta);
-  std::vector<double> ga2_buf(s_.nZeta);
-  std::vector<double> htemp_buf(s_.nZeta);
-  std::vector<double> ftemp_buf(s_.nZeta);
+  std::vector<real_t> ga1_buf(s_.nZeta);
+  std::vector<real_t> ga2_buf(s_.nZeta);
+  std::vector<real_t> htemp_buf(s_.nZeta);
+  std::vector<real_t> ftemp_buf(s_.nZeta);
 
   for (int klp = tp_.ztMin; klp < tp_.ztMax; ++klp) {
     const int ip_idx_base = (klp - tp_.ztMin) * theta_by_nzeta;
     int lp = klp / s_.nZeta;
     int kp = klp % s_.nZeta;
 
-    double bexni = bDotN[klp - tp_.ztMin] * s_.wInt[lp];
+    real_t bexni = bDotN[klp - tp_.ztMin] * s_.wInt[lp];
 
-    double xp = sg_.rcosuv[klp];
-    double yp = sg_.rsinuv[klp];
+    real_t xp = sg_.rcosuv[klp];
+    real_t yp = sg_.rsinuv[klp];
 
     // index of toridal field period; 0, 1, ..., (nfp-1)
     int p = 0;
@@ -90,13 +90,13 @@ void RegularizedIntegrals::update(const std::vector<double>& bDotN) {
     // yper == yp in first period
     // sxsave == snr in first period (TODO(jons): really?)
     // sysave == snv in first period (TODO(jons): really?)
-    double xper = xp * sg_.cos_per[p] - yp * sg_.sin_per[p];
-    double yper = xp * sg_.sin_per[p] + yp * sg_.cos_per[p];
+    real_t xper = xp * sg_.cos_per[p] - yp * sg_.sin_per[p];
+    real_t yper = xp * sg_.sin_per[p] + yp * sg_.cos_per[p];
 
-    double sxsave =
+    real_t sxsave =
         (sg_.snr[klp - tp_.ztMin] * xper - sg_.snv[klp - tp_.ztMin] * yper) /
         sg_.r1b[klp];
-    double sysave =
+    real_t sysave =
         (sg_.snr[klp - tp_.ztMin] * yper + sg_.snv[klp - tp_.ztMin] * xper) /
         sg_.r1b[klp];
 
@@ -159,7 +159,7 @@ void RegularizedIntegrals::update(const std::vector<double>& bDotN) {
                                  (sg_.rcosuv[kl] * sxsave +
                                   sg_.rsinuv[kl] * sysave + dsave[kl]) -
                              ga1_buf[k] * ga2_buf[k]);
-          const double g = twopidivnfp * (htemp_buf[k] - ga1_buf[k]);
+          const real_t g = twopidivnfp * (htemp_buf[k] - ga1_buf[k]);
           gstore[kl] += bexni * g;
         }
       }  // kl
@@ -173,27 +173,27 @@ void RegularizedIntegrals::update(const std::vector<double>& bDotN) {
 
     // all following field periods
     for (int p = 1; p < s_.nfp; ++p) {
-      double xper = xp * sg_.cos_per[p] - yp * sg_.sin_per[p];
-      double yper = xp * sg_.sin_per[p] + yp * sg_.cos_per[p];
-      double sxsave =
+      real_t xper = xp * sg_.cos_per[p] - yp * sg_.sin_per[p];
+      real_t yper = xp * sg_.sin_per[p] + yp * sg_.cos_per[p];
+      real_t sxsave =
           (sg_.snr[klp - tp_.ztMin] * xper - sg_.snv[klp - tp_.ztMin] * yper) /
           sg_.r1b[klp];
-      double sysave =
+      real_t sysave =
           (sg_.snr[klp - tp_.ztMin] * yper + sg_.snv[klp - tp_.ztMin] * xper) /
           sg_.r1b[klp];
 
       for (int kl = 0; kl < theta_by_nzeta; ++kl) {
-        double ftemp =
+        real_t ftemp =
             1.0 /
             (gsave[kl] - 2 * (xper * sg_.rcosuv[kl] + yper * sg_.rsinuv[kl]));
-        double htemp = sqrt(ftemp);
+        real_t htemp = sqrt(ftemp);
 
         // 2 pi from Laplace equation (TODO(jons): really?)
         // 1/nfp to make the toroidal integral below over the whole machine
         greenp[ip_idx_base + kl] +=
             twopidivnfp * htemp * ftemp *
             (sg_.rcosuv[kl] * sxsave + sg_.rsinuv[kl] * sysave + dsave[kl]);
-        const double g = twopidivnfp * htemp;
+        const real_t g = twopidivnfp * htemp;
         gstore[kl] += bexni * g;
       }  // kl
     }  // p

--- a/src/vmecpp/cpp/vmecpp/free_boundary/regularized_integrals/regularized_integrals.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/regularized_integrals/regularized_integrals.h
@@ -20,16 +20,16 @@ class RegularizedIntegrals {
   RegularizedIntegrals(const Sizes* s, const TangentialPartitioning* tp,
                        const SurfaceGeometry* sg);
 
-  void update(const std::vector<double>& bDotN);
+  void update(const std::vector<real_t>& bDotN);
 
-  std::vector<double> gsave;
-  std::vector<double> dsave;
+  std::vector<real_t> gsave;
+  std::vector<real_t> dsave;
 
-  std::vector<double> tanu;
-  std::vector<double> tanv;
+  std::vector<real_t> tanu;
+  std::vector<real_t> tanv;
 
-  std::vector<double> greenp;
-  std::vector<double> gstore;
+  std::vector<real_t> greenp;
+  std::vector<real_t> gstore;
 
  private:
   const Sizes& s_;

--- a/src/vmecpp/cpp/vmecpp/free_boundary/singular_integrals/singular_integrals.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/singular_integrals/singular_integrals.cc
@@ -98,9 +98,9 @@ void SingularIntegrals::computeCoefficients() {
       // also: s_mn = 0.5*(m + n + abs(m - n)) == max(m, n)
       int s_mn = std::max(m, n);
 
-      double f1 = 1.0;
-      double f2 = 1.0;
-      double f3 = 1.0;
+      real_t f1 = 1.0;
+      real_t f2 = 1.0;
+      real_t f3 = 1.0;
 
       for (int i = 1; i <= k_mn; ++i) {
         f1 *= s_mn - i + 1;
@@ -156,7 +156,7 @@ void SingularIntegrals::computeCoefficients() {
   }  // n
 }  // computeCoefficients
 
-void SingularIntegrals::update(const std::vector<double>& bDotN,
+void SingularIntegrals::update(const std::vector<real_t>& bDotN,
                                bool fullUpdate) {
 #ifdef _OPENMP
 #pragma omp barrier
@@ -176,12 +176,12 @@ void SingularIntegrals::update(const std::vector<double>& bDotN,
 #endif  // _OPENMP
 }  // update
 
-void SingularIntegrals::prepareUpdate(const std::vector<double>& a,
-                                      const std::vector<double>& b2,
-                                      const std::vector<double>& c,
-                                      const std::vector<double>& A,
-                                      const std::vector<double>& B2,
-                                      const std::vector<double>& C,
+void SingularIntegrals::prepareUpdate(const std::vector<real_t>& a,
+                                      const std::vector<real_t>& b2,
+                                      const std::vector<real_t>& c,
+                                      const std::vector<real_t>& A,
+                                      const std::vector<real_t>& B2,
+                                      const std::vector<real_t>& C,
                                       bool fullUpdate) {
   int numLocal = tp_.ztMax - tp_.ztMin;
   for (int kl = 0; kl < numLocal; ++kl) {
@@ -215,14 +215,14 @@ void SingularIntegrals::prepareUpdate(const std::vector<double>& a,
       Ra1m[kl] = Am[kl] / am[kl];
     }  // fullUpdate
 
-    const double sqrtap = sqrt(ap[kl]);
-    const double sqrtam = sqrt(am[kl]);
+    const real_t sqrtap = sqrt(ap[kl]);
+    const real_t sqrtam = sqrt(am[kl]);
 
     // Compute T^{\pm}_0 analytically (eq. 6.207 in the_numerics_of_vmecpp.pdf).
-    const double T0p = log((sqrtap * sqrtc2[kl] + ap[kl] + d[kl]) /
+    const real_t T0p = log((sqrtap * sqrtc2[kl] + ap[kl] + d[kl]) /
                            (sqrtap * sqrta2[kl] - ap[kl] + d[kl])) /
                        sqrtap;
-    const double T0m = log((sqrtam * sqrtc2[kl] + am[kl] + d[kl]) /
+    const real_t T0m = log((sqrtam * sqrtc2[kl] + am[kl] + d[kl]) /
                            (sqrtam * sqrta2[kl] - am[kl] + d[kl])) /
                        sqrtam;
 
@@ -256,25 +256,25 @@ void SingularIntegrals::prepareUpdate(const std::vector<double>& a,
     // Near-degenerate kl (|r1|~|r2|~1) fall in the forward branch, where
     // zero-seed Miller is known to misconverge (spurious modes never damp).
     // Formula: kL * ln(B/A) < ln(1e10) -> B/A < exp(ln(1e10)/kL).
-    constexpr double kLogGrowthThreshold = 10.0 * 2.30258509299;  // ln(1e10)
-    const double logRatioP =
+    constexpr real_t kLogGrowthThreshold = 10.0 * 2.30258509299;  // ln(1e10)
+    const real_t logRatioP =
         (am[kl] > ap[kl] && ap[kl] > 0.0) ? std::log(am[kl] / ap[kl]) : 0.0;
     const bool useBackwardP =
-        static_cast<double>(kL) * logRatioP > kLogGrowthThreshold;
-    const double logRatioM =
+        static_cast<real_t>(kL) * logRatioP > kLogGrowthThreshold;
+    const real_t logRatioM =
         (ap[kl] > am[kl] && am[kl] > 0.0) ? std::log(ap[kl] / am[kl]) : 0.0;
     const bool useBackwardM =
-        static_cast<double>(kL) * logRatioM > kLogGrowthThreshold;
+        static_cast<real_t>(kL) * logRatioM > kLogGrowthThreshold;
 
     // --- T^+: A = ap, B = am ---
     Tlp[0][kl] = T0p;
     if (useBackwardP) {
       // forward unstable -> use backward recurrence.
-      double T_hi = 0.0;
-      double T_cur = 1.0e-300;
+      real_t T_hi = 0.0;
+      real_t T_cur = 1.0e-300;
       for (int l = kLtail; l >= 1; --l) {
-        const double rhs = sqrtc2[kl] + (l % 2 == 0 ? -1.0 : 1.0) * sqrta2[kl];
-        const double T_lo =
+        const real_t rhs = sqrtc2[kl] + (l % 2 == 0 ? -1.0 : 1.0) * sqrta2[kl];
+        const real_t T_lo =
             (rhs - (2 * l + 1) * d[kl] * T_cur - (l + 1) * ap[kl] * T_hi) /
             (l * am[kl]);
         T_hi = T_cur;
@@ -283,18 +283,18 @@ void SingularIntegrals::prepareUpdate(const std::vector<double>& a,
           Tlp[l - 1][kl] = T_lo;
         }
       }
-      const double scaleP = T0p / Tlp[0][kl];
+      const real_t scaleP = T0p / Tlp[0][kl];
       for (int l = 0; l <= kL; ++l) {
         Tlp[l][kl] *= scaleP;
       }
     } else {
       // forward stable.
-      double T_prev = 0.0;  // T^+_{-1}
+      real_t T_prev = 0.0;  // T^+_{-1}
       int sgn = 1;
       for (int fl = 0; fl < kL; ++fl) {
         sgn = -sgn;
-        const double rhs = sqrtc2[kl] + sgn * sqrta2[kl];
-        const double T_next =
+        const real_t rhs = sqrtc2[kl] + sgn * sqrta2[kl];
+        const real_t T_next =
             (rhs - (2 * fl + 1) * d[kl] * Tlp[fl][kl] - fl * am[kl] * T_prev) /
             (ap[kl] * (fl + 1));
         T_prev = Tlp[fl][kl];
@@ -306,11 +306,11 @@ void SingularIntegrals::prepareUpdate(const std::vector<double>& a,
     Tlm[0][kl] = T0m;
     if (useBackwardM) {
       // forward unstable -> use backward recurrence.
-      double T_hi = 0.0;
-      double T_cur = 1.0e-300;
+      real_t T_hi = 0.0;
+      real_t T_cur = 1.0e-300;
       for (int l = kLtail; l >= 1; --l) {
-        const double rhs = sqrtc2[kl] + (l % 2 == 0 ? -1.0 : 1.0) * sqrta2[kl];
-        const double T_lo =
+        const real_t rhs = sqrtc2[kl] + (l % 2 == 0 ? -1.0 : 1.0) * sqrta2[kl];
+        const real_t T_lo =
             (rhs - (2 * l + 1) * d[kl] * T_cur - (l + 1) * am[kl] * T_hi) /
             (l * ap[kl]);
         T_hi = T_cur;
@@ -319,18 +319,18 @@ void SingularIntegrals::prepareUpdate(const std::vector<double>& a,
           Tlm[l - 1][kl] = T_lo;
         }
       }
-      const double scaleM = T0m / Tlm[0][kl];
+      const real_t scaleM = T0m / Tlm[0][kl];
       for (int l = 0; l <= kL; ++l) {
         Tlm[l][kl] *= scaleM;
       }
     } else {
       // forward stable.
-      double T_prev = 0.0;  // T^-_{-1}
+      real_t T_prev = 0.0;  // T^-_{-1}
       int sgn = 1;
       for (int fl = 0; fl < kL; ++fl) {
         sgn = -sgn;
-        const double rhs = sqrtc2[kl] + sgn * sqrta2[kl];
-        const double T_next =
+        const real_t rhs = sqrtc2[kl] + sgn * sqrta2[kl];
+        const real_t T_next =
             (rhs - (2 * fl + 1) * d[kl] * Tlm[fl][kl] - fl * ap[kl] * T_prev) /
             (am[kl] * (fl + 1));
         T_prev = Tlm[fl][kl];
@@ -340,7 +340,7 @@ void SingularIntegrals::prepareUpdate(const std::vector<double>& a,
   }  // kl
 }  // prepareUpdate
 
-void SingularIntegrals::performUpdate(const std::vector<double>& bDotN,
+void SingularIntegrals::performUpdate(const std::vector<real_t>& bDotN,
                                       bool fullUpdate) {
   const int numLocal = tp_.ztMax - tp_.ztMin;
 
@@ -386,7 +386,7 @@ void SingularIntegrals::performUpdate(const std::vector<double>& bDotN,
         const int idx_m_negn = (nf - n) * (mf + 1) + m;
 
         const int idx_lnm = (fl * (nf + 1) + n) * (mf + 1) + m;
-        const double cmns_factor =
+        const real_t cmns_factor =
             cmns[idx_lnm] / (fb_.mscale[m] * fb_.nscale[n]);
 
         if (n == 0 || m == 0) {
@@ -401,7 +401,7 @@ void SingularIntegrals::performUpdate(const std::vector<double>& bDotN,
             const int idx_nk = n * s_.nZeta + k;
 
             // sin(mu - |n|v) * cmns(l,n,m)
-            const double sinp = (fb_.sinmu[idx_lm] * fb_.cosnv[idx_nk] -
+            const real_t sinp = (fb_.sinmu[idx_lm] * fb_.cosnv[idx_nk] -
                                  fb_.cosmu[idx_lm] * fb_.sinnv[idx_nk]) *
                                 cmns_factor;
 
@@ -414,7 +414,7 @@ void SingularIntegrals::performUpdate(const std::vector<double>& bDotN,
 
             if (s_.lasym) {
               // cos(mu - |n|v) * cmns(l,n,m)
-              const double cosp = (fb_.cosmu[idx_lm] * fb_.cosnv[idx_nk] +
+              const real_t cosp = (fb_.cosmu[idx_lm] * fb_.cosnv[idx_nk] +
                                    fb_.sinmu[idx_lm] * fb_.sinnv[idx_nk]) *
                                   cmns_factor;
 
@@ -436,11 +436,11 @@ void SingularIntegrals::performUpdate(const std::vector<double>& bDotN,
             const int idx_lm = l * (s_.mnyq2 + 1) + m;
             const int remaining = std::min(s_.nZeta - k, tp_.ztMax - kl);
 
-            const double coeff1 = fb_.sinmu[idx_lm] * cmns_factor;
-            const double coeff2 = fb_.cosmu[idx_lm] * cmns_factor;
+            const real_t coeff1 = fb_.sinmu[idx_lm] * cmns_factor;
+            const real_t coeff2 = fb_.cosmu[idx_lm] * cmns_factor;
 
-            std::array<double, 4> buf_m_posn{};
-            std::array<double, 4> buf_m_negn{};
+            std::array<real_t, 4> buf_m_posn{};
+            std::array<real_t, 4> buf_m_negn{};
 
             int i = 0;
             for (; i + 3 < remaining; i += 4, k += 4, kl += 4) {
@@ -449,18 +449,18 @@ void SingularIntegrals::performUpdate(const std::vector<double>& bDotN,
               const int idx_nk = n * s_.nZeta + k;
 
               const double c0 = bDotN[klRel + 0] * s_.wInt[l];
-              const double c1 = bDotN[klRel + 1] * s_.wInt[l];
-              const double c2 = bDotN[klRel + 2] * s_.wInt[l];
-              const double c3 = bDotN[klRel + 3] * s_.wInt[l];
+              const real_t c1 = bDotN[klRel + 1] * s_.wInt[l];
+              const real_t c2 = bDotN[klRel + 2] * s_.wInt[l];
+              const real_t c3 = bDotN[klRel + 3] * s_.wInt[l];
 
               // sin(mu - |n|v) * cmns(l,n,m)
-              const double sinp0 = coeff1 * fb_.cosnv[idx_nk + 0] -
+              const real_t sinp0 = coeff1 * fb_.cosnv[idx_nk + 0] -
                                    coeff2 * fb_.sinnv[idx_nk + 0];
-              const double sinp1 = coeff1 * fb_.cosnv[idx_nk + 1] -
+              const real_t sinp1 = coeff1 * fb_.cosnv[idx_nk + 1] -
                                    coeff2 * fb_.sinnv[idx_nk + 1];
-              const double sinp2 = coeff1 * fb_.cosnv[idx_nk + 2] -
+              const real_t sinp2 = coeff1 * fb_.cosnv[idx_nk + 2] -
                                    coeff2 * fb_.sinnv[idx_nk + 2];
-              const double sinp3 = coeff1 * fb_.cosnv[idx_nk + 3] -
+              const real_t sinp3 = coeff1 * fb_.cosnv[idx_nk + 3] -
                                    coeff2 * fb_.sinnv[idx_nk + 3];
 
               buf_m_posn[0] += Tlp[fl][klRel + 0] * c0 * sinp0;
@@ -469,13 +469,13 @@ void SingularIntegrals::performUpdate(const std::vector<double>& bDotN,
               buf_m_posn[3] += Tlp[fl][klRel + 3] * c3 * sinp3;
 
               // sin(mu + |n|v) * cmns(l,n,m)
-              const double sinm0 = coeff1 * fb_.cosnv[idx_nk + 0] +
+              const real_t sinm0 = coeff1 * fb_.cosnv[idx_nk + 0] +
                                    coeff2 * fb_.sinnv[idx_nk + 0];
-              const double sinm1 = coeff1 * fb_.cosnv[idx_nk + 1] +
+              const real_t sinm1 = coeff1 * fb_.cosnv[idx_nk + 1] +
                                    coeff2 * fb_.sinnv[idx_nk + 1];
-              const double sinm2 = coeff1 * fb_.cosnv[idx_nk + 2] +
+              const real_t sinm2 = coeff1 * fb_.cosnv[idx_nk + 2] +
                                    coeff2 * fb_.sinnv[idx_nk + 2];
-              const double sinm3 = coeff1 * fb_.cosnv[idx_nk + 3] +
+              const real_t sinm3 = coeff1 * fb_.cosnv[idx_nk + 3] +
                                    coeff2 * fb_.sinnv[idx_nk + 3];
 
               buf_m_negn[0] += Tlm[fl][klRel + 0] * c0 * sinm0;
@@ -515,18 +515,18 @@ void SingularIntegrals::performUpdate(const std::vector<double>& bDotN,
                 const int klRel = kl - tp_.ztMin;
                 const int idx_nk = n * s_.nZeta + k;
 
-                const double coeff1 =
+                const real_t coeff1 =
                     fb_.sinmu[idx_lm] * fb_.cosnv[idx_nk] * cmns_factor;
-                const double coeff2 =
+                const real_t coeff2 =
                     fb_.cosmu[idx_lm] * fb_.sinnv[idx_nk] * cmns_factor;
 
                 // sin(mu + |n|v) * cmns(l,n,m)
-                const double sinm = coeff1 + coeff2;
+                const real_t sinm = coeff1 + coeff2;
 
                 // sin(mu - |n|v) * cmns(l,n,m)
-                const double sinp = coeff1 - coeff2;
+                const real_t sinp = coeff1 - coeff2;
 
-                const double c = bDotN[klRel] * s_.wInt[l];
+                const real_t c = bDotN[klRel] * s_.wInt[l];
                 bvec_sin[idx_m_posn] += Tlp[fl][klRel] * c * sinp;
                 bvec_sin[idx_m_negn] += Tlm[fl][klRel] * c * sinm;
 
@@ -552,16 +552,16 @@ void SingularIntegrals::performUpdate(const std::vector<double>& bDotN,
               const int idx_lm = l * (s_.mnyq2 + 1) + m;
               const int idx_nk = n * s_.nZeta + k;
 
-              const double coeff1 =
+              const real_t coeff1 =
                   fb_.cosmu[idx_lm] * fb_.cosnv[idx_nk] * cmns_factor;
-              const double coeff2 =
+              const real_t coeff2 =
                   fb_.sinmu[idx_lm] * fb_.sinnv[idx_nk] * cmns_factor;
 
               // cos(mu + |n|v) * cmns(l,n,m)
-              const double cosm = coeff1 - coeff2;
+              const real_t cosm = coeff1 - coeff2;
 
               // cos(mu - |n|v) * cmns(l,n,m)
-              const double cosp = coeff1 + coeff2;
+              const real_t cosp = coeff1 + coeff2;
 
               bvec_cos[idx_m_posn] +=
                   Tlp[fl][klRel] * bDotN[klRel] * s_.wInt[l] * cosp;

--- a/src/vmecpp/cpp/vmecpp/free_boundary/singular_integrals/singular_integrals.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/singular_integrals/singular_integrals.h
@@ -21,68 +21,68 @@ class SingularIntegrals {
                     const TangentialPartitioning* tp, const SurfaceGeometry* sg,
                     int nf, int mf);
 
-  void update(const std::vector<double>& bDotN, bool fullUpdate);
+  void update(const std::vector<real_t>& bDotN, bool fullUpdate);
 
   int numSC;
   int numCS;
   int nzLen;  // non-zero length
 
-  std::vector<double> cmn;
-  std::vector<double> cmns;
+  std::vector<real_t> cmn;
+  std::vector<real_t> cmns;
 
-  std::vector<double> ap;
-  std::vector<double> am;
-  std::vector<double> d;
-  std::vector<double> sqrtc2;
-  std::vector<double> sqrta2;
-  std::vector<double> delta4;
+  std::vector<real_t> ap;
+  std::vector<real_t> am;
+  std::vector<real_t> d;
+  std::vector<real_t> sqrtc2;
+  std::vector<real_t> sqrta2;
+  std::vector<real_t> delta4;
 
-  std::vector<double> Ap;
-  std::vector<double> Am;
-  std::vector<double> D;
+  std::vector<real_t> Ap;
+  std::vector<real_t> Am;
+  std::vector<real_t> D;
 
-  std::vector<double> R1p;
-  std::vector<double> R1m;
-  std::vector<double> R0p;
-  std::vector<double> R0m;
-  std::vector<double> Ra1p;
-  std::vector<double> Ra1m;
+  std::vector<real_t> R1p;
+  std::vector<real_t> R1m;
+  std::vector<real_t> R0p;
+  std::vector<real_t> R0m;
+  std::vector<real_t> Ra1p;
+  std::vector<real_t> Ra1m;
 
   // l-2
-  std::vector<double> Tl2p;
+  std::vector<real_t> Tl2p;
   // l-2
-  std::vector<double> Tl2m;
+  std::vector<real_t> Tl2m;
   // l-1
-  std::vector<double> Tl1p;
+  std::vector<real_t> Tl1p;
   // l-1
-  std::vector<double> Tl1m;
+  std::vector<real_t> Tl1m;
   // l
-  std::vector<std::vector<double> > Tlp;
+  std::vector<std::vector<real_t> > Tlp;
   // l
-  std::vector<std::vector<double> > Tlm;
+  std::vector<std::vector<real_t> > Tlm;
 
   // l
-  std::vector<std::vector<double> > Slp;
+  std::vector<std::vector<real_t> > Slp;
   // l
-  std::vector<std::vector<double> > Slm;
+  std::vector<std::vector<real_t> > Slm;
 
   // sum_kl { Tlm * sin(mu + nv), Tlp * sin(mu - nv) }
-  std::vector<double> bvec_sin;
+  std::vector<real_t> bvec_sin;
 
   // sum_kl { Tlm * cos(mu + nv), Tlp * cos(mu - nv) }
-  std::vector<double> bvec_cos;
+  std::vector<real_t> bvec_cos;
 
   // Slm * sin(mu + nv), Slp * sin(mu - nv)
-  std::vector<double> grpmn_sin;
+  std::vector<real_t> grpmn_sin;
 
   // Slm * cos(mu + nv), Slp * cos(mu - nv)
-  std::vector<double> grpmn_cos;
+  std::vector<real_t> grpmn_cos;
 
-  void prepareUpdate(const std::vector<double>& a,
-                     const std::vector<double>& b2,
-                     const std::vector<double>& c, const std::vector<double>& A,
-                     const std::vector<double>& B2,
-                     const std::vector<double>& C, bool fullUpdate);
+  void prepareUpdate(const std::vector<real_t>& a,
+                     const std::vector<real_t>& b2,
+                     const std::vector<real_t>& c, const std::vector<real_t>& A,
+                     const std::vector<real_t>& B2,
+                     const std::vector<real_t>& C, bool fullUpdate);
 
  private:
   const Sizes& s_;
@@ -92,7 +92,7 @@ class SingularIntegrals {
 
   void computeCoefficients();
 
-  void performUpdate(const std::vector<double>& bDotN, bool fullUpdate);
+  void performUpdate(const std::vector<real_t>& bDotN, bool fullUpdate);
 
   int nf;
   int mf;

--- a/src/vmecpp/cpp/vmecpp/free_boundary/singular_integrals/singular_integrals_test.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/singular_integrals/singular_integrals_test.cc
@@ -218,18 +218,18 @@ TEST_P(TlpTlmAccuracyTest, MatchesQuadrature) {
   ASSERT_LT(d * d, ap * am) << "test setup: need smooth integrand on [-1,1]";
 
   const int numLocal = tp.ztMax - tp.ztMin;
-  std::vector<double> a(numLocal, a_val);
-  std::vector<double> b2(numLocal, b2_val);
-  std::vector<double> c(numLocal, c_val);
-  std::vector<double> A(numLocal, 0.0);
-  std::vector<double> B2(numLocal, 0.0);
-  std::vector<double> C(numLocal, 0.0);
+  std::vector<real_t> a(numLocal, a_val);
+  std::vector<real_t> b2(numLocal, b2_val);
+  std::vector<real_t> c(numLocal, c_val);
+  std::vector<real_t> A(numLocal, 0.0);
+  std::vector<real_t> B2(numLocal, 0.0);
+  std::vector<real_t> C(numLocal, 0.0);
 
   si.prepareUpdate(a, b2, c, A, B2, C, /*fullUpdate=*/false);
 
   // Reference values via Gauss-Legendre, independent of either recurrence.
-  std::vector<double> Tp_ref(kL + 1);
-  std::vector<double> Tm_ref(kL + 1);
+  std::vector<real_t> Tp_ref(kL + 1);
+  std::vector<real_t> Tm_ref(kL + 1);
   for (int l = 0; l <= kL; ++l) {
     Tp_ref[l] = TlpReference(l, ap, am, d);
     Tm_ref[l] = TlmReference(l, ap, am, d);

--- a/src/vmecpp/cpp/vmecpp/free_boundary/surface_geometry/surface_geometry.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/surface_geometry/surface_geometry.cc
@@ -62,16 +62,16 @@ SurfaceGeometry::SurfaceGeometry(const Sizes* s,
 }
 
 void SurfaceGeometry::computeConstants() {
-  double omega_per = 2.0 * M_PI / s_.nfp;
+  real_t omega_per = 2.0 * M_PI / s_.nfp;
   for (int p = 0; p < s_.nfp; ++p) {
-    double phi_per = omega_per * p;
+    real_t phi_per = omega_per * p;
     cos_per[p] = cos(phi_per);
     sin_per[p] = sin(phi_per);
   }
 
-  double omega_phi = 2.0 * M_PI / (s_.nfp * s_.nZeta);
+  real_t omega_phi = 2.0 * M_PI / (s_.nfp * s_.nZeta);
   for (int k = 0; k < s_.nZeta; ++k) {
-    double phi = omega_phi * k;
+    real_t phi = omega_phi * k;
     cos_phi[k] = cos(phi);
     sin_phi[k] = sin(phi);
   }
@@ -80,10 +80,10 @@ void SurfaceGeometry::computeConstants() {
 // Evaluate the Fourier series for the surface geometry
 // and compute quantities depending on it.
 void SurfaceGeometry::update(
-    const std::span<const double> rCC, const std::span<const double> rSS,
-    const std::span<const double> rSC, const std::span<const double> rCS,
-    const std::span<const double> zSC, const std::span<const double> zCS,
-    const std::span<const double> zCC, const std::span<const double> zSS,
+    const std::span<const real_t> rCC, const std::span<const real_t> rSS,
+    const std::span<const real_t> rSC, const std::span<const real_t> rCS,
+    const std::span<const real_t> zSC, const std::span<const real_t> zCS,
+    const std::span<const real_t> zCC, const std::span<const real_t> zSS,
     int signOfJacobian, bool fullUpdate) {
 #ifdef _OPENMP
 #pragma omp barrier
@@ -106,10 +106,10 @@ void SurfaceGeometry::update(
 // geometry into realspace and compute 1st- and 2nd-order tangential
 // derivatives.
 void SurfaceGeometry::inverseDFT(
-    const std::span<const double> rCC, const std::span<const double> rSS,
-    const std::span<const double> rSC, const std::span<const double> rCS,
-    const std::span<const double> zSC, const std::span<const double> zCS,
-    const std::span<const double> zCC, const std::span<const double> zSS,
+    const std::span<const real_t> rCC, const std::span<const real_t> rSS,
+    const std::span<const real_t> rSC, const std::span<const real_t> rCS,
+    const std::span<const real_t> zSC, const std::span<const real_t> zCS,
+    const std::span<const real_t> zCC, const std::span<const real_t> zSS,
     bool fullUpdate) {
   // TODO(jons): implement lasym-related code
   (void)rSC;
@@ -147,22 +147,22 @@ void SurfaceGeometry::inverseDFT(
     int lMax = tp_.ztMax / s_.nZeta;
 
     for (int l = 0; l < s_.nThetaReduced; ++l) {
-      double rmkcc = 0.0;
-      double rmkss = 0.0;
-      double zmksc = 0.0;
-      double zmkcs = 0.0;
+      real_t rmkcc = 0.0;
+      real_t rmkss = 0.0;
+      real_t zmksc = 0.0;
+      real_t zmkcs = 0.0;
 
       // ----------------
 
-      double rmkcc_m = 0.0;
-      double rmkcc_mm = 0.0;
-      double rmkss_m = 0.0;
-      double rmkss_mm = 0.0;
+      real_t rmkcc_m = 0.0;
+      real_t rmkcc_mm = 0.0;
+      real_t rmkss_m = 0.0;
+      real_t rmkss_mm = 0.0;
 
-      double zmksc_m = 0.0;
-      double zmksc_mm = 0.0;
-      double zmkcs_m = 0.0;
-      double zmkcs_mm = 0.0;
+      real_t zmksc_m = 0.0;
+      real_t zmksc_mm = 0.0;
+      real_t zmkcs_m = 0.0;
+      real_t zmkcs_mm = 0.0;
 
       for (int m = 0; m < s_.mpol; ++m) {
         int idx_mn = n * s_.mpol + m;
@@ -170,8 +170,8 @@ void SurfaceGeometry::inverseDFT(
         // needed for second-order poloidal derivatives
         int mSq = m * m;
 
-        double cosmu = fb_.cosmu[l * (s_.mnyq2 + 1) + m];
-        double sinmu = fb_.sinmu[l * (s_.mnyq2 + 1) + m];
+        real_t cosmu = fb_.cosmu[l * (s_.mnyq2 + 1) + m];
+        real_t sinmu = fb_.sinmu[l * (s_.mnyq2 + 1) + m];
 
         rmkcc += rCC[idx_mn] * cosmu;
         rmkss += rSS[idx_mn] * sinmu;
@@ -186,10 +186,10 @@ void SurfaceGeometry::inverseDFT(
           // --> these would be excluded here, but they still need to do some
           // work here!
 
-          double cosmum = fb_.cosmum[l * (s_.mnyq2 + 1) + m];
-          double sinmum = fb_.sinmum[l * (s_.mnyq2 + 1) + m];
-          double cosmumm = -mSq * fb_.cosmu[l * (s_.mnyq2 + 1) + m];
-          double sinmumm = -mSq * fb_.sinmu[l * (s_.mnyq2 + 1) + m];
+          real_t cosmum = fb_.cosmum[l * (s_.mnyq2 + 1) + m];
+          real_t sinmum = fb_.sinmum[l * (s_.mnyq2 + 1) + m];
+          real_t cosmumm = -mSq * fb_.cosmu[l * (s_.mnyq2 + 1) + m];
+          real_t sinmumm = -mSq * fb_.sinmu[l * (s_.mnyq2 + 1) + m];
 
           rmkcc_m += rCC[idx_mn] * sinmum;
           rmkcc_mm += rCC[idx_mn] * cosmumm;
@@ -206,8 +206,8 @@ void SurfaceGeometry::inverseDFT(
       for (int k = 0; k < s_.nZeta; ++k) {
         int idx_kl = l * s_.nZeta + k;
 
-        double cosnv = fb_.cosnv[n * s_.nZeta + k];
-        double sinnv = fb_.sinnv[n * s_.nZeta + k];
+        real_t cosnv = fb_.cosnv[n * s_.nZeta + k];
+        real_t sinnv = fb_.sinnv[n * s_.nZeta + k];
 
         r1b[idx_kl] += rmkcc * cosnv + rmkss * sinnv;
         z1b[idx_kl] += zmksc * cosnv + zmkcs * sinnv;
@@ -215,8 +215,8 @@ void SurfaceGeometry::inverseDFT(
         // ----------------
 
         if (tp_.ztMin <= idx_kl && idx_kl < tp_.ztMax) {
-          double cosnvn = fb_.cosnvn[n * s_.nZeta + k];
-          double sinnvn = fb_.sinnvn[n * s_.nZeta + k];
+          real_t cosnvn = fb_.cosnvn[n * s_.nZeta + k];
+          real_t sinnvn = fb_.sinnvn[n * s_.nZeta + k];
 
           rub[idx_kl - tp_.ztMin] += rmkcc_m * cosnv + rmkss_m * sinnv;
           rvb[idx_kl - tp_.ztMin] += rmkcc * sinnvn + rmkss * cosnvn;
@@ -224,8 +224,8 @@ void SurfaceGeometry::inverseDFT(
           zvb[idx_kl - tp_.ztMin] += zmksc * sinnvn + zmkcs * cosnvn;
 
           if (fullUpdate) {
-            double cosnvnn = -nSq * fb_.cosnv[n * s_.nZeta + k];
-            double sinnvnn = -nSq * fb_.sinnv[n * s_.nZeta + k];
+            real_t cosnvnn = -nSq * fb_.cosnv[n * s_.nZeta + k];
+            real_t sinnvnn = -nSq * fb_.sinnv[n * s_.nZeta + k];
 
             ruu[idx_kl - tp_.ztMin] += rmkcc_mm * cosnv + rmkss_mm * sinnv;
             ruv[idx_kl - tp_.ztMin] += rmkcc_m * sinnvn + rmkss_m * cosnvn;

--- a/src/vmecpp/cpp/vmecpp/free_boundary/surface_geometry/surface_geometry.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/surface_geometry/surface_geometry.h
@@ -21,133 +21,133 @@ class SurfaceGeometry {
                   const TangentialPartitioning* tp);
 
   void update(
-      const std::span<const double> rCC, const std::span<const double> rSS,
-      const std::span<const double> rSC, const std::span<const double> rCS,
-      const std::span<const double> zSC, const std::span<const double> zCS,
-      const std::span<const double> zCC, const std::span<const double> zSS,
+      const std::span<const real_t> rCC, const std::span<const real_t> rSS,
+      const std::span<const real_t> rSC, const std::span<const real_t> rCS,
+      const std::span<const real_t> zSC, const std::span<const real_t> zCS,
+      const std::span<const real_t> zCC, const std::span<const real_t> zSS,
       int signOfJacobian, bool fullUpdate);
 
   // [nfp] cos(2 pi / nfp * p)
-  std::vector<double> cos_per;
+  std::vector<real_t> cos_per;
 
   // [nfp] sin(2 pi / nfp * p)
-  std::vector<double> sin_per;
+  std::vector<real_t> sin_per;
 
   // [nZeta] cos(phi)
-  std::vector<double> cos_phi;
+  std::vector<real_t> cos_phi;
 
   // [nZeta] sin(phi)
-  std::vector<double> sin_phi;
+  std::vector<real_t> sin_phi;
 
   // -----------------
 
   // R
   // full surface
-  std::vector<double> r1b;
+  std::vector<real_t> r1b;
 
   // dR/dTheta
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> rub;
+  std::vector<real_t> rub;
 
   // dR/dPhi
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> rvb;
+  std::vector<real_t> rvb;
 
   // Z
   // full surface
-  std::vector<double> z1b;
+  std::vector<real_t> z1b;
 
   // dZ/dTheta
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> zub;
+  std::vector<real_t> zub;
 
   // dZ/dPhi
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> zvb;
+  std::vector<real_t> zvb;
 
   // d^2R/dTheta^2
   // thread-local effective poloidal range (tp->numZT)
   // only needed within SurfaceGeometry() but public for testing
-  std::vector<double> ruu;
+  std::vector<real_t> ruu;
 
   // d^2R/(dTheta dPhi)
   // thread-local effective poloidal range (tp->numZT)
   // only needed within SurfaceGeometry() but public for testing
-  std::vector<double> ruv;
+  std::vector<real_t> ruv;
 
   // d^2R/dPhi^2
   // thread-local effective poloidal range (tp->numZT)
   // only needed within SurfaceGeometry() but public for testing
-  std::vector<double> rvv;
+  std::vector<real_t> rvv;
 
   // d^2Z/dTheta^2
   // thread-local effective poloidal range (tp->numZT)
   // only needed within SurfaceGeometry() but public for testing
-  std::vector<double> zuu;
+  std::vector<real_t> zuu;
 
   // d^2Z/(dTheta dPhi)
   // thread-local effective poloidal range (tp->numZT)
   // only needed within SurfaceGeometry() but public for testing
-  std::vector<double> zuv;
+  std::vector<real_t> zuv;
 
   // d^2Z/dPhi^2
   // thread-local effective poloidal range (tp->numZT)
   // only needed within SurfaceGeometry() but public for testing
-  std::vector<double> zvv;
+  std::vector<real_t> zvv;
 
   // N^r * signOfJacobian
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> snr;
+  std::vector<real_t> snr;
 
   // N^phi * signOfJacobian
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> snv;
+  std::vector<real_t> snv;
 
   // N^z * signOfJacobian
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> snz;
+  std::vector<real_t> snz;
 
   // g_{theta,theta}
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> guu;
+  std::vector<real_t> guu;
 
   // 2 * g_{theta,zeta} = 2/nfp * g_{theta,phi}
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> guv;
+  std::vector<real_t> guv;
 
   // g_{zeta,zeta} = 1/(nfp*nfp) g_{phi,phi}
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> gvv;
+  std::vector<real_t> gvv;
 
   // 1/2 d^2X/dTheta^2 dot N
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> auu;
+  std::vector<real_t> auu;
 
   // d^2X/(dTheta dZeta) dot N
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> auv;
+  std::vector<real_t> auv;
 
   // 1/2 d^2X/dZeta^2 dot N
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> avv;
+  std::vector<real_t> avv;
 
   // - (R N^R + Z N^Z)
   // needed for dsave --> (X - X') dot N'
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> drv;
+  std::vector<real_t> drv;
 
   // R^2 + Z^2
   // needed for gsave --> |X - X'|^2
   // full surface
-  std::vector<double> rzb2;
+  std::vector<real_t> rzb2;
 
   // x
   // full surface
-  std::vector<double> rcosuv;
+  std::vector<real_t> rcosuv;
 
   // y
   // full surface
-  std::vector<double> rsinuv;
+  std::vector<real_t> rsinuv;
 
  private:
   const Sizes& s_;
@@ -156,19 +156,19 @@ class SurfaceGeometry {
 
   void computeConstants();
 
-  void inverseDFT(const std::span<const double> rCC,
-                  const std::span<const double> rSS,
-                  const std::span<const double> rSC,
-                  const std::span<const double> rCS,
-                  const std::span<const double> zSC,
-                  const std::span<const double> zCS,
-                  const std::span<const double> zCC,
-                  const std::span<const double> zSS, bool fullUpdate);
+  void inverseDFT(const std::span<const real_t> rCC,
+                  const std::span<const real_t> rSS,
+                  const std::span<const real_t> rSC,
+                  const std::span<const real_t> rCS,
+                  const std::span<const real_t> zSC,
+                  const std::span<const real_t> zCS,
+                  const std::span<const real_t> zCC,
+                  const std::span<const real_t> zSS, bool fullUpdate);
 
   void derivedSurfaceQuantities(int signOfJacobian, bool fullUpdate);
 
-  std::vector<double> r1b_asym;
-  std::vector<double> z1b_asym;
+  std::vector<real_t> r1b_asym;
+  std::vector<real_t> z1b_asym;
 };
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/free_boundary/surface_geometry_mockup/surface_geometry_mockup.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/surface_geometry_mockup/surface_geometry_mockup.cc
@@ -45,45 +45,49 @@ SurfaceGeometryMockup SurfaceGeometryMockup::InitializeFromFile(
     LOG(FATAL) << xn.status().message();
   }
 
-  absl::StatusOr<std::vector<double>> rmnc =
+  absl::StatusOr<std::vector<real_t>> rmnc_double =
       composed_types::CoefficientsRCos(*maybe_surface);
-  if (!rmnc.ok()) {
-    LOG(FATAL) << rmnc.status().message();
+  if (!rmnc_double.ok()) {
+    LOG(FATAL) << rmnc_double.status().message();
   }
+  std::vector<real_t> rmnc(rmnc_double->begin(), rmnc_double->end());
 
-  absl::StatusOr<std::vector<double>> rmns =
+  absl::StatusOr<std::vector<real_t>> rmns_double =
       composed_types::CoefficientsRSin(*maybe_surface);
-  if (!rmns.ok()) {
-    LOG(FATAL) << rmns.status().message();
+  if (!rmns_double.ok()) {
+    LOG(FATAL) << rmns_double.status().message();
   }
+  std::vector<real_t> rmns(rmns_double->begin(), rmns_double->end());
 
-  absl::StatusOr<std::vector<double>> zmnc =
+  absl::StatusOr<std::vector<real_t>> zmnc_double =
       composed_types::CoefficientsZCos(*maybe_surface);
-  if (!zmnc.ok()) {
-    LOG(FATAL) << zmnc.status().message();
+  if (!zmnc_double.ok()) {
+    LOG(FATAL) << zmnc_double.status().message();
   }
+  std::vector<real_t> zmnc(zmnc_double->begin(), zmnc_double->end());
 
-  absl::StatusOr<std::vector<double>> zmns =
+  absl::StatusOr<std::vector<real_t>> zmns_double =
       composed_types::CoefficientsZSin(*maybe_surface);
-  if (!zmns.ok()) {
-    LOG(FATAL) << zmns.status().message();
+  if (!zmns_double.ok()) {
+    LOG(FATAL) << zmns_double.status().message();
   }
+  std::vector<real_t> zmns(zmns_double->begin(), zmns_double->end());
 
   const int mpol = std::ranges::max(*xm) + 1;
 
   // Note that this xn does not contain the nfp factor, as VMEC's xn does.
   const int ntor = std::ranges::max(*xn);
 
-  return SurfaceGeometryMockup(lasym, nfp, mpol, ntor, ntheta, nphi, *rmnc,
-                               *rmns, *zmns, *zmnc);
+  return SurfaceGeometryMockup(lasym, nfp, mpol, ntor, ntheta, nphi, rmnc, rmns,
+                               zmns, zmnc);
 }  // InitializeFromFile
 
 SurfaceGeometryMockup::SurfaceGeometryMockup(bool lasym, int nfp, int mpol,
                                              int ntor, int ntheta, int nphi,
-                                             std::vector<double>& m_rmnc,
-                                             std::vector<double>& m_rmns,
-                                             std::vector<double>& m_zmns,
-                                             std::vector<double>& m_zmnc,
+                                             std::vector<real_t>& m_rmnc,
+                                             std::vector<real_t>& m_rmns,
+                                             std::vector<real_t>& m_zmns,
+                                             std::vector<real_t>& m_zmnc,
                                              int num_threads, int thread_id)
     : lasym(lasym),
       rmnc(m_rmnc),
@@ -95,10 +99,10 @@ SurfaceGeometryMockup::SurfaceGeometryMockup(bool lasym, int nfp, int mpol,
       tp(s.nZnT, num_threads, thread_id),
       sg(&s, &fb, &tp) {
   // convert into 2D Fourier coefficient arrays
-  std::vector<double> rCC(s.mnsize);
-  std::vector<double> rSS(s.mnsize);
-  std::vector<double> rSC;
-  std::vector<double> rCS;
+  std::vector<real_t> rCC(s.mnsize);
+  std::vector<real_t> rSS(s.mnsize);
+  std::vector<real_t> rSC;
+  std::vector<real_t> rCS;
   fb.cos_to_cc_ss(m_rmnc, rCC, rSS, s.ntor, s.mpol);
   if (s.lasym) {
     rSC.resize(s.mnsize, 0.0);
@@ -106,10 +110,10 @@ SurfaceGeometryMockup::SurfaceGeometryMockup(bool lasym, int nfp, int mpol,
     fb.sin_to_sc_cs(m_rmns, rSC, rCS, s.ntor, s.mpol);
   }
 
-  std::vector<double> zSC(s.mnsize);
-  std::vector<double> zCS(s.mnsize);
-  std::vector<double> zCC;
-  std::vector<double> zSS;
+  std::vector<real_t> zSC(s.mnsize);
+  std::vector<real_t> zCS(s.mnsize);
+  std::vector<real_t> zCC;
+  std::vector<real_t> zSS;
   fb.sin_to_sc_cs(m_zmns, zSC, zCS, s.ntor, s.mpol);
   if (s.lasym) {
     zCC.resize(s.mnsize, 0.0);

--- a/src/vmecpp/cpp/vmecpp/free_boundary/surface_geometry_mockup/surface_geometry_mockup.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/surface_geometry_mockup/surface_geometry_mockup.h
@@ -27,17 +27,17 @@ class SurfaceGeometryMockup {
       bool lasym = false, int nphi = 36, int ntheta = 0, int nfp = 5);
 
   SurfaceGeometryMockup(bool lasym, int nfp, int mpol, int ntor, int ntheta,
-                        int nphi, std::vector<double>& m_rmnc,
-                        std::vector<double>& m_rmns,
-                        std::vector<double>& m_zmns,
-                        std::vector<double>& m_zmnc, int num_threads = 1,
+                        int nphi, std::vector<real_t>& m_rmnc,
+                        std::vector<real_t>& m_rmns,
+                        std::vector<real_t>& m_zmns,
+                        std::vector<real_t>& m_zmnc, int num_threads = 1,
                         int thread_id = 0);
 
   bool lasym;
-  std::vector<double> rmnc;
-  std::vector<double> rmns;
-  std::vector<double> zmns;
-  std::vector<double> zmnc;
+  std::vector<real_t> rmnc;
+  std::vector<real_t> rmns;
+  std::vector<real_t> zmns;
+  std::vector<real_t> zmnc;
 
   Sizes s;
   FourierBasisFastToroidal fb;

--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/boundaries.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/boundaries.cc
@@ -67,7 +67,7 @@ void Boundaries::parseToInternalArrays(const VmecINDATA& id, bool verbose) {
 
   // check for necessity to shift poloidal angle
   // to achieve unique poloidal angle
-  double delta = 0.0;
+  real_t delta = 0.0;
   if (s_.lasym) {
     // comment by Matt Landreman in Simsopt Slack:
     // > When lasym=.true.,  vmec claims to shift theta for the provided
@@ -106,8 +106,8 @@ void Boundaries::parseToInternalArrays(const VmecINDATA& id, bool verbose) {
   }
 
   for (int m = 0; m < s_.mpol; ++m) {
-    double cosMDelta = 1.0;
-    double sinMDelta = 0.0;
+    real_t cosMDelta = 1.0;
+    real_t sinMDelta = 0.0;
     if (delta != 0.0) {
       cosMDelta = cos(m * delta);
       sinMDelta = sin(m * delta);
@@ -118,10 +118,10 @@ void Boundaries::parseToInternalArrays(const VmecINDATA& id, bool verbose) {
       int source_n = s_.ntor + n;
 
       int target_n = abs(n);
-      double sign_n = signum(n);
+      real_t sign_n = signum(n);
 
-      double rbc;
-      double zbs;
+      real_t rbc;
+      real_t zbs;
       if (!s_.lasym || delta == 0.0) {
         rbc = id.rbc(m, source_n);
         zbs = id.zbs(m, source_n);
@@ -146,8 +146,8 @@ void Boundaries::parseToInternalArrays(const VmecINDATA& id, bool verbose) {
       }
 
       if (s_.lasym) {
-        double rbs;
-        double zbc;
+        real_t rbs;
+        real_t zbc;
         if (delta == 0.0) {
           rbs = (*id.rbs)(m, source_n);
           zbc = (*id.zbc)(m, source_n);
@@ -182,8 +182,8 @@ bool Boundaries::checkSignOfJacobian() {
    * clockwise.
    */
 
-  double rTest = 0.0;
-  double zTest = 0.0;
+  real_t rTest = 0.0;
+  real_t zTest = 0.0;
   for (int n = 0; n < s_.ntor + 1; ++n) {
     int m = 1;
     int idx_mn = m * (s_.ntor + 1) + n;
@@ -236,17 +236,17 @@ void Boundaries::flipTheta() {
  * Essentially, the initial boundary is re-scaled to yield a unique poloidal
  * origin.
  */
-void Boundaries::ensureM1Constrained(const double scaling_factor) {
+void Boundaries::ensureM1Constrained(const real_t scaling_factor) {
   for (int n = 0; n <= s_.ntor; ++n) {
     int m = 1;
     int idx_mn = m * (s_.ntor + 1) + n;
     if (s_.lthreed) {
-      double backup_rss = rbss[idx_mn];
+      real_t backup_rss = rbss[idx_mn];
       rbss[idx_mn] = (backup_rss + zbcs[idx_mn]) * scaling_factor;
       zbcs[idx_mn] = (backup_rss - zbcs[idx_mn]) * scaling_factor;
     }
     if (s_.lasym) {
-      double backup_rsc = rbsc[idx_mn];
+      real_t backup_rsc = rbsc[idx_mn];
       rbsc[idx_mn] = (backup_rsc + zbcc[idx_mn]) * scaling_factor;
       zbcc[idx_mn] = (backup_rsc - zbcc[idx_mn]) * scaling_factor;
     }

--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/boundaries.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/boundaries.h
@@ -9,6 +9,7 @@
 
 #include "vmecpp/common/fourier_basis_fast_poloidal/fourier_basis_fast_poloidal.h"
 #include "vmecpp/common/sizes/sizes.h"
+#include "vmecpp/common/util/real_type.h"
 #include "vmecpp/common/util/util.h"
 #include "vmecpp/common/vmec_indata/vmec_indata.h"
 
@@ -21,7 +22,7 @@ class Boundaries {
              int sign_of_jacobian);
 
   bool setupFromIndata(const VmecINDATA& id, bool verbose = true);
-  void ensureM1Constrained(double scaling_factor);
+  void ensureM1Constrained(real_t scaling_factor);
 
   // This object is initialized with an initial guess for the magnetic axis
   // geometry via setupFromIndata() that is provided by the user. This method
@@ -36,20 +37,20 @@ class Boundaries {
   void RecomputeMagneticAxisToFixJacobianSign(int number_of_flux_surfaces,
                                               int sign_of_jacobian);
 
-  Eigen::VectorXd raxis_c;
-  Eigen::VectorXd zaxis_s;
-  Eigen::VectorXd raxis_s;
-  Eigen::VectorXd zaxis_c;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> raxis_c;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zaxis_s;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> raxis_s;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zaxis_c;
 
-  Eigen::VectorXd rbcc;
-  Eigen::VectorXd rbss;
-  Eigen::VectorXd rbsc;
-  Eigen::VectorXd rbcs;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rbcc;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rbss;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rbsc;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rbcs;
 
-  Eigen::VectorXd zbsc;
-  Eigen::VectorXd zbcs;
-  Eigen::VectorXd zbcc;
-  Eigen::VectorXd zbss;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zbsc;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zbcs;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zbcc;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zbss;
 
  private:
   const Sizes& s_;

--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/guess_magnetic_axis.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/guess_magnetic_axis.cc
@@ -11,13 +11,19 @@ namespace vmecpp {
 
 RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
     int number_of_flux_surfaces, int sign_of_jacobian, const Sizes& s,
-    const FourierBasisFastPoloidal& t, const Eigen::VectorXd& rbcc,
-    const Eigen::VectorXd& rbss, const Eigen::VectorXd& rbsc,
-    const Eigen::VectorXd& rbcs, const Eigen::VectorXd& zbsc,
-    const Eigen::VectorXd& zbcs, const Eigen::VectorXd& zbcc,
-    const Eigen::VectorXd& zbss, const Eigen::VectorXd& raxis_c,
-    const Eigen::VectorXd& raxis_s, const Eigen::VectorXd& zaxis_s,
-    const Eigen::VectorXd& zaxis_c) {
+    const FourierBasisFastPoloidal& t,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& rbcc,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& rbss,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& rbsc,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& rbcs,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& zbsc,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& zbcs,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& zbcc,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& zbss,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& raxis_c,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& raxis_s,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& zaxis_s,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& zaxis_c) {
   RecomputeAxisWorkspace w;
 
   w.r_axis.resize(s.nZeta);
@@ -82,23 +88,23 @@ RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
   const int ns12 = (number_of_flux_surfaces + 1) / 2 - 1;
 
   // radial step size between boundary (ns - 1) and ~mid-radius (ns12)
-  const double delta_s =
+  const real_t delta_s =
       (number_of_flux_surfaces - 1 - ns12) / (number_of_flux_surfaces - 1.0);
 
   // sqrt(s_j) at j = ns12, where s is the normalized radial coordinate
-  const double sqrtSF12 = std::sqrt(ns12 / (number_of_flux_surfaces - 1.0));
+  const real_t sqrtSF12 = std::sqrt(ns12 / (number_of_flux_surfaces - 1.0));
 
   // start: interpolate Fourier coefficients between initial guess for axis and
   // boundary
 
-  std::vector<std::vector<double> > rcc_half(s.mpol);
-  std::vector<std::vector<double> > rss_half;
-  std::vector<std::vector<double> > rsc_half;
-  std::vector<std::vector<double> > rcs_half;
-  std::vector<std::vector<double> > zsc_half(s.mpol);
-  std::vector<std::vector<double> > zcs_half;
-  std::vector<std::vector<double> > zcc_half;
-  std::vector<std::vector<double> > zss_half;
+  std::vector<std::vector<real_t> > rcc_half(s.mpol);
+  std::vector<std::vector<real_t> > rss_half;
+  std::vector<std::vector<real_t> > rsc_half;
+  std::vector<std::vector<real_t> > rcs_half;
+  std::vector<std::vector<real_t> > zsc_half(s.mpol);
+  std::vector<std::vector<real_t> > zcs_half;
+  std::vector<std::vector<real_t> > zcc_half;
+  std::vector<std::vector<real_t> > zss_half;
   if (s.lthreed) {
     rss_half.resize(s.mpol);
     zcs_half.resize(s.mpol);
@@ -113,11 +119,11 @@ RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
   }
 
   // undo m=1 constraint
-  const double scalingFactor = 1.0;
-  std::vector<std::vector<double> > rss_boundary;  // lthreed
-  std::vector<std::vector<double> > zcs_boundary;  // lthreed
-  std::vector<std::vector<double> > rsc_boundary;  // lasym
-  std::vector<std::vector<double> > zcc_boundary;  // lasym
+  const real_t scalingFactor = 1.0;
+  std::vector<std::vector<real_t> > rss_boundary;  // lthreed
+  std::vector<std::vector<real_t> > zcs_boundary;  // lthreed
+  std::vector<std::vector<real_t> > rsc_boundary;  // lasym
+  std::vector<std::vector<real_t> > zcc_boundary;  // lasym
   if (s.lthreed) {
     rss_boundary.resize(s.mpol);
     zcs_boundary.resize(s.mpol);
@@ -176,7 +182,7 @@ RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
 
       if (m == 0) {
         // m = 0: linear interpolation in s between axis and boundary
-        const double interpolation_weight = sqrtSF12 * sqrtSF12;
+        const real_t interpolation_weight = sqrtSF12 * sqrtSF12;
 
         rcc_half[m][n] = (interpolation_weight * rbcc[idx_mn] +
                           (1.0 - interpolation_weight) * raxis_c[n]);
@@ -202,7 +208,7 @@ RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
         }
       } else {
         // m > 0: scale boundary into volume by s^(m/2) == sqrt(s)^m == rho^m
-        const double interpolation_weight = std::pow(sqrtSF12, m);
+        const real_t interpolation_weight = std::pow(sqrtSF12, m);
 
         rcc_half[m][n] = interpolation_weight * rbcc[idx_mn];
         zsc_half[m][n] = interpolation_weight * zbsc[idx_mn];
@@ -246,7 +252,7 @@ RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
           int idx_kn = k * (s.nnyq2 + 1) + n;
           int idx_mn = m * (s.ntor + 1) + n;
 
-          const double basis_norm = 1.0 / (t.mscale[m] * t.nscale[n]);
+          const real_t basis_norm = 1.0 / (t.mscale[m] * t.nscale[n]);
 
           w.r_lcfs[k][l] +=
               basis_norm * rbcc[idx_mn] * t.cosmu[idx_ml] * t.cosnv[idx_kn];
@@ -366,7 +372,7 @@ RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
     for (int n = 0; n <= s.ntor; ++n) {
       int idx_kn = k * (s.nnyq2 + 1) + n;
 
-      const double basis_norm = 1.0 / (t.mscale[m0] * t.nscale[n]);
+      const real_t basis_norm = 1.0 / (t.mscale[m0] * t.nscale[n]);
 
       w.r_axis[k] += raxis_c[n] * t.cosnv[idx_kn] * basis_norm;
       w.z_axis[k] -= zaxis_s[n] * t.sinnv[idx_kn] * basis_norm;
@@ -381,18 +387,18 @@ RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
   // the new axis position is estimated
   for (int k = 0; k < s.nZeta / 2 + 1; ++k) {
     // compute grid extent
-    const double min_r =
+    const real_t min_r =
         *std::min_element(w.r_lcfs[k].begin(), w.r_lcfs[k].end());
-    const double max_r =
+    const real_t max_r =
         *std::max_element(w.r_lcfs[k].begin(), w.r_lcfs[k].end());
-    const double min_z =
+    const real_t min_z =
         *std::min_element(w.z_lcfs[k].begin(), w.z_lcfs[k].end());
-    const double max_z =
+    const real_t max_z =
         *std::max_element(w.z_lcfs[k].begin(), w.z_lcfs[k].end());
 
     // grid step sizes
-    const double delta_r = (max_r - min_r) / (kNumberOfGridPoints - 1.0);
-    const double delta_z = (max_z - min_z) / (kNumberOfGridPoints - 1.0);
+    const real_t delta_r = (max_r - min_r) / (kNumberOfGridPoints - 1.0);
+    const real_t delta_z = (max_z - min_z) / (kNumberOfGridPoints - 1.0);
 
     // compute initial guess for new axis: center of grid in each toroidal plane
     w.new_r_axis[k] = (max_r + min_r) / 2.0;
@@ -408,10 +414,10 @@ RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
                      w.d_z_d_theta_half[k][l] * w.d_r_d_s_half[k][l];
     }  // l
 
-    double min_tau = 0.0;
+    real_t min_tau = 0.0;
 
     for (int index_z = 0; index_z < kNumberOfGridPoints; ++index_z) {
-      double z_grid = min_z + index_z * delta_z;
+      real_t z_grid = min_z + index_z * delta_z;
 
       // early exit in some cases(?)
       if (!s.lasym && (k == 0 || k == s.nZeta / 2)) {
@@ -422,7 +428,7 @@ RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
       }
 
       for (int index_r = 0; index_r < kNumberOfGridPoints; ++index_r) {
-        double r_grid = min_r + index_r * delta_r;
+        real_t r_grid = min_r + index_r * delta_r;
 
         // Find position of magnetic axis that maximizes the minimum Jacobian
         // value.
@@ -433,7 +439,7 @@ RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
                          w.d_z_d_theta_half[k][l] * r_grid);
         }  // l
 
-        double min_tau_temp =
+        real_t min_tau_temp =
             *std::min_element(w.tau[k].begin(), w.tau[k].end());
 
         if (min_tau_temp > min_tau) {
@@ -462,7 +468,7 @@ RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
   }  // !lasym
 
   // Fourier-transform the axis guess
-  const double delta_v = 2.0 / s.nZeta;
+  const real_t delta_v = 2.0 / s.nZeta;
   for (int k = 0; k < s.nZeta; ++k) {
     for (int n = 0; n <= s.ntor; ++n) {
       // accumulate all contributions to the toroidal Fourier integral

--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/guess_magnetic_axis.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/guess_magnetic_axis.h
@@ -10,44 +10,45 @@
 
 #include "vmecpp/common/fourier_basis_fast_poloidal/fourier_basis_fast_poloidal.h"
 #include "vmecpp/common/sizes/sizes.h"
+#include "vmecpp/common/util/real_type.h"
 
 namespace vmecpp {
 
 // workspace for RecomputeMagneticAxisToFixJacobianSign
 struct RecomputeAxisWorkspace {
   // geometry of current (= from initial guess) axis: R, Z
-  std::vector<double> r_axis;
-  std::vector<double> z_axis;
+  std::vector<real_t> r_axis;
+  std::vector<real_t> z_axis;
 
   // geometry of boundary: R, Z, dR/dTheta, dR/dZeta
-  std::vector<std::vector<double> > r_lcfs;
-  std::vector<std::vector<double> > z_lcfs;
-  std::vector<std::vector<double> > d_r_d_theta_lcfs;
-  std::vector<std::vector<double> > d_z_d_theta_lcfs;
+  std::vector<std::vector<real_t> > r_lcfs;
+  std::vector<std::vector<real_t> > z_lcfs;
+  std::vector<std::vector<real_t> > d_r_d_theta_lcfs;
+  std::vector<std::vector<real_t> > d_z_d_theta_lcfs;
 
   // geometry at ~mid-radius: R, Z, dR/dTheta, dR/dZeta, dR/ds, dZ/ds
-  std::vector<std::vector<double> > r_half;
-  std::vector<std::vector<double> > z_half;
-  std::vector<std::vector<double> > d_r_d_theta_half;
-  std::vector<std::vector<double> > d_z_d_theta_half;
-  std::vector<std::vector<double> > d_r_d_s_half;
-  std::vector<std::vector<double> > d_z_d_s_half;
+  std::vector<std::vector<real_t> > r_half;
+  std::vector<std::vector<real_t> > z_half;
+  std::vector<std::vector<real_t> > d_r_d_theta_half;
+  std::vector<std::vector<real_t> > d_z_d_theta_half;
+  std::vector<std::vector<real_t> > d_r_d_s_half;
+  std::vector<std::vector<real_t> > d_z_d_s_half;
 
   // cylindrical part of the Jacobian
   // tau0 is the static part,
   // tau is the full thing
-  std::vector<std::vector<double> > tau0;
-  std::vector<std::vector<double> > tau;
+  std::vector<std::vector<real_t> > tau0;
+  std::vector<std::vector<real_t> > tau;
 
   // [nZeta] realspace geometry of the guess for the magnetic axis
-  std::vector<double> new_r_axis;
-  std::vector<double> new_z_axis;
+  std::vector<real_t> new_r_axis;
+  std::vector<real_t> new_z_axis;
 
   // [ntor + 1] Fourier coefficients of new axis
-  std::vector<double> new_raxis_c;
-  std::vector<double> new_raxis_s;
-  std::vector<double> new_zaxis_s;
-  std::vector<double> new_zaxis_c;
+  std::vector<real_t> new_raxis_c;
+  std::vector<real_t> new_raxis_s;
+  std::vector<real_t> new_zaxis_s;
+  std::vector<real_t> new_zaxis_c;
 };
 
 // This object is initialized with an initial guess for the magnetic axis
@@ -62,13 +63,19 @@ struct RecomputeAxisWorkspace {
 // done assuming the given number_of_flux_surfaces.
 RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
     int number_of_flux_surfaces, int sign_of_jacobian, const Sizes& s,
-    const FourierBasisFastPoloidal& t, const Eigen::VectorXd& rbcc,
-    const Eigen::VectorXd& rbss, const Eigen::VectorXd& rbsc,
-    const Eigen::VectorXd& rbcs, const Eigen::VectorXd& zbsc,
-    const Eigen::VectorXd& zbcs, const Eigen::VectorXd& zbcc,
-    const Eigen::VectorXd& zbss, const Eigen::VectorXd& raxis_c,
-    const Eigen::VectorXd& raxis_s, const Eigen::VectorXd& zaxis_s,
-    const Eigen::VectorXd& zaxis_c);
+    const FourierBasisFastPoloidal& t,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& rbcc,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& rbss,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& rbsc,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& rbcs,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& zbsc,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& zbcs,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& zbcc,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& zbss,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& raxis_c,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& raxis_s,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& zaxis_s,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& zaxis_c);
 
 }  // namespace vmecpp
 

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.cc
@@ -120,8 +120,9 @@ void FourierCoeffs::setZero() {
 }
 
 /** apply even/odd-m decomposition */
-void FourierCoeffs::decomposeInto(FourierCoeffs& m_x,
-                                  const Eigen::VectorXd& scalxc) const {
+void FourierCoeffs::decomposeInto(
+    FourierCoeffs& m_x,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& scalxc) const {
   // TODO(jons): understand correct limits in fixed-boundary vs. free-boundary
   int jMaxIncludingBoundary = nsMax_;
   if (r_.nsMaxF1 == ns) {
@@ -139,7 +140,7 @@ void FourierCoeffs::decomposeInto(FourierCoeffs& m_x,
         int m_parity = m % 2;
 
         // scalxc is always defined on numFull1
-        double scal = scalxc[(jF - r_.nsMinF1) * 2 + m_parity];
+        real_t scal = scalxc[(jF - r_.nsMinF1) * 2 + m_parity];
 
         if (jF < jMaxRZ) {
           m_x.rcc[idx_fc] = rcc[idx_fc] * scal;
@@ -173,7 +174,7 @@ void FourierCoeffs::decomposeInto(FourierCoeffs& m_x,
 }
 
 /** (un)do m=1 constraint to couple R_ss,Z_cs as well as R_sc,Z_cc */
-void FourierCoeffs::m1Constraint(double scalingFactor,
+void FourierCoeffs::m1Constraint(real_t scalingFactor,
                                  std::optional<int> jMax) {
   int nsMaxToUse = nsMax_;
   if (jMax.has_value()) {
@@ -185,12 +186,12 @@ void FourierCoeffs::m1Constraint(double scalingFactor,
       int m = 1;
       int idx_fc = ((jF - nsMin_) * s_.mpol + m) * (s_.ntor + 1) + n;
       if (s_.lthreed) {
-        double old_rss = rss[idx_fc];
+        real_t old_rss = rss[idx_fc];
         rss[idx_fc] = (old_rss + zcs[idx_fc]) * scalingFactor;
         zcs[idx_fc] = (old_rss - zcs[idx_fc]) * scalingFactor;
       }
       if (s_.lasym) {
-        double old_rsc = rsc[idx_fc];
+        real_t old_rsc = rsc[idx_fc];
         rsc[idx_fc] = (old_rsc + zcc[idx_fc]) * scalingFactor;
         zcc[idx_fc] = (old_rsc - zcc[idx_fc]) * scalingFactor;
       }
@@ -198,10 +199,10 @@ void FourierCoeffs::m1Constraint(double scalingFactor,
   }  // j
 }
 
-double FourierCoeffs::rzNorm(bool include_offset, int nsMinHere,
+real_t FourierCoeffs::rzNorm(bool include_offset, int nsMinHere,
                              int nsMaxHere) const {
   // accumulator for local thread
-  double local_norm2 = 0.0;
+  real_t local_norm2 = 0.0;
 
   for (int jF = nsMinHere; jF < nsMaxHere; ++jF) {
     for (int m = 0; m < s_.mpol; ++m) {
@@ -233,7 +234,7 @@ double FourierCoeffs::rzNorm(bool include_offset, int nsMinHere,
   return local_norm2;
 }
 
-double FourierCoeffs::GetXcElement(int rzl, int idx_basis, int jF, int n,
+real_t FourierCoeffs::GetXcElement(int rzl, int idx_basis, int jF, int n,
                                    int m) const {
   int idx_fc = ((jF - nsMin_) * s_.mpol + m) * (s_.ntor + 1) + n;
 

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.h
@@ -27,8 +27,10 @@ class FourierCoeffs {
 
   void setZero();
 
-  void decomposeInto(FourierCoeffs& m_x, const Eigen::VectorXd& scalxc) const;
-  void m1Constraint(double scalingFactor,
+  void decomposeInto(
+      FourierCoeffs& m_x,
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& scalxc) const;
+  void m1Constraint(real_t scalingFactor,
                     std::optional<int> jMax = std::nullopt);
 
   // Get the sum of squared coefficients for R and Z.
@@ -36,9 +38,9 @@ class FourierCoeffs {
   // left out. The range of flux surface to count in is specified as [nsMinHere,
   // nsMaxHere[ in order to allow to not count stuff twice at the borders in
   // different threads.
-  double rzNorm(bool includeOffset, int nsMinHere, int nsMaxHere) const;
+  real_t rzNorm(bool includeOffset, int nsMinHere, int nsMaxHere) const;
 
-  double GetXcElement(int rzl, int basis_index, int j, int n, int m) const;
+  real_t GetXcElement(int rzl, int basis_index, int j, int n, int m) const;
 
   int nsMin() const;
   int nsMax() const;
@@ -52,44 +54,44 @@ class FourierCoeffs {
   const int ns;
 
   // [ns x numFC] R ~ cos(m*theta)*cos(n*zeta)
-  Eigen::VectorXd rcc;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rcc;
 
   // [ns x numFC] R ~ sin(m*theta)*sin(n*zeta)
-  Eigen::VectorXd rss;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rss;
 
   // [ns x numFC] R ~ sin(m*theta)*cos(n*zeta)
-  Eigen::VectorXd rsc;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rsc;
 
   // [ns x numFC] R ~ cos(m*theta)*sin(n*zeta)
-  Eigen::VectorXd rcs;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rcs;
 
   //***************/
 
   // [ns x numFC] Z ~ sin(m*theta)*cos(n*zeta)
-  Eigen::VectorXd zsc;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zsc;
 
   // [ns x numFC] Z ~ cos(m*theta)*sin(n*zeta)
-  Eigen::VectorXd zcs;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zcs;
 
   // [ns x numFC] Z ~ cos(m*theta)*cos(n*zeta)
-  Eigen::VectorXd zcc;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zcc;
 
   // [ns x numFC] Z ~ sin(m*theta)*sin(n*zeta)
-  Eigen::VectorXd zss;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zss;
 
   //***************/
 
   // [ns x numFC] lambda ~ sin(m*theta)*cos(n*zeta)
-  Eigen::VectorXd lsc;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> lsc;
 
   // [ns x numFC] lambda ~ cos(m*theta)*sin(n*zeta)
-  Eigen::VectorXd lcs;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> lcs;
 
   // [ns x numFC] lambda ~ cos(m*theta)*cos(n*zeta)
-  Eigen::VectorXd lcc;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> lcc;
 
   // [ns x numFC] lambda ~ sin(m*theta)*sin(n*zeta)
-  Eigen::VectorXd lss;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> lss;
 };
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_forces/fourier_forces.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_forces/fourier_forces.cc
@@ -103,7 +103,7 @@ void FourierForces::zeroZForceForM1() {
 }
 
 /** Compute the force residuals and write them into the provided [3] array. */
-void FourierForces::residuals(Eigen::VectorXd& fRes,
+void FourierForces::residuals(Eigen::Matrix<real_t, Eigen::Dynamic, 1>& fRes,
                               bool includeEdgeRZForces) const {
   int jMaxRZ = std::min(nsMax_, ns - 1);
   if (includeEdgeRZForces && r_.nsMaxF1 == ns) {
@@ -115,9 +115,9 @@ void FourierForces::residuals(Eigen::VectorXd& fRes,
     jMaxIncludeBoundary = ns;
   }
 
-  double local_fResR = 0.0;
-  double local_fResZ = 0.0;
-  double local_fResL = 0.0;
+  real_t local_fResR = 0.0;
+  real_t local_fResZ = 0.0;
+  real_t local_fResL = 0.0;
   for (int jF = nsMin_; jF < jMaxIncludeBoundary; ++jF) {
     for (int m = 0; m < s_.mpol; ++m) {
       for (int n = 0; n < s_.ntor + 1; ++n) {

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_forces/fourier_forces.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_forces/fourier_forces.h
@@ -8,6 +8,7 @@
 #include <Eigen/Dense>
 #include <span>
 
+#include "vmecpp/common/util/real_type.h"
 #include "vmecpp/vmec/fourier_coefficients/fourier_coefficients.h"
 
 namespace vmecpp {
@@ -21,23 +22,24 @@ class FourierForces : public FourierCoeffs {
   FourierForces& operator=(FourierForces&& other) noexcept;
 
   void zeroZForceForM1();
-  void residuals(Eigen::VectorXd& fRes, bool includeEdgeRZ) const;
+  void residuals(Eigen::Matrix<real_t, Eigen::Dynamic, 1>& fRes,
+                 bool includeEdgeRZ) const;
 
   // appropriately-named variables for the data in FourierCoeffs
-  std::span<double> frcc;
-  std::span<double> frss;
-  std::span<double> frsc;
-  std::span<double> frcs;
+  std::span<real_t> frcc;
+  std::span<real_t> frss;
+  std::span<real_t> frsc;
+  std::span<real_t> frcs;
 
-  std::span<double> fzsc;
-  std::span<double> fzcs;
-  std::span<double> fzcc;
-  std::span<double> fzss;
+  std::span<real_t> fzsc;
+  std::span<real_t> fzcs;
+  std::span<real_t> fzcc;
+  std::span<real_t> fzss;
 
-  std::span<double> flsc;
-  std::span<double> flcs;
-  std::span<double> flcc;
-  std::span<double> flss;
+  std::span<real_t> flsc;
+  std::span<real_t> flcs;
+  std::span<real_t> flcc;
+  std::span<real_t> flss;
 
  private:
   void BindSpans();

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.cc
@@ -104,14 +104,14 @@ void FourierGeometry::interpFromBoundaryAndAxis(
         int idx_bdy = m * (s_.ntor + 1) + n;
         int idx_fc = ((jF - nsMin_) * s_.mpol + m) * (s_.ntor + 1) + n;
 
-        double basis_norm = 1.0 / (t.mscale[m] * t.nscale[n]);
+        real_t basis_norm = 1.0 / (t.mscale[m] * t.nscale[n]);
 
         if (m == 0) {
           // m=0-terms: only cos(m*theta) contribute
 
           // interpolate geometry between magnetic axis and LCFS into plasma
           // volume
-          double interpolationWeight =
+          real_t interpolationWeight =
               p.sqrtSF[jF - r_.nsMinF1] * p.sqrtSF[jF - r_.nsMinF1];
 
           rmncc[idx_fc] =
@@ -146,7 +146,7 @@ void FourierGeometry::interpFromBoundaryAndAxis(
 
           // weighting factor for radial interpolation between 0 at axis and 1
           // at boundary
-          double interpolationWeight = pow(p.sqrtSF[jF - r_.nsMinF1], m);
+          real_t interpolationWeight = pow(p.sqrtSF[jF - r_.nsMinF1], m);
 
           rmncc[idx_fc] = basis_norm * interpolationWeight * b.rbcc[idx_bdy];
           zmnsc[idx_fc] = basis_norm * interpolationWeight * b.zbsc[idx_bdy];
@@ -171,9 +171,9 @@ void FourierGeometry::interpFromBoundaryAndAxis(
 }
 
 void FourierGeometry::InitFromState(const FourierBasisFastPoloidal& fb,
-                                    const RowMatrixXd& rmnc,
-                                    const RowMatrixXd& zmns,
-                                    const RowMatrixXd& lmns_full,
+                                    const RowMatrixXr& rmnc,
+                                    const RowMatrixXr& zmns,
+                                    const RowMatrixXr& lmns_full,
                                     const RadialProfiles& p,
                                     const VmecConstants& constants,
                                     const Boundaries* b) {
@@ -183,19 +183,19 @@ void FourierGeometry::InitFromState(const FourierBasisFastPoloidal& fb,
   const int max_ns_to_set_rz_on_from_state_locally =
       std::min(nsMax_, max_ns_to_set_rz_on_from_state);
   for (int jF = nsMin_; jF < max_ns_to_set_rz_on_from_state_locally; ++jF) {
-    const Eigen::VectorXd rmnc_col = rmnc.col(jF);
-    const std::vector<double> rmnc_col_vector(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1> rmnc_col = rmnc.col(jF);
+    const std::vector<real_t> rmnc_col_vector(
         rmnc_col.data(), rmnc_col.data() + rmnc_col.size());
-    std::vector<double> rmncc_at_jF(s_.mpol * (s_.ntor + 1));
-    std::vector<double> rmnss_at_jF(s_.mpol * (s_.ntor + 1));
+    std::vector<real_t> rmncc_at_jF(s_.mpol * (s_.ntor + 1));
+    std::vector<real_t> rmnss_at_jF(s_.mpol * (s_.ntor + 1));
     fb.cos_to_cc_ss(rmnc_col_vector, rmncc_at_jF, rmnss_at_jF, s_.ntor,
                     s_.mpol);
 
-    const Eigen::VectorXd zmns_col = zmns.col(jF);
-    const std::vector<double> zmns_col_vector(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1> zmns_col = zmns.col(jF);
+    const std::vector<real_t> zmns_col_vector(
         zmns_col.data(), zmns_col.data() + zmns_col.size());
-    std::vector<double> zmnsc_at_jF(s_.mpol * (s_.ntor + 1));
-    std::vector<double> zmncs_at_jF(s_.mpol * (s_.ntor + 1));
+    std::vector<real_t> zmnsc_at_jF(s_.mpol * (s_.ntor + 1));
+    std::vector<real_t> zmncs_at_jF(s_.mpol * (s_.ntor + 1));
     fb.sin_to_sc_cs(zmns_col_vector, zmnsc_at_jF, zmncs_at_jF, s_.ntor,
                     s_.mpol);
 
@@ -218,11 +218,11 @@ void FourierGeometry::InitFromState(const FourierBasisFastPoloidal& fb,
   // the lambda Fourier coefficients on every flux surface,
   // __including__ the plasma boundary.
   for (int jF = nsMin_; jF < nsMax_; ++jF) {
-    const Eigen::VectorXd lmns_col = lmns_full.col(jF);
-    const std::vector<double> lmns_col_vector(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1> lmns_col = lmns_full.col(jF);
+    const std::vector<real_t> lmns_col_vector(
         lmns_col.data(), lmns_col.data() + lmns_col.size());
-    std::vector<double> lmnsc_at_jF(s_.mpol * (s_.ntor + 1));
-    std::vector<double> lmncs_at_jF(s_.mpol * (s_.ntor + 1));
+    std::vector<real_t> lmnsc_at_jF(s_.mpol * (s_.ntor + 1));
+    std::vector<real_t> lmncs_at_jF(s_.mpol * (s_.ntor + 1));
     fb.sin_to_sc_cs(lmns_col_vector, lmnsc_at_jF, lmncs_at_jF, s_.ntor,
                     s_.mpol);
 
@@ -233,7 +233,7 @@ void FourierGeometry::InitFromState(const FourierBasisFastPoloidal& fb,
 
         // undo lambda un-scaling that was done when writing the wout file
         // contents
-        const double lambda_unscaling =
+        const real_t lambda_unscaling =
             constants.lamscale / p.phipF[jF - r_.nsMinF1];
 
         lmnsc[idx_jmn] = lmnsc_at_jF[idx_mn] / lambda_unscaling;
@@ -268,7 +268,7 @@ void FourierGeometry::InitFromState(const FourierBasisFastPoloidal& fb,
       for (int n = 0; n < s_.ntor + 1; ++n) {
         int idx_fc = ((jF - nsMin_) * s_.mpol + m) * (s_.ntor + 1) + n;
 
-        double basis_norm = 1.0 / (fb.mscale[m] * fb.nscale[n]);
+        real_t basis_norm = 1.0 / (fb.mscale[m] * fb.nscale[n]);
 
         rmncc[idx_fc] *= basis_norm;
         zmnsc[idx_fc] *= basis_norm;
@@ -364,20 +364,22 @@ void FourierGeometry::ComputeSpectralWidth(
 
   // compute only on unique full-grid points
   for (int jF = minimum_j; jF < nsMax_; ++jF) {
-    double spectral_width_numerator = 0.0;
-    double spectral_width_denominator = 0.0;
+    real_t spectral_width_numerator = 0.0;
+    real_t spectral_width_denominator = 0.0;
 
     // note that we exclude m = 0
     for (int m = 1; m < s_.mpol; ++m) {
       for (int n = 0; n < s_.ntor + 1; ++n) {
         int fourier_index = ((jF - nsMin_) * s_.mpol + m) * (s_.ntor + 1) + n;
 
-        const double basis_norm =
+        const real_t basis_norm =
             fourier_basis.mscale[m] * fourier_basis.nscale[n];
 
         // Use Eigen for vectorized norm computation
-        Eigen::Vector4d r_coefficients = Eigen::Vector4d::Zero();
-        Eigen::Vector4d z_coefficients = Eigen::Vector4d::Zero();
+        Eigen::Vector<real_t, 4> r_coefficients =
+            Eigen::Vector<real_t, 4>::Zero();
+        Eigen::Vector<real_t, 4> z_coefficients =
+            Eigen::Vector<real_t, 4>::Zero();
         int basis_dimension = 0;
 
         r_coefficients[basis_dimension] = rmncc[fourier_index];
@@ -390,8 +392,8 @@ void FourierGeometry::ComputeSpectralWidth(
         // TO REQUIRED rsc, zcc FORMS
         if (s_.lthreed) {
           if (m == 1) {
-            const double r_plus = rmnss[fourier_index];
-            const double r_minus = zmncs[fourier_index];
+            const real_t r_plus = rmnss[fourier_index];
+            const real_t r_minus = zmncs[fourier_index];
             // rmnss
             r_coefficients[basis_dimension] = r_plus + r_minus;
             // zmncs
@@ -404,8 +406,8 @@ void FourierGeometry::ComputeSpectralWidth(
         }
         if (s_.lasym) {
           if (m == 1) {
-            const double r_plus = rmnsc[fourier_index];
-            const double r_minus = zmncc[fourier_index];
+            const real_t r_plus = rmnsc[fourier_index];
+            const real_t r_minus = zmncc[fourier_index];
             // rmnsc
             r_coefficients[basis_dimension] = r_plus + r_minus;
             // zmncc
@@ -424,7 +426,7 @@ void FourierGeometry::ComputeSpectralWidth(
         }
 
         // Vectorized squared norm computation
-        double coefficient_norm =
+        real_t coefficient_norm =
             r_coefficients.head(basis_dimension).squaredNorm() +
             z_coefficients.head(basis_dimension).squaredNorm();
         coefficient_norm *= basis_norm * basis_norm;

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.h
@@ -34,8 +34,8 @@ class FourierGeometry : public FourierCoeffs {
   // This latter use case applies to fixed-boundary hot-restart operation of
   // VMEC++.
   void InitFromState(const FourierBasisFastPoloidal &fb,
-                     const RowMatrixXd &rmnc, const RowMatrixXd &zmns,
-                     const RowMatrixXd &lmns_full, const RadialProfiles &p,
+                     const RowMatrixXr &rmnc, const RowMatrixXr &zmns,
+                     const RowMatrixXr &lmns_full, const RadialProfiles &p,
                      const VmecConstants &constants,
                      const Boundaries *b = nullptr);
 
@@ -51,44 +51,44 @@ class FourierGeometry : public FourierCoeffs {
   // FourierCoeffs
 
   // contrib to R ~ cos(m * theta) * cos(n * zeta)
-  std::span<double> rmncc;
+  std::span<real_t> rmncc;
 
   // contrib to R ~ sin(m * theta) * sin(n * zeta)
-  std::span<double> rmnss;
+  std::span<real_t> rmnss;
 
   // contrib to R ~ sin(m * theta) * cos(n * zeta)
-  std::span<double> rmnsc;
+  std::span<real_t> rmnsc;
 
   // contrib to R ~ cos(m * theta) * sin(n * zeta)
-  std::span<double> rmncs;
+  std::span<real_t> rmncs;
 
   // -----------
 
   // contrib to Z ~ sin(m * theta) * cos(n * zeta)
-  std::span<double> zmnsc;
+  std::span<real_t> zmnsc;
 
   // contrib to Z ~ cos(m * theta) * sin(n * zeta)
-  std::span<double> zmncs;
+  std::span<real_t> zmncs;
 
   // contrib to Z ~ cos(m * theta) * cos(n * zeta)
-  std::span<double> zmncc;
+  std::span<real_t> zmncc;
 
   // contrib to Z ~ sin(m * theta) * sin(n * zeta)
-  std::span<double> zmnss;
+  std::span<real_t> zmnss;
 
   // -----------
 
   // contrib to lambda ~ sin(m * theta) * cos(n * zeta)
-  std::span<double> lmnsc;
+  std::span<real_t> lmnsc;
 
   // contrib to lambda ~ cos(m * theta) * sin(n * zeta)
-  std::span<double> lmncs;
+  std::span<real_t> lmncs;
 
   // contrib to lambda ~ cos(m * theta) * cos(n * zeta)
-  std::span<double> lmncc;
+  std::span<real_t> lmncc;
 
   // contrib to lambda ~ sin(m * theta) * sin(n * zeta)
-  std::span<double> lmnss;
+  std::span<real_t> lmnss;
 
  private:
   void BindSpans();

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_velocity/fourier_velocity.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_velocity/fourier_velocity.h
@@ -20,20 +20,20 @@ class FourierVelocity : public FourierCoeffs {
   FourierVelocity& operator=(FourierVelocity&& other) noexcept;
 
   // appropriately-named variables for the data in FourierCoeffs
-  std::span<double> vrcc;
-  std::span<double> vrss;
-  std::span<double> vrsc;
-  std::span<double> vrcs;
+  std::span<real_t> vrcc;
+  std::span<real_t> vrss;
+  std::span<real_t> vrsc;
+  std::span<real_t> vrcs;
 
-  std::span<double> vzsc;
-  std::span<double> vzcs;
-  std::span<double> vzcc;
-  std::span<double> vzss;
+  std::span<real_t> vzsc;
+  std::span<real_t> vzcs;
+  std::span<real_t> vzcc;
+  std::span<real_t> vzss;
 
-  std::span<double> vlsc;
-  std::span<double> vlcs;
-  std::span<double> vlcc;
-  std::span<double> vlss;
+  std::span<real_t> vlsc;
+  std::span<real_t> vlcs;
+  std::span<real_t> vlcc;
+  std::span<real_t> vlss;
 
  private:
   void BindSpans();

--- a/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.cc
@@ -183,7 +183,7 @@ void HandoverStorage::RegisterSpectralWidthContribution(
   spectral_width_denominator_ += spectral_width_contribution.denominator;
 }  // RegisterSpectralWidthContribution
 
-double HandoverStorage::VolumeAveragedSpectralWidth() const {
+real_t HandoverStorage::VolumeAveragedSpectralWidth() const {
   return spectral_width_numerator_ / spectral_width_denominator_;
 }  // VolumeAveragedSpectralWidth
 

--- a/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
@@ -12,6 +12,7 @@
 
 #include "vmecpp/common/flow_control/flow_control.h"
 #include "vmecpp/common/sizes/sizes.h"
+#include "vmecpp/common/util/real_type.h"
 #include "vmecpp/common/util/util.h"
 #include "vmecpp/vmec/radial_partitioning/radial_partitioning.h"
 
@@ -21,19 +22,19 @@ namespace vmecpp {
 // Note that these correspond to an invalid spectral width,
 // as a division-by-zero would occur.
 struct SpectralWidthContribution {
-  double numerator = 0.0;
-  double denominator = 0.0;
+  real_t numerator = 0.0;
+  real_t denominator = 0.0;
 };
 
 // Size of the plasma in radial direction.
 struct RadialExtent {
-  double r_outer = 0.0;
-  double r_inner = 0.0;
+  real_t r_outer = 0.0;
+  real_t r_inner = 0.0;
 };
 
 struct GeometricOffset {
-  double r_00 = 0.0;
-  double z_00 = 0.0;
+  real_t r_00 = 0.0;
+  real_t z_00 = 0.0;
 };
 
 class HandoverStorage {
@@ -45,7 +46,7 @@ class HandoverStorage {
   void ResetSpectralWidthAccumulators();
   void RegisterSpectralWidthContribution(
       const SpectralWidthContribution& spectral_width_contribution);
-  double VolumeAveragedSpectralWidth() const;
+  real_t VolumeAveragedSpectralWidth() const;
 
   void SetRadialExtent(const RadialExtent& radial_extent);
   void SetGeometricOffset(const GeometricOffset& geometric_offset);
@@ -55,126 +56,126 @@ class HandoverStorage {
 
   // -------------------
 
-  double thermalEnergy;
-  double magneticEnergy;
-  double mhdEnergy;
+  real_t thermalEnergy;
+  real_t magneticEnergy;
+  real_t mhdEnergy;
 
   /** plasma volume in m^3/(2pi)^2 */
-  double plasmaVolume;
+  real_t plasmaVolume;
 
   // initial plasma volume (at start of multi-grid step) in m^3
-  double voli;
+  real_t voli;
 
   // force residual normalization factor for R and Z
-  double fNormRZ;
+  real_t fNormRZ;
 
   // force residual normalization factor for lambda
-  double fNormL;
+  real_t fNormL;
 
   // preconditioned force residual normalization factor for R, Z and lambda
-  double fNorm1;
+  real_t fNorm1;
 
   // poloidal current at axis
-  double rBtor0;
+  real_t rBtor0;
 
   // poloidal current at LCFS; rBtor / MU_0 is in Amperes
-  double rBtor;
+  real_t rBtor;
 
   // net enclosed toroidal current at LCFS; cTor / MU_0 is in Amperes
-  double cTor;
+  real_t cTor;
 
   // net toroidal current from vacuum; bSubUVac / MU_0 is in Amperes
-  double bSubUVac;
+  real_t bSubUVac;
 
   // poloidal current at LCFS from vacuum; bSubVVac * 2 * pi / MU_0 is in
   // Amperes
-  double bSubVVac;
+  real_t bSubVVac;
 
   // Used only in rzConIntoVolume() to extrapolate the constraint force
   // contribution from the LCFS into the plasma volume.
   // TODO(jurasic) this should have a smaller scope.
-  Eigen::VectorXd rCon_LCFS;
-  Eigen::VectorXd zCon_LCFS;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rCon_LCFS;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zCon_LCFS;
 
-  // Inter-thread handover storage: RowMatrixXd [num_threads, mnsize]
+  // Inter-thread handover storage: RowMatrixXr [num_threads, mnsize]
   // _i arrays: inside boundary, _o arrays: outside boundary
 
-  RowMatrixXd rmncc_i;
-  RowMatrixXd rmnss_i;
-  RowMatrixXd zmnsc_i;
-  RowMatrixXd zmncs_i;
-  RowMatrixXd lmnsc_i;
-  RowMatrixXd lmncs_i;
+  RowMatrixXr rmncc_i;
+  RowMatrixXr rmnss_i;
+  RowMatrixXr zmnsc_i;
+  RowMatrixXr zmncs_i;
+  RowMatrixXr lmnsc_i;
+  RowMatrixXr lmncs_i;
   // Asymmetric arrays for lasym=true
-  RowMatrixXd rmnsc_i;
-  RowMatrixXd rmncs_i;
-  RowMatrixXd zmncc_i;
-  RowMatrixXd zmnss_i;
-  RowMatrixXd lmncc_i;
-  RowMatrixXd lmnss_i;
+  RowMatrixXr rmnsc_i;
+  RowMatrixXr rmncs_i;
+  RowMatrixXr zmncc_i;
+  RowMatrixXr zmnss_i;
+  RowMatrixXr lmncc_i;
+  RowMatrixXr lmnss_i;
 
-  RowMatrixXd rmncc_o;
-  RowMatrixXd rmnss_o;
-  RowMatrixXd zmnsc_o;
-  RowMatrixXd zmncs_o;
-  RowMatrixXd lmnsc_o;
-  RowMatrixXd lmncs_o;
+  RowMatrixXr rmncc_o;
+  RowMatrixXr rmnss_o;
+  RowMatrixXr zmnsc_o;
+  RowMatrixXr zmncs_o;
+  RowMatrixXr lmnsc_o;
+  RowMatrixXr lmncs_o;
   // Asymmetric arrays for lasym=true
-  RowMatrixXd rmnsc_o;
-  RowMatrixXd rmncs_o;
-  RowMatrixXd zmncc_o;
-  RowMatrixXd zmnss_o;
-  RowMatrixXd lmncc_o;
-  RowMatrixXd lmnss_o;
+  RowMatrixXr rmnsc_o;
+  RowMatrixXr rmncs_o;
+  RowMatrixXr zmncc_o;
+  RowMatrixXr zmnss_o;
+  RowMatrixXr lmncc_o;
+  RowMatrixXr lmnss_o;
 
   // Serial tri-diagonal solver storage
-  // Matrix: RowMatrixXd [mn, j], RHS: vector of RowMatrixXd [mn][basis, j]
+  // Matrix: RowMatrixXr [mn, j], RHS: vector of RowMatrixXr [mn][basis, j]
 
   int mnsize;
-  RowMatrixXd all_ar;  // [mnsize, ns]
-  RowMatrixXd all_az;
-  RowMatrixXd all_dr;
-  RowMatrixXd all_dz;
-  RowMatrixXd all_br;
-  RowMatrixXd all_bz;
+  RowMatrixXr all_ar;  // [mnsize, ns]
+  RowMatrixXr all_az;
+  RowMatrixXr all_dr;
+  RowMatrixXr all_dz;
+  RowMatrixXr all_br;
+  RowMatrixXr all_bz;
 
   // [mnsize] -> [num_basis, ns]
-  std::vector<RowMatrixXd> all_cr;
-  std::vector<RowMatrixXd> all_cz;
+  std::vector<RowMatrixXr> all_cr;
+  std::vector<RowMatrixXr> all_cz;
 
   // Parallel tri-diagonal solver storage
-  // handover_cR/cZ: RowMatrixXd [num_basis, mnsize], handover_aR/aZ: flat
+  // handover_cR/cZ: RowMatrixXr [num_basis, mnsize], handover_aR/aZ: flat
   // [mnsize]
 
-  RowMatrixXd handover_cR;      // [num_basis, mnsize]
-  Eigen::VectorXd handover_aR;  // [mnsize]
-  RowMatrixXd handover_cZ;
-  Eigen::VectorXd handover_aZ;
+  RowMatrixXr handover_cR;                               // [num_basis, mnsize]
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> handover_aR;  // [mnsize]
+  RowMatrixXr handover_cZ;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> handover_aZ;
   // magnetic axis geometry for NESTOR
-  Eigen::VectorXd rAxis;
-  Eigen::VectorXd zAxis;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rAxis;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zAxis;
 
   // LCFS geometry for NESTOR
-  Eigen::VectorXd rCC_LCFS;
-  Eigen::VectorXd rSS_LCFS;
-  Eigen::VectorXd rSC_LCFS;
-  Eigen::VectorXd rCS_LCFS;
-  Eigen::VectorXd zSC_LCFS;
-  Eigen::VectorXd zCS_LCFS;
-  Eigen::VectorXd zCC_LCFS;
-  Eigen::VectorXd zSS_LCFS;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rCC_LCFS;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rSS_LCFS;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rSC_LCFS;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rCS_LCFS;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zSC_LCFS;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zCS_LCFS;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zCC_LCFS;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zSS_LCFS;
 
   // [nZnT] vacuum magnetic pressure |B_vac^2|/2 at the plasma boundary
-  Eigen::VectorXd vacuum_magnetic_pressure;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> vacuum_magnetic_pressure;
 
   // [nZnT] cylindrical B^R of Nestor's vacuum magnetic field
-  Eigen::VectorXd vacuum_b_r;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> vacuum_b_r;
 
   // [nZnT] cylindrical B^phi of Nestor's vacuum magnetic field
-  Eigen::VectorXd vacuum_b_phi;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> vacuum_b_phi;
 
   // [nZnT] cylindrical B^Z of Nestor's vacuum magnetic field
-  Eigen::VectorXd vacuum_b_z;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> vacuum_b_z;
 
  private:
   const Sizes& s_;
@@ -182,8 +183,8 @@ class HandoverStorage {
   int num_threads_;
   int num_basis_;
 
-  double spectral_width_numerator_;
-  double spectral_width_denominator_;
+  real_t spectral_width_numerator_;
+  real_t spectral_width_denominator_;
 
   RadialExtent radial_extent_;
   GeometricOffset geometric_offset_;

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/dft_data.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/dft_data.h
@@ -14,49 +14,49 @@ namespace vmecpp {
 // TODO(eguiraud): use this struct as a data member in IdealMHDModel (with
 // vectors instead of spans).
 struct RealSpaceForces {
-  std::span<const double> armn_e;
-  std::span<const double> armn_o;
-  std::span<const double> azmn_e;
-  std::span<const double> azmn_o;
-  std::span<const double> blmn_e;
-  std::span<const double> blmn_o;
-  std::span<const double> brmn_e;
-  std::span<const double> brmn_o;
-  std::span<const double> bzmn_e;
-  std::span<const double> bzmn_o;
-  std::span<const double> clmn_e;
-  std::span<const double> clmn_o;
-  std::span<const double> crmn_e;
-  std::span<const double> crmn_o;
-  std::span<const double> czmn_e;
-  std::span<const double> czmn_o;
-  std::span<const double> frcon_e;
-  std::span<const double> frcon_o;
-  std::span<const double> fzcon_e;
-  std::span<const double> fzcon_o;
+  std::span<const real_t> armn_e;
+  std::span<const real_t> armn_o;
+  std::span<const real_t> azmn_e;
+  std::span<const real_t> azmn_o;
+  std::span<const real_t> blmn_e;
+  std::span<const real_t> blmn_o;
+  std::span<const real_t> brmn_e;
+  std::span<const real_t> brmn_o;
+  std::span<const real_t> bzmn_e;
+  std::span<const real_t> bzmn_o;
+  std::span<const real_t> clmn_e;
+  std::span<const real_t> clmn_o;
+  std::span<const real_t> crmn_e;
+  std::span<const real_t> crmn_o;
+  std::span<const real_t> czmn_e;
+  std::span<const real_t> czmn_o;
+  std::span<const real_t> frcon_e;
+  std::span<const real_t> frcon_o;
+  std::span<const real_t> fzcon_e;
+  std::span<const real_t> fzcon_o;
 };
 
 // A bundle of views over (non-const) data required by the "FourierToReal"
 // calculations
 struct RealSpaceGeometry {
-  std::span<double> r1_e;
-  std::span<double> r1_o;
-  std::span<double> ru_e;
-  std::span<double> ru_o;
-  std::span<double> rv_e;
-  std::span<double> rv_o;
-  std::span<double> z1_e;
-  std::span<double> z1_o;
-  std::span<double> zu_e;
-  std::span<double> zu_o;
-  std::span<double> zv_e;
-  std::span<double> zv_o;
-  std::span<double> lu_e;
-  std::span<double> lu_o;
-  std::span<double> lv_e;
-  std::span<double> lv_o;
-  std::span<double> rCon;
-  std::span<double> zCon;
+  std::span<real_t> r1_e;
+  std::span<real_t> r1_o;
+  std::span<real_t> ru_e;
+  std::span<real_t> ru_o;
+  std::span<real_t> rv_e;
+  std::span<real_t> rv_o;
+  std::span<real_t> z1_e;
+  std::span<real_t> z1_o;
+  std::span<real_t> zu_e;
+  std::span<real_t> zu_o;
+  std::span<real_t> zv_e;
+  std::span<real_t> zv_o;
+  std::span<real_t> lu_e;
+  std::span<real_t> lu_o;
+  std::span<real_t> lv_e;
+  std::span<real_t> lv_o;
+  std::span<real_t> rCon;
+  std::span<real_t> zCon;
 };
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -56,9 +56,11 @@ void HandOverBoundaryGeometry(vmecpp::HandoverStorage& m_h,
   }
 }  // HandOverBoundaryGeometry
 
-void HandOverMagneticAxis(vmecpp::HandoverStorage& m_h,
-                          const Eigen::VectorXd& r1_e,
-                          const Eigen::VectorXd& z1_e, const vmecpp::Sizes& s) {
+void HandOverMagneticAxis(
+    vmecpp::HandoverStorage& m_h,
+    const Eigen::Matrix<vmecpp::real_t, Eigen::Dynamic, 1>& r1_e,
+    const Eigen::Matrix<vmecpp::real_t, Eigen::Dynamic, 1>& z1_e,
+    const vmecpp::Sizes& s) {
   for (int k = 0; k < s.nZeta; ++k) {
     // we are interested in l == 0
     int idx_kl = k * s.nThetaEff;
@@ -70,7 +72,8 @@ void HandOverMagneticAxis(vmecpp::HandoverStorage& m_h,
 }  // namespace
 
 void vmecpp::ForcesToFourier3DSymmFastPoloidal(
-    const RealSpaceForces& d, const Eigen::VectorXd& xmpq,
+    const RealSpaceForces& d,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& xmpq,
     const RadialPartitioning& rp, const FlowControl& fc, const Sizes& s,
     const FourierBasisFastPoloidal& fb,
     VacuumPressureState vacuum_pressure_state,
@@ -118,50 +121,60 @@ void vmecpp::ForcesToFourier3DSymmFastPoloidal(
         auto cosmumi_seg = fb.cosmumi.segment(idx_ml_base, s.nThetaReduced);
         auto sinmumi_seg = fb.sinmumi.segment(idx_ml_base, s.nThetaReduced);
 
-        auto blmn_seg = Eigen::Map<const Eigen::VectorXd>(
-            blmn.data() + idx_kl_base, s.nThetaReduced);
-        auto clmn_seg = Eigen::Map<const Eigen::VectorXd>(
-            clmn.data() + idx_kl_base, s.nThetaReduced);
-        auto crmn_seg = Eigen::Map<const Eigen::VectorXd>(
-            crmn.data() + idx_kl_base, s.nThetaReduced);
-        auto czmn_seg = Eigen::Map<const Eigen::VectorXd>(
-            czmn.data() + idx_kl_base, s.nThetaReduced);
-        auto armn_seg = Eigen::Map<const Eigen::VectorXd>(
-            armn.data() + idx_kl_base, s.nThetaReduced);
-        auto azmn_seg = Eigen::Map<const Eigen::VectorXd>(
-            azmn.data() + idx_kl_base, s.nThetaReduced);
-        auto brmn_seg = Eigen::Map<const Eigen::VectorXd>(
-            brmn.data() + idx_kl_base, s.nThetaReduced);
-        auto bzmn_seg = Eigen::Map<const Eigen::VectorXd>(
-            bzmn.data() + idx_kl_base, s.nThetaReduced);
-        auto frcon_seg = Eigen::Map<const Eigen::VectorXd>(
-            frcon.data() + idx_kl_base, s.nThetaReduced);
-        auto fzcon_seg = Eigen::Map<const Eigen::VectorXd>(
-            fzcon.data() + idx_kl_base, s.nThetaReduced);
+        auto blmn_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                blmn.data() + idx_kl_base, s.nThetaReduced);
+        auto clmn_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                clmn.data() + idx_kl_base, s.nThetaReduced);
+        auto crmn_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                crmn.data() + idx_kl_base, s.nThetaReduced);
+        auto czmn_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                czmn.data() + idx_kl_base, s.nThetaReduced);
+        auto armn_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                armn.data() + idx_kl_base, s.nThetaReduced);
+        auto azmn_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                azmn.data() + idx_kl_base, s.nThetaReduced);
+        auto brmn_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                brmn.data() + idx_kl_base, s.nThetaReduced);
+        auto bzmn_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                bzmn.data() + idx_kl_base, s.nThetaReduced);
+        auto frcon_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                frcon.data() + idx_kl_base, s.nThetaReduced);
+        auto fzcon_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                fzcon.data() + idx_kl_base, s.nThetaReduced);
 
-        double lmksc = blmn_seg.dot(cosmumi_seg);
-        double lmkcs = blmn_seg.dot(sinmumi_seg);
-        double lmkcs_n = -clmn_seg.dot(cosmui_seg);
-        double lmksc_n = -clmn_seg.dot(sinmui_seg);
+        real_t lmksc = blmn_seg.dot(cosmumi_seg);
+        real_t lmkcs = blmn_seg.dot(sinmumi_seg);
+        real_t lmkcs_n = -clmn_seg.dot(cosmui_seg);
+        real_t lmksc_n = -clmn_seg.dot(sinmui_seg);
 
-        double rmkcc_n = -crmn_seg.dot(cosmui_seg);
-        double zmkcs_n = -czmn_seg.dot(cosmui_seg);
+        real_t rmkcc_n = -crmn_seg.dot(cosmui_seg);
+        real_t zmkcs_n = -czmn_seg.dot(cosmui_seg);
 
-        double rmkss_n = -crmn_seg.dot(sinmui_seg);
-        double zmksc_n = -czmn_seg.dot(sinmui_seg);
+        real_t rmkss_n = -crmn_seg.dot(sinmui_seg);
+        real_t zmksc_n = -czmn_seg.dot(sinmui_seg);
 
         // Assemble effective R and Z forces from MHD and spectral condensation
         // contributions. Materialize to avoid re-evaluation in each dot
         // product.
-        const Eigen::VectorXd tempR_seg =
+        const Eigen::Matrix<real_t, Eigen::Dynamic, 1> tempR_seg =
             (armn_seg + xmpq[m] * frcon_seg).eval();
-        const Eigen::VectorXd tempZ_seg =
+        const Eigen::Matrix<real_t, Eigen::Dynamic, 1> tempZ_seg =
             (azmn_seg + xmpq[m] * fzcon_seg).eval();
 
-        double rmkcc = tempR_seg.dot(cosmui_seg) + brmn_seg.dot(sinmumi_seg);
-        double rmkss = tempR_seg.dot(sinmui_seg) + brmn_seg.dot(cosmumi_seg);
-        double zmksc = tempZ_seg.dot(sinmui_seg) + bzmn_seg.dot(cosmumi_seg);
-        double zmkcs = tempZ_seg.dot(cosmui_seg) + bzmn_seg.dot(sinmumi_seg);
+        real_t rmkcc = tempR_seg.dot(cosmui_seg) + brmn_seg.dot(sinmumi_seg);
+        real_t rmkss = tempR_seg.dot(sinmui_seg) + brmn_seg.dot(cosmumi_seg);
+        real_t zmksc = tempZ_seg.dot(sinmui_seg) + bzmn_seg.dot(cosmumi_seg);
+        real_t zmkcs = tempZ_seg.dot(cosmui_seg) + bzmn_seg.dot(sinmumi_seg);
 
         // Vectorized toroidal scatter: segment ops replace scalar n-loop
         const int ntorp1 = s.ntor + 1;
@@ -173,13 +186,13 @@ void vmecpp::ForcesToFourier3DSymmFastPoloidal(
         auto cosnvn_seg = fb.cosnvn.segment(idx_kn_base, ntorp1);
         auto sinnvn_seg = fb.sinnvn.segment(idx_kn_base, ntorp1);
 
-        Eigen::Map<Eigen::VectorXd> frcc_seg(
+        Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>> frcc_seg(
             m_physical_forces.frcc.data() + idx_mn_base, ntorp1);
-        Eigen::Map<Eigen::VectorXd> frss_seg(
+        Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>> frss_seg(
             m_physical_forces.frss.data() + idx_mn_base, ntorp1);
-        Eigen::Map<Eigen::VectorXd> fzsc_seg(
+        Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>> fzsc_seg(
             m_physical_forces.fzsc.data() + idx_mn_base, ntorp1);
-        Eigen::Map<Eigen::VectorXd> fzcs_seg(
+        Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>> fzcs_seg(
             m_physical_forces.fzcs.data() + idx_mn_base, ntorp1);
 
         frcc_seg += rmkcc * cosnv_seg + rmkcc_n * sinnvn_seg;
@@ -188,9 +201,9 @@ void vmecpp::ForcesToFourier3DSymmFastPoloidal(
         fzcs_seg += zmkcs * sinnv_seg + zmkcs_n * cosnvn_seg;
 
         if (jMinL <= jF) {
-          Eigen::Map<Eigen::VectorXd> flsc_seg(
+          Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>> flsc_seg(
               m_physical_forces.flsc.data() + idx_mn_base, ntorp1);
-          Eigen::Map<Eigen::VectorXd> flcs_seg(
+          Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>> flcs_seg(
               m_physical_forces.flcs.data() + idx_mn_base, ntorp1);
           flsc_seg += lmksc * cosnv_seg + lmksc_n * sinnvn_seg;
           flcs_seg += lmkcs * sinnv_seg + lmkcs_n * cosnvn_seg;
@@ -218,15 +231,17 @@ void vmecpp::ForcesToFourier3DSymmFastPoloidal(
         auto cosmumi_seg = fb.cosmumi.segment(idx_ml_base, s.nThetaReduced);
         auto sinmumi_seg = fb.sinmumi.segment(idx_ml_base, s.nThetaReduced);
 
-        auto blmn_seg = Eigen::Map<const Eigen::VectorXd>(
-            blmn.data() + idx_kl_base, s.nThetaReduced);
-        auto clmn_seg = Eigen::Map<const Eigen::VectorXd>(
-            clmn.data() + idx_kl_base, s.nThetaReduced);
+        auto blmn_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                blmn.data() + idx_kl_base, s.nThetaReduced);
+        auto clmn_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                clmn.data() + idx_kl_base, s.nThetaReduced);
 
-        double lmksc = blmn_seg.dot(cosmumi_seg);
-        double lmkcs = blmn_seg.dot(sinmumi_seg);
-        double lmkcs_n = -clmn_seg.dot(cosmui_seg);
-        double lmksc_n = -clmn_seg.dot(sinmui_seg);
+        real_t lmksc = blmn_seg.dot(cosmumi_seg);
+        real_t lmkcs = blmn_seg.dot(sinmumi_seg);
+        real_t lmkcs_n = -clmn_seg.dot(cosmui_seg);
+        real_t lmksc_n = -clmn_seg.dot(sinmui_seg);
 
         // Vectorized toroidal scatter for lambda-only section
         const int ntorp1 = s.ntor + 1;
@@ -238,9 +253,9 @@ void vmecpp::ForcesToFourier3DSymmFastPoloidal(
         auto cosnvn_seg = fb.cosnvn.segment(idx_kn_base, ntorp1);
         auto sinnvn_seg = fb.sinnvn.segment(idx_kn_base, ntorp1);
 
-        Eigen::Map<Eigen::VectorXd> flsc_seg(
+        Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>> flsc_seg(
             m_physical_forces.flsc.data() + idx_mn_base, ntorp1);
-        Eigen::Map<Eigen::VectorXd> flcs_seg(
+        Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>> flcs_seg(
             m_physical_forces.flcs.data() + idx_mn_base, ntorp1);
 
         flsc_seg += lmksc * cosnv_seg + lmksc_n * sinnvn_seg;
@@ -251,7 +266,8 @@ void vmecpp::ForcesToFourier3DSymmFastPoloidal(
 }
 
 void vmecpp::FourierToReal3DSymmFastPoloidal(
-    const FourierGeometry& physical_x, const Eigen::VectorXd& xmpq,
+    const FourierGeometry& physical_x,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& xmpq,
     const RadialPartitioning& r, const Sizes& s, const RadialProfiles& rp,
     const FourierBasisFastPoloidal& fb, RealSpaceGeometry& m_geometry) {
   // can safely assume lthreed == true in here
@@ -285,7 +301,7 @@ void vmecpp::FourierToReal3DSymmFastPoloidal(
       const int idx_ml_base = m * s.nThetaReduced;
 
       // with sqrtS for odd-m
-      const double con_factor =
+      const real_t con_factor =
           m_even ? xmpq[m] : xmpq[m] * rp.sqrtSF[jF - nsMinF1];
 
       auto& r1 = m_even ? m_geometry.r1_e : m_geometry.r1_o;
@@ -320,31 +336,37 @@ void vmecpp::FourierToReal3DSymmFastPoloidal(
         auto sinnvn_seg = fb.sinnvn.segment(idx_kn_base, s.ntor + 1);
         auto cosnvn_seg = fb.cosnvn.segment(idx_kn_base, s.ntor + 1);
 
-        auto rmncc_seg = Eigen::Map<const Eigen::VectorXd>(
-            physical_x.rmncc.data() + idx_mn_base, s.ntor + 1);
-        auto rmnss_seg = Eigen::Map<const Eigen::VectorXd>(
-            physical_x.rmnss.data() + idx_mn_base, s.ntor + 1);
-        auto zmnsc_seg = Eigen::Map<const Eigen::VectorXd>(
-            physical_x.zmnsc.data() + idx_mn_base, s.ntor + 1);
-        auto zmncs_seg = Eigen::Map<const Eigen::VectorXd>(
-            physical_x.zmncs.data() + idx_mn_base, s.ntor + 1);
-        auto lmnsc_seg = Eigen::Map<const Eigen::VectorXd>(
-            physical_x.lmnsc.data() + idx_mn_base, s.ntor + 1);
-        auto lmncs_seg = Eigen::Map<const Eigen::VectorXd>(
-            physical_x.lmncs.data() + idx_mn_base, s.ntor + 1);
+        auto rmncc_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                physical_x.rmncc.data() + idx_mn_base, s.ntor + 1);
+        auto rmnss_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                physical_x.rmnss.data() + idx_mn_base, s.ntor + 1);
+        auto zmnsc_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                physical_x.zmnsc.data() + idx_mn_base, s.ntor + 1);
+        auto zmncs_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                physical_x.zmncs.data() + idx_mn_base, s.ntor + 1);
+        auto lmnsc_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                physical_x.lmnsc.data() + idx_mn_base, s.ntor + 1);
+        auto lmncs_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                physical_x.lmncs.data() + idx_mn_base, s.ntor + 1);
 
-        double rmkcc = rmncc_seg.dot(cosnv_seg);
-        double rmkcc_n = rmncc_seg.dot(sinnvn_seg);
-        double rmkss = rmnss_seg.dot(sinnv_seg);
-        double rmkss_n = rmnss_seg.dot(cosnvn_seg);
-        double zmksc = zmnsc_seg.dot(cosnv_seg);
-        double zmksc_n = zmnsc_seg.dot(sinnvn_seg);
-        double zmkcs = zmncs_seg.dot(sinnv_seg);
-        double zmkcs_n = zmncs_seg.dot(cosnvn_seg);
-        double lmksc = lmnsc_seg.dot(cosnv_seg);
-        double lmksc_n = lmnsc_seg.dot(sinnvn_seg);
-        double lmkcs = lmncs_seg.dot(sinnv_seg);
-        double lmkcs_n = lmncs_seg.dot(cosnvn_seg);
+        real_t rmkcc = rmncc_seg.dot(cosnv_seg);
+        real_t rmkcc_n = rmncc_seg.dot(sinnvn_seg);
+        real_t rmkss = rmnss_seg.dot(sinnv_seg);
+        real_t rmkss_n = rmnss_seg.dot(cosnvn_seg);
+        real_t zmksc = zmnsc_seg.dot(cosnv_seg);
+        real_t zmksc_n = zmnsc_seg.dot(sinnvn_seg);
+        real_t zmkcs = zmncs_seg.dot(sinnv_seg);
+        real_t zmkcs_n = zmncs_seg.dot(cosnvn_seg);
+        real_t lmksc = lmnsc_seg.dot(cosnv_seg);
+        real_t lmksc_n = lmnsc_seg.dot(sinnvn_seg);
+        real_t lmkcs = lmncs_seg.dot(sinnv_seg);
+        real_t lmkcs_n = lmncs_seg.dot(cosnvn_seg);
 
         // INVERSE TRANSFORM IN M-THETA, FOR ALL RADIAL, ZETA VALUES
         const int idx_kl_base = ((jF - nsMinF1) * s.nZeta + k) * s.nThetaEff;
@@ -353,12 +375,12 @@ void vmecpp::FourierToReal3DSymmFastPoloidal(
         auto sinmum_seg = fb.sinmum.segment(idx_ml_base, s.nThetaReduced);
         auto cosmum_seg = fb.cosmum.segment(idx_ml_base, s.nThetaReduced);
 
-        auto ru_seg = Eigen::Map<Eigen::VectorXd>(ru.data() + idx_kl_base,
-                                                  s.nThetaReduced);
-        auto zu_seg = Eigen::Map<Eigen::VectorXd>(zu.data() + idx_kl_base,
-                                                  s.nThetaReduced);
-        auto lu_seg = Eigen::Map<Eigen::VectorXd>(lu.data() + idx_kl_base,
-                                                  s.nThetaReduced);
+        auto ru_seg = Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+            ru.data() + idx_kl_base, s.nThetaReduced);
+        auto zu_seg = Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+            zu.data() + idx_kl_base, s.nThetaReduced);
+        auto lu_seg = Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+            lu.data() + idx_kl_base, s.nThetaReduced);
 
         // NOTE: element-wise multiplication
         ru_seg += rmkcc * sinmum_seg + rmkss * cosmum_seg;
@@ -368,12 +390,12 @@ void vmecpp::FourierToReal3DSymmFastPoloidal(
         auto cosmu_seg = fb.cosmu.segment(idx_ml_base, s.nThetaReduced);
         auto sinmu_seg = fb.sinmu.segment(idx_ml_base, s.nThetaReduced);
 
-        auto rv_seg = Eigen::Map<Eigen::VectorXd>(rv.data() + idx_kl_base,
-                                                  s.nThetaReduced);
-        auto zv_seg = Eigen::Map<Eigen::VectorXd>(zv.data() + idx_kl_base,
-                                                  s.nThetaReduced);
-        auto lv_seg = Eigen::Map<Eigen::VectorXd>(lv.data() + idx_kl_base,
-                                                  s.nThetaReduced);
+        auto rv_seg = Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+            rv.data() + idx_kl_base, s.nThetaReduced);
+        auto zv_seg = Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+            zv.data() + idx_kl_base, s.nThetaReduced);
+        auto lv_seg = Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+            lv.data() + idx_kl_base, s.nThetaReduced);
 
         // NOTE: element-wise multiplication
         rv_seg += rmkcc_n * cosmu_seg + rmkss_n * sinmu_seg;
@@ -381,10 +403,10 @@ void vmecpp::FourierToReal3DSymmFastPoloidal(
         // it is here that lv gets a negative sign!
         lv_seg -= lmksc_n * sinmu_seg + lmkcs_n * cosmu_seg;
 
-        auto r1_seg = Eigen::Map<Eigen::VectorXd>(r1.data() + idx_kl_base,
-                                                  s.nThetaReduced);
-        auto z1_seg = Eigen::Map<Eigen::VectorXd>(z1.data() + idx_kl_base,
-                                                  s.nThetaReduced);
+        auto r1_seg = Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+            r1.data() + idx_kl_base, s.nThetaReduced);
+        auto z1_seg = Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+            z1.data() + idx_kl_base, s.nThetaReduced);
 
         r1_seg += rmkcc * cosmu_seg + rmkss * sinmu_seg;
         z1_seg += zmksc * sinmu_seg + zmkcs * cosmu_seg;
@@ -393,9 +415,9 @@ void vmecpp::FourierToReal3DSymmFastPoloidal(
           // spectral condensation is local per flux surface
           const int idx_con_base = ((jF - nsMinF) * s.nZeta + k) * s.nThetaEff;
 
-          auto rCon_seg = Eigen::Map<Eigen::VectorXd>(
+          auto rCon_seg = Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
               m_geometry.rCon.data() + idx_con_base, s.nThetaReduced);
-          auto zCon_seg = Eigen::Map<Eigen::VectorXd>(
+          auto zCon_seg = Eigen::Map<Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
               m_geometry.zCon.data() + idx_con_base, s.nThetaReduced);
 
           rCon_seg += (rmkcc * cosmu_seg + rmkss * sinmu_seg) * con_factor;
@@ -410,9 +432,12 @@ void vmecpp::FourierToReal3DSymmFastPoloidal(
 void vmecpp::deAliasConstraintForce(
     const vmecpp::RadialPartitioning& rp,
     const vmecpp::FourierBasisFastPoloidal& fb, const vmecpp::Sizes& s_,
-    const Eigen::VectorXd& faccon, const Eigen::VectorXd& tcon,
-    const Eigen::VectorXd& gConEff, Eigen::VectorXd& m_gsc,
-    Eigen::VectorXd& m_gcs, Eigen::VectorXd& m_gCon) {
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& faccon,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& tcon,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& gConEff,
+    Eigen::Matrix<real_t, Eigen::Dynamic, 1>& m_gsc,
+    Eigen::Matrix<real_t, Eigen::Dynamic, 1>& m_gcs,
+    Eigen::Matrix<real_t, Eigen::Dynamic, 1>& m_gCon) {
   absl::c_fill_n(m_gCon, (rp.nsMaxF - rp.nsMinF) * s_.nZnT, 0);
 
   // no constraint on axis --> has no poloidal angle
@@ -432,13 +457,14 @@ void vmecpp::deAliasConstraintForce(
         const int kl_base = ((jF - rp.nsMinF) * s_.nZeta + k) * s_.nThetaEff;
         const int ml_base = m * s_.nThetaReduced;
 
-        auto gConEff_seg = Eigen::Map<const Eigen::VectorXd>(
-            gConEff.data() + kl_base, s_.nThetaReduced);
+        auto gConEff_seg =
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                gConEff.data() + kl_base, s_.nThetaReduced);
         auto sinmui_seg = fb.sinmui.segment(ml_base, s_.nThetaReduced);
         auto cosmui_seg = fb.cosmui.segment(ml_base, s_.nThetaReduced);
 
-        double w0 = gConEff_seg.dot(sinmui_seg);
-        double w1 = gConEff_seg.dot(cosmui_seg);
+        real_t w0 = gConEff_seg.dot(sinmui_seg);
+        real_t w1 = gConEff_seg.dot(cosmui_seg);
 
         // forward Fourier transform in toroidal direction for full set of mode
         // numbers (n = 0, 1, ..., ntor)
@@ -464,12 +490,14 @@ void vmecpp::deAliasConstraintForce(
         auto sinnv_seg = fb.sinnv.segment(kn_base, s_.ntor + 1);
 
         auto m_gsc_seg =
-            Eigen::Map<const Eigen::VectorXd>(m_gsc.data(), s_.ntor + 1);
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                m_gsc.data(), s_.ntor + 1);
         auto m_gcs_seg =
-            Eigen::Map<const Eigen::VectorXd>(m_gcs.data(), s_.ntor + 1);
+            Eigen::Map<const Eigen::Matrix<real_t, Eigen::Dynamic, 1>>(
+                m_gcs.data(), s_.ntor + 1);
 
-        double w0 = m_gsc_seg.dot(cosnv_seg);
-        double w1 = m_gcs_seg.dot(sinnv_seg);
+        real_t w0 = m_gsc_seg.dot(cosnv_seg);
+        real_t w1 = m_gcs_seg.dot(sinnv_seg);
 
         // inv transform in poloidal direction
         for (int l = 0; l < s_.nThetaReduced; ++l) {
@@ -662,7 +690,8 @@ void IdealMhdModel::setFromINDATA(int ncurr, double adiabaticIndex,
   this->tcon0 = tcon0;
 }
 
-void IdealMhdModel::evalFResInvar(const Eigen::VectorXd& localFResInvar) {
+void IdealMhdModel::evalFResInvar(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& localFResInvar) {
 #ifdef _OPENMP
 #pragma omp single
 #endif  // _OPENMP
@@ -693,7 +722,7 @@ void IdealMhdModel::evalFResInvar(const Eigen::VectorXd& localFResInvar) {
   {
     // set new values
     // TODO(jons): what is `r1scale`?
-    constexpr double r1scale = 0.25;
+    constexpr real_t r1scale = 0.25;
 
     m_fc_.fsqr = m_fc_.fResInvar[0] * m_h_.fNormRZ * r1scale;
     m_fc_.fsqz = m_fc_.fResInvar[1] * m_h_.fNormRZ * r1scale;
@@ -701,7 +730,8 @@ void IdealMhdModel::evalFResInvar(const Eigen::VectorXd& localFResInvar) {
   }
 }
 
-void IdealMhdModel::evalFResPrecd(const Eigen::VectorXd& localFResPrecd) {
+void IdealMhdModel::evalFResPrecd(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& localFResPrecd) {
 #ifdef _OPENMP
 #pragma omp single
 #endif  // _OPENMP
@@ -934,8 +964,9 @@ absl::StatusOr<bool> IdealMhdModel::update(
 
     // EXTEND NVACSKIP AS EQUILIBRIUM CONVERGES
     if (ivacskip == 0) {
-      const int new_nvacskip = static_cast<int>(
-          1.0 / std::max(0.1, 1.0e11 * (m_fc_.fsqr + m_fc_.fsqz)));
+      const int new_nvacskip =
+          static_cast<int>(1.0 / std::max(static_cast<real_t>(0.1),
+                                          1.0e11 * (m_fc_.fsqr + m_fc_.fsqz)));
       nvacskip = std::max(nvacskip, new_nvacskip);
 
 #ifdef _OPENMP
@@ -981,7 +1012,7 @@ absl::StatusOr<bool> IdealMhdModel::update(
 #ifdef _OPENMP
 #pragma omp barrier
 #endif  // _OPENMP
-      const double netToroidalCurrent = m_h_.cTor / MU_0;
+      const real_t netToroidalCurrent = m_h_.cTor / MU_0;
       bool reached_checkpoint = m_fb_->update(
           m_h_.rCC_LCFS, m_h_.rSS_LCFS, m_h_.rSC_LCFS, m_h_.rCS_LCFS,
           m_h_.zSC_LCFS, m_h_.zCS_LCFS, m_h_.zCC_LCFS, m_h_.zSS_LCFS,
@@ -1003,7 +1034,7 @@ absl::StatusOr<bool> IdealMhdModel::update(
           if (verbose) {
             // bSubUVac and cTor contain 2*pi already; see Nestor.cc for
             // bSubUVac and above for cTor
-            const double fac = 1.0e-6 / MU_0;  // in MA
+            const real_t fac = 1.0e-6 / MU_0;  // in MA
             std::cout << "\n";
             std::cout << absl::StrFormat(
                 "2*pi * a * -BPOL(vac) = %10.2e MA       R * BTOR(vacuum) = "
@@ -1043,7 +1074,7 @@ absl::StatusOr<bool> IdealMhdModel::update(
         // MUST NOT BREAK TRI-DIAGONAL RADIAL COUPLING: OFFENDS PRECONDITIONER!
         // double edgePressure = 1.5 * p.presH[r.nsMaxH-1 - r.nsMinH] - 0.5 *
         // p.presH[r.nsMinH - r.nsMinH];
-        double edgePressure =
+        real_t edgePressure =
             m_p_.evalMassProfile((m_fc_.ns - 1.5) / (m_fc_.ns - 1.0));
         if (edgePressure != 0.0) {
           edgePressure = m_p_.evalMassProfile(1.0) / edgePressure *
@@ -1064,7 +1095,7 @@ absl::StatusOr<bool> IdealMhdModel::update(
           const int k = kl / s_.nThetaEff;
           const int l = kl % s_.nThetaEff;
           const int idx_lk = l * s_.nZeta + k;
-          double outsideEdgePressure =
+          real_t outsideEdgePressure =
               m_h_.vacuum_magnetic_pressure[idx_lk] + edgePressure;
 
           // term to enter MHD forces
@@ -1161,7 +1192,8 @@ absl::StatusOr<bool> IdealMhdModel::update(
                                         VacuumPressureState::kInitialized);
   bool includeEdgeRZForces =
       ((iter2 - iter1) < 50 && (almost_converged || hot_restart));
-  Eigen::VectorXd localFResInvar = Eigen::VectorXd::Zero(3);
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> localFResInvar =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(3);
   m_decomposed_f.residuals(localFResInvar, includeEdgeRZForces);
 
   evalFResInvar(localFResInvar);
@@ -1196,7 +1228,8 @@ absl::StatusOr<bool> IdealMhdModel::update(
     return true;
   }
 
-  Eigen::VectorXd localFResPrecd = Eigen::VectorXd::Zero(3);
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> localFResPrecd =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(3);
   m_decomposed_f.residuals(localFResPrecd, true);
 
   evalFResPrecd(localFResPrecd);
@@ -1330,9 +1363,9 @@ void IdealMhdModel::dft_FourierToReal_2d_symm(
 #endif  // _OPENMP
 
   for (int jF = r_.nsMinF1; jF < r_.nsMaxF1; ++jF) {
-    double* src_rcc = &(physical_x.rmncc[(jF - r_.nsMinF1) * s_.mnsize]);
-    double* src_zsc = &(physical_x.zmnsc[(jF - r_.nsMinF1) * s_.mnsize]);
-    double* src_lsc = &(physical_x.lmnsc[(jF - r_.nsMinF1) * s_.mnsize]);
+    real_t* src_rcc = &(physical_x.rmncc[(jF - r_.nsMinF1) * s_.mnsize]);
+    real_t* src_zsc = &(physical_x.zmnsc[(jF - r_.nsMinF1) * s_.mnsize]);
+    real_t* src_lsc = &(physical_x.lmnsc[(jF - r_.nsMinF1) * s_.mnsize]);
 
     for (int l = 0; l < s_.nThetaReduced; ++l) {
       std::array<double, 2> rnkcc = {0.0, 0.0};
@@ -1362,35 +1395,35 @@ void IdealMhdModel::dft_FourierToReal_2d_symm(
       for (int m = 0; m < num_m; ++m) {
         const int m_parity = m % 2;
         const int idx_ml = m * s_.nThetaReduced + l;
-        const double cosmu = t_.cosmu[idx_ml];
+        const real_t cosmu = t_.cosmu[idx_ml];
         rnkcc[m_parity] += src_rcc[m] * cosmu;
       }
 
       for (int m = 0; m < num_m; ++m) {
         const int m_parity = m % 2;
         const int idx_ml = m * s_.nThetaReduced + l;
-        const double sinmum = t_.sinmum[idx_ml];
+        const real_t sinmum = t_.sinmum[idx_ml];
         rnkcc_m[m_parity] += src_rcc[m] * sinmum;
       }
 
       for (int m = 0; m < num_m; ++m) {
         const int m_parity = m % 2;
         const int idx_ml = m * s_.nThetaReduced + l;
-        const double sinmu = t_.sinmu[idx_ml];
+        const real_t sinmu = t_.sinmu[idx_ml];
         znksc[m_parity] += src_zsc[m] * sinmu;
       }
 
       for (int m = 0; m < num_m; ++m) {
         const int m_parity = m % 2;
         const int idx_ml = m * s_.nThetaReduced + l;
-        const double cosmum = t_.cosmum[idx_ml];
+        const real_t cosmum = t_.cosmum[idx_ml];
         znksc_m[m_parity] += src_zsc[m] * cosmum;
       }
 
       for (int m = 0; m < num_m; ++m) {
         const int m_parity = m % 2;
         const int idx_ml = m * s_.nThetaReduced + l;
-        const double cosmum = t_.cosmum[idx_ml];
+        const real_t cosmum = t_.cosmum[idx_ml];
         lnksc_m[m_parity] += src_lsc[m] * cosmum;
       }
 
@@ -1413,8 +1446,8 @@ void IdealMhdModel::dft_FourierToReal_2d_symm(
   // innermost loops.
 
   for (int jF = r_.nsMinF; jF < r_.nsMaxFIncludingLcfs; ++jF) {
-    double* src_rcc = &(physical_x.rmncc[(jF - r_.nsMinF1) * s_.mnsize]);
-    double* src_zsc = &(physical_x.zmnsc[(jF - r_.nsMinF1) * s_.mnsize]);
+    real_t* src_rcc = &(physical_x.rmncc[(jF - r_.nsMinF1) * s_.mnsize]);
+    real_t* src_zsc = &(physical_x.zmnsc[(jF - r_.nsMinF1) * s_.mnsize]);
 
     // NOTE: The axis only gets contributions up to m=1.
     // This is counterintuitive on its own, since the axis is a
@@ -1452,24 +1485,24 @@ void IdealMhdModel::dft_FourierToReal_2d_symm(
     //       scale *= m_p_.sqrtSF[jF - r_.nsMinF1];
     //   }
     // with the following code:
-    //   const double scale = xmpq[m] * (1 - m_parity + m_parity *
+    //   const real_t scale = xmpq[m] * (1 - m_parity + m_parity *
     //   m_p_.sqrtSF[jF - r_.nsMinF1]);
 
     for (int m = 0; m < num_m; ++m) {
       const int m_parity = m % 2;
-      const double scale =
+      const real_t scale =
           xmpq[m] * (1 - m_parity + m_parity * m_p_.sqrtSF[jF - r_.nsMinF1]);
 
       for (int l = 0; l < s_.nThetaReduced; ++l) {
         const int idx_ml = m * s_.nThetaReduced + l;
-        const double cosmu = t_.cosmu[idx_ml];
+        const real_t cosmu = t_.cosmu[idx_ml];
         const int idx_con = (jF - r_.nsMinF) * s_.nThetaEff + l;
         rCon[idx_con] += src_rcc[m] * cosmu * scale;
       }  // l
 
       for (int l = 0; l < s_.nThetaReduced; ++l) {
         const int idx_ml = m * s_.nThetaReduced + l;
-        const double sinmu = t_.sinmu[idx_ml];
+        const real_t sinmu = t_.sinmu[idx_ml];
         const int idx_con = (jF - r_.nsMinF) * s_.nThetaEff + l;
         zCon[idx_con] += src_zsc[m] * sinmu * scale;
       }  // l
@@ -1503,7 +1536,7 @@ void IdealMhdModel::rzConIntoVolume() {
 
   // step 2: all threads interpolate into volume
   for (int jF = std::max(1, r_.nsMinF); jF < r_.nsMaxFIncludingLcfs; ++jF) {
-    double sFull = m_p_.sqrtSF[jF - r_.nsMinF1] * m_p_.sqrtSF[jF - r_.nsMinF1];
+    real_t sFull = m_p_.sqrtSF[jF - r_.nsMinF1] * m_p_.sqrtSF[jF - r_.nsMinF1];
     for (int kl = 0; kl < s_.nZnT; ++kl) {
       int idx_kl = (jF - r_.nsMinF) * s_.nZnT + kl;
       rCon0[idx_kl] = m_h_.rCon_LCFS[kl] * sFull;
@@ -1515,8 +1548,8 @@ void IdealMhdModel::rzConIntoVolume() {
 void IdealMhdModel::computeJacobian() {
   // r12, ru12, zu12, rs, zs, tau
 
-  double minTau = 0.0;
-  double maxTau = 0.0;
+  real_t minTau = 0.0;
+  real_t maxTau = 0.0;
 
   // contributions from full-grid surface _i_nside j-th half-grid surface
   int j0 = r_.nsMinF1;
@@ -1533,18 +1566,18 @@ void IdealMhdModel::computeJacobian() {
 
   for (int jH = r_.nsMinH; jH < r_.nsMaxH; ++jH) {
     // sqrt(s) on j-th half-grid pos
-    double sqrtSH = m_p_.sqrtSH[jH - r_.nsMinH];
+    real_t sqrtSH = m_p_.sqrtSH[jH - r_.nsMinH];
 
     for (int kl = 0; kl < s_.nZnT; ++kl) {
       // contributions from full-grid surface _o_utside j-th half-grid surface
-      double r1e_o = r1_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
-      double r1o_o = r1_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
-      double z1e_o = z1_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
-      double z1o_o = z1_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
-      double rue_o = ru_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
-      double ruo_o = ru_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
-      double zue_o = zu_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
-      double zuo_o = zu_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+      real_t r1e_o = r1_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+      real_t r1o_o = r1_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+      real_t z1e_o = z1_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+      real_t z1o_o = z1_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+      real_t rue_o = ru_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+      real_t ruo_o = ru_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+      real_t zue_o = zu_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+      real_t zuo_o = zu_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
 
       int iHalf = (jH - r_.nsMinH) * s_.nZnT + kl;
 
@@ -1571,13 +1604,13 @@ void IdealMhdModel::computeJacobian() {
           m_fc_.deltaS;
 
       // sqrt(g)/R on half-grid: assemble as governed by product rule
-      double tau1 = ru12[iHalf] * zs[iHalf] - rs[iHalf] * zu12[iHalf];
-      double tau2 = ruo_o * z1o_o + m_ls_.ruo_i[kl] * m_ls_.z1o_i[kl] -
+      real_t tau1 = ru12[iHalf] * zs[iHalf] - rs[iHalf] * zu12[iHalf];
+      real_t tau2 = ruo_o * z1o_o + m_ls_.ruo_i[kl] * m_ls_.z1o_i[kl] -
                     zuo_o * r1o_o - m_ls_.zuo_i[kl] * m_ls_.r1o_i[kl] +
                     (rue_o * z1o_o + m_ls_.rue_i[kl] * m_ls_.z1o_i[kl] -
                      zue_o * r1o_o - m_ls_.zue_i[kl] * m_ls_.r1o_i[kl]) /
                         sqrtSH;
-      double tau_val = tau1 + dSHalfDsInterp * tau2;
+      real_t tau_val = tau1 + dSHalfDsInterp * tau2;
 
       if (tau_val < minTau || minTau == 0.0) {
         minTau = tau_val;
@@ -1642,16 +1675,16 @@ void IdealMhdModel::computeMetricElements() {
   }
 
   // s on inner full-grid pos
-  double sF_i =
+  real_t sF_i =
       m_p_.sqrtSF[r_.nsMinH - r_.nsMinF1] * m_p_.sqrtSF[r_.nsMinH - r_.nsMinF1];
 
   for (int jH = r_.nsMinH; jH < r_.nsMaxH; ++jH) {
     // s on outside full-grid pos
-    double sF_o =
+    real_t sF_o =
         m_p_.sqrtSF[jH + 1 - r_.nsMinF1] * m_p_.sqrtSF[jH + 1 - r_.nsMinF1];
 
     // sqrt(s) on j-th half-grid pos
-    double sqrtSH = m_p_.sqrtSH[jH - r_.nsMinH];
+    real_t sqrtSH = m_p_.sqrtSH[jH - r_.nsMinH];
 
     for (int kl = 0; kl < s_.nZnT; ++kl) {
       int iHalf = (jH - r_.nsMinH) * s_.nZnT + kl;
@@ -1664,12 +1697,12 @@ void IdealMhdModel::computeMetricElements() {
       gsqrt[iHalf] = tau[iHalf] * r12[iHalf];
 
       // contributions from full-grid surface _o_utside j-th half-grid surface
-      double r1e_o = r1_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
-      double r1o_o = r1_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
-      double rue_o = ru_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
-      double ruo_o = ru_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
-      double zue_o = zu_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
-      double zuo_o = zu_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+      real_t r1e_o = r1_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+      real_t r1o_o = r1_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+      real_t rue_o = ru_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+      real_t ruo_o = ru_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+      real_t zue_o = zu_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+      real_t zuo_o = zu_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
 
       // g_{\theta,\theta} is needed for both 2D and 3D cases
       guu[iHalf] = 0.5 * ((m_ls_.rue_i[kl] * m_ls_.rue_i[kl] +
@@ -1689,10 +1722,10 @@ void IdealMhdModel::computeMetricElements() {
                    sqrtSH * (m_ls_.r1e_i[kl] * m_ls_.r1o_i[kl] + r1e_o * r1o_o);
 
       if (s_.lthreed) {
-        double rve_o = rv_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
-        double rvo_o = rv_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
-        double zve_o = zv_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
-        double zvo_o = zv_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+        real_t rve_o = rv_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+        real_t rvo_o = rv_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+        real_t zve_o = zv_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+        real_t zvo_o = zv_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
 
         // g_{\theta,\zeta} is only needed for the 3D case
         guv[iHalf] = 0.5 * ((m_ls_.rue_i[kl] * m_ls_.rve_i[kl] +
@@ -1770,7 +1803,7 @@ void IdealMhdModel::updateDifferentialVolume() {
 
 // first iteration of a multi-grid step
 void IdealMhdModel::computeInitialVolume() {
-  double localPlasmaVolume = 0.0;
+  real_t localPlasmaVolume = 0.0;
   for (int jH = r_.nsMinH; jH < r_.nsMaxH; ++jH) {
     // radial integral to get plasma volume
     // This must be done over UNIQUE half-grid points !!!
@@ -1800,7 +1833,7 @@ void IdealMhdModel::computeInitialVolume() {
 }  // computeInitialVolume
 
 void IdealMhdModel::updateVolume() {
-  double localPlasmaVolume = 0.0;
+  real_t localPlasmaVolume = 0.0;
   for (int jH = r_.nsMinH; jH < r_.nsMaxH; ++jH) {
     // radial integral to get plasma volume
     // This must be done over UNIQUE half-grid points !!!
@@ -1863,7 +1896,7 @@ void IdealMhdModel::computeBContra() {
 
   for (int jH = r_.nsMinH; jH < r_.nsMaxH; ++jH) {
     // sqrt(s) on j-th half-grid pos
-    double sqrtSH = m_p_.sqrtSH[jH - r_.nsMinH];
+    real_t sqrtSH = m_p_.sqrtSH[jH - r_.nsMinH];
 
     for (int kl = 0; kl < s_.nZnT; ++kl) {
       int iHalf = (jH - r_.nsMinH) * s_.nZnT + kl;
@@ -1881,10 +1914,10 @@ void IdealMhdModel::computeBContra() {
           m_p_.phipF[jH + 1 - r_.nsMinH];
 
       // contributions from full-grid surface _o_utside j-th half-grid surface
-      double lue_o = lu_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
-      double luo_o = lu_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
-      double lve_o = 0.0;
-      double lvo_o = 0.0;
+      real_t lue_o = lu_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+      real_t luo_o = lu_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
+      real_t lve_o = 0.0;
+      real_t lvo_o = 0.0;
       if (s_.lthreed) {
         lve_o = lv_e[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
         lvo_o = lv_o[(jH + 1 - r_.nsMinF1) * s_.nZnT + kl];
@@ -1922,8 +1955,8 @@ void IdealMhdModel::computeBContra() {
     // --> compute chi' consistent with prescribed toroidal current
 
     for (int jH = r_.nsMinH; jH < r_.nsMaxH; ++jH) {
-      double jvPlasma = 0.0;
-      double avg_guu_gsqrt = 0.0;
+      real_t jvPlasma = 0.0;
+      real_t avg_guu_gsqrt = 0.0;
       for (int kl = 0; kl < s_.nZnT; ++kl) {
         int iHalf = (jH - r_.nsMinH) * s_.nZnT + kl;
         int l = kl % s_.nThetaEff;
@@ -2012,7 +2045,7 @@ void IdealMhdModel::pressureAndEnergies() {
   // presH, totalPressure
   // thermalEnergy, magneticEnergy, mhdEnergy
 
-  double localThermalEnergy = 0.0;
+  real_t localThermalEnergy = 0.0;
   for (int jH = r_.nsMinH; jH < r_.nsMaxH; ++jH) {
     // compute pressure from mass, dV/ds and adiabatic index (gamma)
     m_p_.presH[jH - r_.nsMinH] =
@@ -2040,7 +2073,7 @@ void IdealMhdModel::pressureAndEnergies() {
   totalPressure = 0.5 * (bsupu.cwiseProduct(bsubu) + bsupv.cwiseProduct(bsubv));
 
   // Accumulate magnetic energy and add kinetic pressure per surface
-  double localMagneticEnergy = 0.0;
+  real_t localMagneticEnergy = 0.0;
   for (int jH = r_.nsMinH; jH < r_.nsMaxH; ++jH) {
     const int offset = (jH - r_.nsMinH) * s_.nZnT;
 
@@ -2112,7 +2145,7 @@ void IdealMhdModel::radialForceBalance() {
     }  // kl
   }  // jH
 
-  double signByDeltaS = signOfJacobian / m_fc_.deltaS;
+  real_t signByDeltaS = signOfJacobian / m_fc_.deltaS;
 
   // Compute derivatives on interior full-grid knots
   // and from them, evaluate radial force balance residual.
@@ -2151,7 +2184,7 @@ void IdealMhdModel::hybridLambdaForce() {
 
   // obtain first inside point
   int j0 = r_.nsMinF;
-  double sqrtSHi = 0.0;
+  real_t sqrtSHi = 0.0;
   if (j0 > 0) {
     sqrtSHi = m_p_.sqrtSH[j0 - 1 - r_.nsMinH];
   }
@@ -2176,7 +2209,7 @@ void IdealMhdModel::hybridLambdaForce() {
   }  // kl
 
   for (int jF = r_.nsMinF; jF < r_.nsMaxFIncludingLcfs; ++jF) {
-    double sqrtSHo = 0.0;
+    real_t sqrtSHo = 0.0;
     if (jF < r_.nsMaxH) {
       sqrtSHo = m_p_.sqrtSH[jF - r_.nsMinH];
     }
@@ -2184,11 +2217,11 @@ void IdealMhdModel::hybridLambdaForce() {
     for (int kl = 0; kl < s_.nZnT; ++kl) {
       // obtain next outside point
       // defaults to 0: no contribution from half-grid point outside LCFS
-      double bsubv_o = 0.0;
+      real_t bsubv_o = 0.0;
       // gvv / gsqrt
-      double gvv_gsqrt_o = 0.0;
+      real_t gvv_gsqrt_o = 0.0;
       // guv * bsupu
-      double guv_bsupu_o = 0.0;
+      real_t guv_bsupu_o = 0.0;
       if (jF < r_.nsMaxH) {
         // for the j-th forces full-grid point, the j-th half-grid point is
         // outside
@@ -2201,23 +2234,23 @@ void IdealMhdModel::hybridLambdaForce() {
       }
 
       // alternative way to interpolate bsubv onto the full-grid
-      double gvv_gsqrt_lu_e = 0.5 * (m_ls_.gvv_gsqrt_i[kl] + gvv_gsqrt_o) *
+      real_t gvv_gsqrt_lu_e = 0.5 * (m_ls_.gvv_gsqrt_i[kl] + gvv_gsqrt_o) *
                               lu_e[(jF - r_.nsMinF1) * s_.nZnT + kl];
-      double gvv_gsqrt_lu_o =
+      real_t gvv_gsqrt_lu_o =
           0.5 * (m_ls_.gvv_gsqrt_i[kl] * sqrtSHi + gvv_gsqrt_o * sqrtSHo) *
           lu_o[(jF - r_.nsMinF1) * s_.nZnT + kl];
 
-      double gvv_gsqrt_lu = gvv_gsqrt_lu_e + gvv_gsqrt_lu_o;
-      double bsubv_alternative = gvv_gsqrt_lu;
+      real_t gvv_gsqrt_lu = gvv_gsqrt_lu_e + gvv_gsqrt_lu_o;
+      real_t bsubv_alternative = gvv_gsqrt_lu;
       if (s_.lthreed) {
-        double guv_bsupu = 0.5 * (m_ls_.guv_bsupu_i[kl] + guv_bsupu_o);
+        real_t guv_bsupu = 0.5 * (m_ls_.guv_bsupu_i[kl] + guv_bsupu_o);
         bsubv_alternative += guv_bsupu;
       }
 
-      const double bsubv_average = 0.5 * (bsubv_o + m_ls_.bsubv_i[kl]);
+      const real_t bsubv_average = 0.5 * (bsubv_o + m_ls_.bsubv_i[kl]);
 
       // blend together two ways of interpolating bsubv
-      double _blmn =
+      real_t _blmn =
           bsubv_average * (1.0 - m_p_.radialBlending[jF - r_.nsMinF1]) +
           bsubv_alternative * m_p_.radialBlending[jF - r_.nsMinF1];
 
@@ -2234,12 +2267,12 @@ void IdealMhdModel::hybridLambdaForce() {
       if (s_.lthreed) {
         // obtain next outside point
         // defaults to 0 for half-grid point outside LCFS
-        double bsubu_o = 0.0;
+        real_t bsubu_o = 0.0;
         if (jF < r_.nsMaxH) {
           bsubu_o = bsubu[(jF - r_.nsMinH) * s_.nZnT + kl];
         }
 
-        double _clmn = 0.5 * (bsubu_o + m_ls_.bsubu_i[kl]);
+        real_t _clmn = 0.5 * (bsubu_o + m_ls_.bsubu_i[kl]);
 
         if (jF > 0) {
           // TODO(jons): no lamscale and (-1) factor for axis lambda force?
@@ -2274,11 +2307,11 @@ void IdealMhdModel::hybridLambdaForce() {
 // Compute normalization factors for force residuals.
 void IdealMhdModel::computeForceNorms(const FourierGeometry& decomposed_x) {
   // r2 in Fortran VMEC
-  double energyDensity =
+  real_t energyDensity =
       std::max(m_h_.magneticEnergy, m_h_.thermalEnergy) / m_h_.plasmaVolume;
 
-  double localForceNormSumRZ = 0.0;
-  double localForceNormSumL = 0.0;
+  real_t localForceNormSumRZ = 0.0;
+  real_t localForceNormSumL = 0.0;
   for (int jH = r_.nsMinH; jH < r_.nsMaxH; ++jH) {
     for (int kl = 0; kl < s_.nZnT; ++kl) {
       int iHalf = (jH - r_.nsMinH) * s_.nZnT + kl;
@@ -2303,7 +2336,7 @@ void IdealMhdModel::computeForceNorms(const FourierGeometry& decomposed_x) {
   // decomposed_x is over nsMinF1 ... nsMaxF1 --> would count overlapping
   // elements twice !!!
   const int nsMinHere = r_.nsMinF;
-  double localForceNorm1 =
+  real_t localForceNorm1 =
       decomposed_x.rzNorm(false, nsMinHere, r_.nsMaxFIncludingLcfs);
 
 #ifdef _OPENMP
@@ -2353,7 +2386,7 @@ void IdealMhdModel::computeMHDForces() {
 
   // obtain first inside point
   // stuff gets divided by sqrtSHi, so cannot be 0
-  double sqrtSHi = 1.0;
+  real_t sqrtSHi = 1.0;
   if (r_.nsMinF > 0) {
     // for the rel-0-th forces full-grid point, the rel-0-th half-grid point is
     // inside
@@ -2384,25 +2417,34 @@ void IdealMhdModel::computeMHDForces() {
     m_ls_.gbvbv_i.setZero();
   }
 
-  Eigen::VectorXd P_o =
-      Eigen::VectorXd::Zero(s_.nZnT);  //  r12 * totalPressure = P
-  Eigen::VectorXd rup_o = Eigen::VectorXd::Zero(s_.nZnT);   // ru12 * P
-  Eigen::VectorXd zup_o = Eigen::VectorXd::Zero(s_.nZnT);   // zu12 * P
-  Eigen::VectorXd rsp_o = Eigen::VectorXd::Zero(s_.nZnT);   //   rs * P
-  Eigen::VectorXd zsp_o = Eigen::VectorXd::Zero(s_.nZnT);   //   zs * P
-  Eigen::VectorXd taup_o = Eigen::VectorXd::Zero(s_.nZnT);  //  tau * P
-  Eigen::VectorXd gbubu_o =
-      Eigen::VectorXd::Zero(s_.nZnT);  // gsqrt * bsupu * bsupu
-  Eigen::VectorXd gbubv_o =
-      Eigen::VectorXd::Zero(s_.nZnT);  // gsqrt * bsupu * bsupv
-  Eigen::VectorXd gbvbv_o =
-      Eigen::VectorXd::Zero(s_.nZnT);  // gsqrt * bsupv * bsupv
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> P_o =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(
+          s_.nZnT);  //  r12 * totalPressure = P
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rup_o =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(s_.nZnT);  // ru12 * P
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zup_o =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(s_.nZnT);  // zu12 * P
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rsp_o =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(s_.nZnT);  //   rs * P
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zsp_o =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(s_.nZnT);  //   zs * P
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> taup_o =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(s_.nZnT);  //  tau * P
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> gbubu_o =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(
+          s_.nZnT);  // gsqrt * bsupu * bsupu
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> gbubv_o =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(
+          s_.nZnT);  // gsqrt * bsupu * bsupv
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> gbvbv_o =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(
+          s_.nZnT);  // gsqrt * bsupv * bsupv
 
   for (int jF = r_.nsMinF; jF < jMaxRZ; ++jF) {
-    const double sFull =
+    const real_t sFull =
         m_p_.sqrtSF[jF - r_.nsMinF1] * m_p_.sqrtSF[jF - r_.nsMinF1];
     // stuff gets divided by sqrtSHo, so cannot be 0
-    double sqrtSHo = 1.0;
+    real_t sqrtSHo = 1.0;
     if (jF < r_.nsMaxH) {
       sqrtSHo = m_p_.sqrtSH[jF - r_.nsMinH];
     }
@@ -2454,17 +2496,21 @@ void IdealMhdModel::computeMHDForces() {
     const auto z1o = z1_o.segment(g_off, nZnT);
 
     // Pre-compute common sub-expressions (averages and weighted averages)
-    const double invDS = 1.0 / m_fc_.deltaS;
-    const double invSHo = 1.0 / sqrtSHo;
-    const double invSHi = 1.0 / sqrtSHi;
-    const Eigen::VectorXd P_avg = 0.5 * (P_o + m_ls_.P_i);
-    const Eigen::VectorXd P_wavg = 0.5 * (P_o * invSHo + m_ls_.P_i * invSHi);
+    const real_t invDS = 1.0 / m_fc_.deltaS;
+    const real_t invSHo = 1.0 / sqrtSHo;
+    const real_t invSHi = 1.0 / sqrtSHi;
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1> P_avg =
+        0.5 * (P_o + m_ls_.P_i);
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1> P_wavg =
+        0.5 * (P_o * invSHo + m_ls_.P_i * invSHi);
 
-    const Eigen::VectorXd gbubu_avg = 0.5 * (gbubu_o + m_ls_.gbubu_i);
-    const Eigen::VectorXd gbubu_wavg =
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1> gbubu_avg =
+        0.5 * (gbubu_o + m_ls_.gbubu_i);
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1> gbubu_wavg =
         0.5 * (gbubu_o * sqrtSHo + m_ls_.gbubu_i * sqrtSHi);
-    const Eigen::VectorXd gbvbv_avg = 0.5 * (gbvbv_o + m_ls_.gbvbv_i);
-    const Eigen::VectorXd gbvbv_wavg =
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1> gbvbv_avg =
+        0.5 * (gbvbv_o + m_ls_.gbvbv_i);
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1> gbvbv_wavg =
         0.5 * (gbvbv_o * sqrtSHo + m_ls_.gbvbv_i * sqrtSHi);
 
     // A_R force
@@ -2502,8 +2548,9 @@ void IdealMhdModel::computeMHDForces() {
         gbubu_avg.cwiseProduct(zuo) * sFull;
 
     if (s_.lthreed) {
-      const Eigen::VectorXd gbubv_avg = 0.5 * (gbubv_o + m_ls_.gbubv_i);
-      const Eigen::VectorXd gbubv_wavg =
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1> gbubv_avg =
+          0.5 * (gbubv_o + m_ls_.gbubv_i);
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1> gbubv_wavg =
           0.5 * (gbubv_o * sqrtSHo + m_ls_.gbubv_i * sqrtSHi);
       const auto rve = rv_e.segment(g_off, nZnT);
       const auto rvo = rv_o.segment(g_off, nZnT);
@@ -2578,7 +2625,7 @@ void IdealMhdModel::updateLambdaPreconditioner() {
   // lambdaPreconditioner
 
   // TODO(jons): what is this ?
-  const double pFactor =
+  const real_t pFactor =
       dampingFactor / (4.0 * constants_.lamscale * constants_.lamscale);
 
   // evaluate preconditioning matrix elements on half-grid
@@ -2636,7 +2683,7 @@ void IdealMhdModel::updateLambdaPreconditioner() {
 
   for (int jF = std::max(jMin, r_.nsMinF); jF < r_.nsMaxFIncludingLcfs; ++jF) {
     for (int n = 0; n < s_.ntor + 1; ++n) {
-      double tnn = n * s_.nfp * n * s_.nfp;
+      real_t tnn = n * s_.nfp * n * s_.nfp;
 
       for (int m = 0; m < s_.mpol; ++m) {
         if (m == 0 && n == 0) {
@@ -2648,10 +2695,10 @@ void IdealMhdModel::updateLambdaPreconditioner() {
         int tmm = m * m;
 
         // TODO(jons): what is this ? (see below)
-        double pwr = std::min(tmm / (16.0 * 16.0), 8.0);
-        double tmn = 2.0 * m * n * s_.nfp;
+        real_t pwr = std::min(tmm / (16.0 * 16.0), 8.0);
+        real_t tmn = 2.0 * m * n * s_.nfp;
 
-        double faclam =
+        real_t faclam =
             tnn * bLambda[jF - r_.nsMinF] +
             tmn * copysign(dLambda[jF - r_.nsMinF], bLambda[jF - r_.nsMinF]) +
             tmm * cLambda[jF - r_.nsMinF];
@@ -2680,16 +2727,22 @@ void IdealMhdModel::updateLambdaPreconditioner() {
  * The diagonal terms (..d) are on the forces full-grid.
  */
 void IdealMhdModel::computePreconditioningMatrix(
-    const Eigen::VectorXd& xs, const Eigen::VectorXd& xu12,
-    const Eigen::VectorXd& xu_e, const Eigen::VectorXd& xu_o,
-    const Eigen::VectorXd& x1_o, Eigen::VectorXd& m_axm, Eigen::VectorXd& m_axd,
-    Eigen::VectorXd& m_bxm, Eigen::VectorXd& m_bxd, Eigen::VectorXd& m_cxd) {
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& xs,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& xu12,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& xu_e,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& xu_o,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& x1_o,
+    Eigen::Matrix<real_t, Eigen::Dynamic, 1>& m_axm,
+    Eigen::Matrix<real_t, Eigen::Dynamic, 1>& m_axd,
+    Eigen::Matrix<real_t, Eigen::Dynamic, 1>& m_bxm,
+    Eigen::Matrix<real_t, Eigen::Dynamic, 1>& m_bxd,
+    Eigen::Matrix<real_t, Eigen::Dynamic, 1>& m_cxd) {
   // zs, zu12, zu, z1 --> arm, ard, brm, brd, cxd
   // rs, ru12, ru, r1 --> azm, azd, bzm, bzd, cxd
 
   // restored in v8.51
   // TODO(jons): what is this?
-  double pFactor = -4.0;
+  real_t pFactor = -4.0;
 
   // zero intermediate work arrays
   absl::c_fill_n(ax, (r_.nsMaxH - r_.nsMinH) * 4, 0);
@@ -2705,16 +2758,16 @@ void IdealMhdModel::computePreconditioningMatrix(
 
       int l = kl % s_.nThetaEff;
 
-      double pTau =
+      real_t pTau =
           pFactor * r12[iHalf] * totalPressure[iHalf] / tau[iHalf] * s_.wInt[l];
 
       // COMPUTE DOMINANT (1/DELTA-S)**2 PRECONDITIONING MATRIX ELEMENTS
 
-      double t1a = xu12[iHalf] / m_fc_.deltaS;
-      double t2a =
+      real_t t1a = xu12[iHalf] / m_fc_.deltaS;
+      real_t t2a =
           0.25 * (xu_e[iFull_1] / m_p_.sqrtSH[jH - r_.nsMinH] + xu_o[iFull_1]) /
           m_p_.sqrtSH[jH - r_.nsMinH];
-      double t3a =
+      real_t t3a =
           0.25 * (xu_e[iFull_0] / m_p_.sqrtSH[jH - r_.nsMinH] + xu_o[iFull_0]) /
           m_p_.sqrtSH[jH - r_.nsMinH];
 
@@ -2737,9 +2790,9 @@ void IdealMhdModel::computePreconditioningMatrix(
 
       // assemble full radial derivative; incl radial interpolation of odd-m X
       // contrib (?)
-      double t1b =
+      real_t t1b =
           0.5 * (xs[iHalf] + 0.5 / m_p_.sqrtSH[jH - r_.nsMinH] * x1_o[iFull_1]);
-      double t2b =
+      real_t t2b =
           0.5 * (xs[iHalf] + 0.5 / m_p_.sqrtSH[jH - r_.nsMinH] * x1_o[iFull_0]);
 
       // even-m and odd-m
@@ -2761,8 +2814,8 @@ void IdealMhdModel::computePreconditioningMatrix(
     }  // kl
   }  // jH
 
-  const Eigen::VectorXd& sm = m_p_.sm;
-  const Eigen::VectorXd& sp = m_p_.sp;
+  const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& sm = m_p_.sm;
+  const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& sp = m_p_.sp;
 
   // radial assembly of preconditioning matrix element components
   // All this sm, sp logic seems to be related to the odd-m scaling factors...
@@ -2815,7 +2868,7 @@ absl::Status IdealMhdModel::constraintForceMultiplier() {
 
   // TODO(jons): some parabola in ns,
   // but why these specific values of the parameters ?
-  double tcon_multiplier =
+  real_t tcon_multiplier =
       tcon0 * (1.0 + m_fc_.ns * (1.0 / 60.0 + m_fc_.ns / (200.0 * 120.0)));
 
   // Scaling of ard, azd (2*r0scale**2);
@@ -2830,8 +2883,8 @@ absl::Status IdealMhdModel::constraintForceMultiplier() {
   }
 
   for (int jF = std::max(jMin, r_.nsMinF); jF < r_.nsMaxF; ++jF) {
-    double arNorm = 0.0;
-    double azNorm = 0.0;
+    real_t arNorm = 0.0;
+    real_t azNorm = 0.0;
     for (int kl = 0; kl < s_.nZnT; ++kl) {
       int idx_kl = (jF - r_.nsMinF) * s_.nZnT + kl;
       int l = kl % s_.nThetaEff;
@@ -2846,7 +2899,7 @@ absl::Status IdealMhdModel::constraintForceMultiplier() {
       return absl::InternalError("azNorm should never be 0.0.");
     }
 
-    double tcon_base =
+    real_t tcon_base =
         std::min(fabs(ard[(jF - r_.nsMinF) * 2 + kEvenParity] / arNorm),
                  fabs(azd[(jF - r_.nsMinF) * 2 + kEvenParity] / azNorm));
 
@@ -2918,8 +2971,8 @@ void IdealMhdModel::assembleTotalForces() {
     for (int kl = 0; kl < s_.nZnT; ++kl) {
       int idx_kl = (jF - r_.nsMinF) * s_.nZnT + kl;
 
-      double brcon = (rCon[idx_kl] - rCon0[idx_kl]) * gCon[idx_kl];
-      double bzcon = (zCon[idx_kl] - zCon0[idx_kl]) * gCon[idx_kl];
+      real_t brcon = (rCon[idx_kl] - rCon0[idx_kl]) * gCon[idx_kl];
+      real_t bzcon = (zCon[idx_kl] - zCon0[idx_kl]) * gCon[idx_kl];
 
       brmn_e[idx_kl] += brcon;
       bzmn_e[idx_kl] += bzcon;
@@ -3027,25 +3080,25 @@ void IdealMhdModel::dft_ForcesToFourier_2d_symm(FourierForces& m_physical_f) {
       for (int l = 0; l < s_.nThetaReduced; ++l) {
         const int idx_jl = (jF - r_.nsMinF) * s_.nThetaEff + l;
 
-        const double rnkcc = armn[idx_jl];
-        const double rnkcc_m = brmn[idx_jl];
-        const double znksc = azmn[idx_jl];
-        const double znksc_m = bzmn[idx_jl];
+        const real_t rnkcc = armn[idx_jl];
+        const real_t rnkcc_m = brmn[idx_jl];
+        const real_t znksc = azmn[idx_jl];
+        const real_t znksc_m = bzmn[idx_jl];
 
-        const double rcon_cc = frcon[idx_jl];
-        const double zcon_sc = fzcon[idx_jl];
+        const real_t rcon_cc = frcon[idx_jl];
+        const real_t zcon_sc = fzcon[idx_jl];
 
         const int idx_ml = m * s_.nThetaReduced + l;
-        const double cosmui = t_.cosmui[idx_ml];
-        const double sinmumi = t_.sinmumi[idx_ml];
-        const double sinmui = t_.sinmui[idx_ml];
-        const double cosmumi = t_.cosmumi[idx_ml];
+        const real_t cosmui = t_.cosmui[idx_ml];
+        const real_t sinmumi = t_.sinmumi[idx_ml];
+        const real_t sinmui = t_.sinmui[idx_ml];
+        const real_t cosmumi = t_.cosmumi[idx_ml];
         // assemble effective R and Z forces from MHD and spectral condensation
         // contributions
-        const double _rcc = rnkcc + xmpq[m] * rcon_cc;
+        const real_t _rcc = rnkcc + xmpq[m] * rcon_cc;
         m_physical_f.frcc[idx_jm] += _rcc * cosmui + rnkcc_m * sinmumi;
 
-        const double _zsc = znksc + xmpq[m] * zcon_sc;
+        const real_t _zsc = znksc + xmpq[m] * zcon_sc;
         m_physical_f.fzsc[idx_jm] += _zsc * sinmui + znksc_m * cosmumi;
       }  // m
     }  // l
@@ -3063,9 +3116,9 @@ void IdealMhdModel::dft_ForcesToFourier_2d_symm(FourierForces& m_physical_f) {
 
       for (int l = 0; l < s_.nThetaReduced; ++l) {
         const int idx_jl = (jF - r_.nsMinF) * s_.nThetaEff + l;
-        const double lnksc_m = blmn[idx_jl];
+        const real_t lnksc_m = blmn[idx_jl];
 
-        const double cosmumi = t_.cosmumi[m * s_.nThetaReduced + l];
+        const real_t cosmumi = t_.cosmumi[m * s_.nThetaReduced + l];
         m_physical_f.flsc[idx_jm] += lnksc_m * cosmumi;
       }  // m
     }  // l
@@ -3086,13 +3139,13 @@ void IdealMhdModel::applyM1Preconditioner(FourierForces& m_decomposed_f) {
       int m = 1;
       int mPar = m % 2;
 
-      double denom =
+      real_t denom =
           ard[(jF - r_.nsMinF) * 2 + mPar] + brd[(jF - r_.nsMinF) * 2 + mPar] +
           azd[(jF - r_.nsMinF) * 2 + mPar] + bzd[(jF - r_.nsMinF) * 2 + mPar];
-      double forceScaleR = (ard[(jF - r_.nsMinF) * 2 + mPar] +
+      real_t forceScaleR = (ard[(jF - r_.nsMinF) * 2 + mPar] +
                             brd[(jF - r_.nsMinF) * 2 + mPar]) /
                            denom;
-      double forceScaleZ = (azd[(jF - r_.nsMinF) * 2 + mPar] +
+      real_t forceScaleZ = (azd[(jF - r_.nsMinF) * 2 + mPar] +
                             bzd[(jF - r_.nsMinF) * 2 + mPar]) /
                            denom;
 
@@ -3193,7 +3246,7 @@ void IdealMhdModel::assembleRZPreconditioner() {
     // SMALL EDGE PEDESTAL NEEDED TO IMPROVE CONVERGENCE
     // IN PARTICULAR, NEEDED TO ACCOUNT FOR POTENTIAL ZERO
     // EIGENVALUE DUE TO NEUMANN (GRADIENT) CONDITION AT EDGE
-    const double edge_pedestal = 0.05;
+    const real_t edge_pedestal = 0.05;
     for (int n = 0; n < s_.ntor + 1; ++n) {
       {
         int m = 0;
@@ -3222,8 +3275,8 @@ void IdealMhdModel::assembleRZPreconditioner() {
     // COEFFICIENT OF < Ru (R Pvac)> ~ -fac*(z-zeq) WHERE fac (EIGENVALUE, OR
     // FIELD INDEX) DEPENDS ON THE EQUILIBRIUM MAGNETIC FIELD AND CURRENT,
     // AND zeq IS THE EQUILIBRIUM EDGE VALUE OF Z00
-    double fac = 0.25;
-    double multFact = std::min(fac, fac * m_fc_.deltaS * 15.0);
+    real_t fac = 0.25;
+    real_t multFact = std::min(fac, fac * m_fc_.deltaS * 15.0);
 
     // METHOD 1: SUBTRACT (INSTABILITY) Pedge ~ fac*z/hs FROM PRECONDITIONER AT
     // EDGE iflag parameter is used in Fortran VMEC to enable this feature only
@@ -3261,8 +3314,8 @@ void IdealMhdModel::assembleRZPreconditioner() {
 // serial variant
 absl::Status IdealMhdModel::applyRZPreconditioner(
     FourierForces& m_decomposed_f) {
-  std::vector<std::span<double>> cR(s_.num_basis);
-  std::vector<std::span<double>> cZ(s_.num_basis);
+  std::vector<std::span<real_t>> cR(s_.num_basis);
+  std::vector<std::span<real_t>> cZ(s_.num_basis);
   {
     int idx_basis = 0;
 
@@ -3340,14 +3393,14 @@ absl::Status IdealMhdModel::applyRZPreconditioner(
   // Uses span accessors to pass contiguous radial slices to the solver
   const int ns = m_h_.all_ar.cols();
   for (int mn = mnmin; mn < mnmax; ++mn) {
-    TridiagonalSolveSerial(std::span<double>(m_h_.all_ar.row(mn).data(), ns),
-                           std::span<double>(m_h_.all_dr.row(mn).data(), ns),
-                           std::span<double>(m_h_.all_br.row(mn).data(), ns),
+    TridiagonalSolveSerial(std::span<real_t>(m_h_.all_ar.row(mn).data(), ns),
+                           std::span<real_t>(m_h_.all_dr.row(mn).data(), ns),
+                           std::span<real_t>(m_h_.all_br.row(mn).data(), ns),
                            m_h_.all_cr[mn].data(), ns, jMin[mn], jMax,
                            s_.num_basis);
-    TridiagonalSolveSerial(std::span<double>(m_h_.all_az.row(mn).data(), ns),
-                           std::span<double>(m_h_.all_dz.row(mn).data(), ns),
-                           std::span<double>(m_h_.all_bz.row(mn).data(), ns),
+    TridiagonalSolveSerial(std::span<real_t>(m_h_.all_az.row(mn).data(), ns),
+                           std::span<real_t>(m_h_.all_dz.row(mn).data(), ns),
+                           std::span<real_t>(m_h_.all_bz.row(mn).data(), ns),
                            m_h_.all_cz[mn].data(), ns, jMin[mn], jMax,
                            s_.num_basis);
   }  // mn
@@ -3448,11 +3501,11 @@ void IdealMhdModel::applyLambdaPreconditioner(FourierForces& m_decomposed_f) {
   }  // j
 }
 
-double IdealMhdModel::get_delbsq() const {
-  double delBSqAvg = 0.0;
+real_t IdealMhdModel::get_delbsq() const {
+  real_t delBSqAvg = 0.0;
   if (m_fc_.lfreeb &&
       m_vacuum_pressure_state_ == VacuumPressureState::kActive) {
-    double delBSqNorm = 0.0;
+    real_t delBSqNorm = 0.0;
     for (int kl = 0; kl < s_.nZnT; ++kl) {
       int l = kl % s_.nThetaEff;
       delBSqAvg += delBSq[kl] * s_.wInt[l];

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
@@ -35,7 +35,8 @@ namespace vmecpp {
 // "FastPoloidal" indicates that, in real space, iterations use the
 // poloidal coordinate as the fast index.
 void ForcesToFourier3DSymmFastPoloidal(
-    const RealSpaceForces& d, const Eigen::VectorXd& xmpq,
+    const RealSpaceForces& d,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& xmpq,
     const RadialPartitioning& rp, const FlowControl& fc, const Sizes& s,
     const FourierBasisFastPoloidal& fb,
     VacuumPressureState vacuum_pressure_state,
@@ -44,21 +45,21 @@ void ForcesToFourier3DSymmFastPoloidal(
 // Implemented as a free function for easier testing and benchmarking.
 // "FastPoloidal" indicates that, in real space, iterations use the
 // poloidal coordinate as the fast index.
-void FourierToReal3DSymmFastPoloidal(const FourierGeometry& physical_x,
-                                     const Eigen::VectorXd& xmpq,
-                                     const RadialPartitioning& r,
-                                     const Sizes& s, const RadialProfiles& rp,
-                                     const FourierBasisFastPoloidal& fb,
-                                     RealSpaceGeometry& m_geometry);
+void FourierToReal3DSymmFastPoloidal(
+    const FourierGeometry& physical_x,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& xmpq,
+    const RadialPartitioning& r, const Sizes& s, const RadialProfiles& rp,
+    const FourierBasisFastPoloidal& fb, RealSpaceGeometry& m_geometry);
 
 // Implemented as a free function for easier testing and benchmarking.
-void deAliasConstraintForce(const RadialPartitioning& rp,
-                            const FourierBasisFastPoloidal& fb, const Sizes& s_,
-                            const Eigen::VectorXd& faccon,
-                            const Eigen::VectorXd& tcon,
-                            const Eigen::VectorXd& gConEff,
-                            Eigen::VectorXd& m_gsc, Eigen::VectorXd& m_gcs,
-                            Eigen::VectorXd& m_gCon);
+void deAliasConstraintForce(
+    const RadialPartitioning& rp, const FourierBasisFastPoloidal& fb,
+    const Sizes& s_, const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& faccon,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& tcon,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& gConEff,
+    Eigen::Matrix<real_t, Eigen::Dynamic, 1>& m_gsc,
+    Eigen::Matrix<real_t, Eigen::Dynamic, 1>& m_gcs,
+    Eigen::Matrix<real_t, Eigen::Dynamic, 1>& m_gCon);
 
 class IdealMhdModel {
  public:
@@ -73,11 +74,13 @@ class IdealMhdModel {
 
   // Compute the invariant (i.e., not preconditioned yet) force residuals.
   // Will put them into the provided array as { fsqr, fsqz, fsql }.
-  void evalFResInvar(const Eigen::VectorXd& localFResInvar);
+  void evalFResInvar(
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& localFResInvar);
 
   // Compute the preconditioned force residuals.
   // Will put them into the provided array as { fsqr1, fsqz1, fsql1 }.
-  void evalFResPrecd(const Eigen::VectorXd& localFResPrecd);
+  void evalFResPrecd(
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& localFResPrecd);
 
   // Return true/false depending on whether the VmecCheckpoint was reached,
   // or an error status if something went wrong.
@@ -193,11 +196,16 @@ class IdealMhdModel {
   // Support function for computing the radial preconditioner matrix elements
   // for R and Z.
   void computePreconditioningMatrix(
-      const Eigen::VectorXd& xs, const Eigen::VectorXd& xu12,
-      const Eigen::VectorXd& xu_e, const Eigen::VectorXd& xu_o,
-      const Eigen::VectorXd& x1_o, Eigen::VectorXd& m_axm,
-      Eigen::VectorXd& m_axd, Eigen::VectorXd& m_bxm, Eigen::VectorXd& m_bxd,
-      Eigen::VectorXd& m_cxd);
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& xs,
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& xu12,
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& xu_e,
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& xu_o,
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& x1_o,
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>& m_axm,
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>& m_axd,
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>& m_bxm,
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>& m_bxd,
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>& m_cxd);
 
   // Applies the radial preconditioner for the m=1 Fourier coefficients of R and
   // Z.
@@ -215,7 +223,7 @@ class IdealMhdModel {
   void applyLambdaPreconditioner(FourierForces& m_decomposed_f);
 
   // Computes the mismatch in |B|^2 at the LCFS.
-  double get_delbsq() const;
+  real_t get_delbsq() const;
 
   // `ivacskip` is the current counter that controls whether a full update or a
   // partial update of the Nestor free boundary force contribution is computed.
@@ -224,195 +232,195 @@ class IdealMhdModel {
   /**********************************************/
 
   // R on full-grid
-  Eigen::VectorXd r1_e;
-  Eigen::VectorXd r1_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> r1_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> r1_o;
 
   // dRdTheta on full-grid
-  Eigen::VectorXd ru_e;
-  Eigen::VectorXd ru_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> ru_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> ru_o;
 
   // dRdZeta on full-grid
-  Eigen::VectorXd rv_e;
-  Eigen::VectorXd rv_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rv_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rv_o;
 
   // Z on full-grid
-  Eigen::VectorXd z1_e;
-  Eigen::VectorXd z1_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> z1_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> z1_o;
 
   // dZdTheta on full-grid
-  Eigen::VectorXd zu_e;
-  Eigen::VectorXd zu_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zu_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zu_o;
 
   // dZdZeta on full-grid
-  Eigen::VectorXd zv_e;
-  Eigen::VectorXd zv_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zv_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zv_o;
 
   // d(lambda)dTheta on full-grid
-  Eigen::VectorXd lu_e;
-  Eigen::VectorXd lu_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> lu_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> lu_o;
 
   // d(lambda)dZeta on full-grid
-  Eigen::VectorXd lv_e;
-  Eigen::VectorXd lv_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> lv_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> lv_o;
 
   // constraint force contribution X on full-grid
-  Eigen::VectorXd rCon;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rCon;
 
   // constraint force contribution Y on full-grid
   // In free-boundary this starts as a large value and is slowly reduced to zero
   // to gradually increase the vacuum pressure constraint (force felt from the
   // B^2 contribution).
-  Eigen::VectorXd zCon;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zCon;
 
   // initial constraint force contribution X on full-grid.
   // In free-boundary this starts as a large value and is slowly reduced to zero
   // to gradually increase the vacuum pressure constraint (force felt from the
   // B^2 contribution).
-  Eigen::VectorXd rCon0;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rCon0;
 
   // initial constraint force contribution Y on full-grid
-  Eigen::VectorXd zCon0;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zCon0;
 
   // dRdTheta combined on full-grid
-  Eigen::VectorXd ruFull;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> ruFull;
 
   // dRdZeta combined on full-grid
-  Eigen::VectorXd zuFull;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zuFull;
 
   /**********************************************/
 
   // R on half-grid
-  Eigen::VectorXd r12;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> r12;
 
   // dRdTheta on half-grid
-  Eigen::VectorXd ru12;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> ru12;
 
   // dZdTheta on half-grid
-  Eigen::VectorXd zu12;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zu12;
 
   // dRdS on half-grid (without 0.5/sqrt(s) contrib)
-  Eigen::VectorXd rs;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rs;
 
   // dZdS on half-grid (without 0.5/sqrt(s) contrib)
-  Eigen::VectorXd zs;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zs;
 
   // sqrt(g)/R on half-grid
-  Eigen::VectorXd tau;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> tau;
 
   /**********************************************/
 
   // sqrt(g) == Jacobian on half-grid
-  Eigen::VectorXd gsqrt;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> gsqrt;
 
   // metric elements
-  Eigen::VectorXd guu;
-  Eigen::VectorXd guv;
-  Eigen::VectorXd gvv;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> guu;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> guv;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> gvv;
 
   /**********************************************/
 
   // contravariant magnetic field components
-  Eigen::VectorXd bsupu;
-  Eigen::VectorXd bsupv;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bsupu;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bsupv;
 
   /**********************************************/
 
   // covariant magnetic field components
-  Eigen::VectorXd bsubu;
-  Eigen::VectorXd bsubv;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bsubu;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bsubv;
 
   /**********************************************/
 
   // |B|^2/(2 mu_0) + p
-  Eigen::VectorXd totalPressure;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> totalPressure;
 
   // r * |B_vac|^2 at LCFS
-  Eigen::VectorXd rBSq;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rBSq;
 
   // (|B|^2/(2 mu_0) + p) on inside of LCFS
-  Eigen::VectorXd insideTotalPressure;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> insideTotalPressure;
 
   // mismatch in |B|^2 between plasma and vacuum regions at LCFS
-  Eigen::VectorXd delBSq;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> delBSq;
 
   /**********************************************/
 
   // real-space forces
-  Eigen::VectorXd armn_e;
-  Eigen::VectorXd armn_o;
-  Eigen::VectorXd brmn_e;
-  Eigen::VectorXd brmn_o;
-  Eigen::VectorXd crmn_e;
-  Eigen::VectorXd crmn_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> armn_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> armn_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> brmn_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> brmn_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> crmn_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> crmn_o;
   // ---------
-  Eigen::VectorXd azmn_e;
-  Eigen::VectorXd azmn_o;
-  Eigen::VectorXd bzmn_e;
-  Eigen::VectorXd bzmn_o;
-  Eigen::VectorXd czmn_e;
-  Eigen::VectorXd czmn_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> azmn_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> azmn_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bzmn_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bzmn_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> czmn_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> czmn_o;
   // ---------
-  Eigen::VectorXd blmn_e;
-  Eigen::VectorXd blmn_o;
-  Eigen::VectorXd clmn_e;
-  Eigen::VectorXd clmn_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> blmn_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> blmn_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> clmn_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> clmn_o;
 
   /**********************************************/
 
   // lambda preconditioner
-  Eigen::VectorXd bLambda;
-  Eigen::VectorXd dLambda;
-  Eigen::VectorXd cLambda;
-  Eigen::VectorXd lambdaPreconditioner;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bLambda;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> dLambda;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> cLambda;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> lambdaPreconditioner;
 
   // R,Z preconditioner
-  Eigen::VectorXd ax;
-  Eigen::VectorXd bx;
-  Eigen::VectorXd cx;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> ax;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bx;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> cx;
 
-  Eigen::VectorXd arm;
-  Eigen::VectorXd ard;
-  Eigen::VectorXd brm;
-  Eigen::VectorXd brd;
-  Eigen::VectorXd azm;
-  Eigen::VectorXd azd;
-  Eigen::VectorXd bzm;
-  Eigen::VectorXd bzd;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> arm;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> ard;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> brm;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> brd;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> azm;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> azd;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bzm;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bzd;
   // crd == czd --> cxd
-  Eigen::VectorXd cxd;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> cxd;
 
-  Eigen::VectorXd ar;
-  Eigen::VectorXd dr;
-  Eigen::VectorXd br;
-  Eigen::VectorXd az;
-  Eigen::VectorXd dz;
-  Eigen::VectorXd bz;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> ar;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> dr;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> br;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> az;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> dz;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bz;
 
   /**********************************************/
 
   // constraint force ingredients
-  Eigen::VectorXd xmpq;
-  Eigen::VectorXd faccon;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> xmpq;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> faccon;
 
   // radial profile of constraint force multiplier
-  Eigen::VectorXd tcon;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> tcon;
 
   // effective constraint force - still to be de-aliased
-  Eigen::VectorXd gConEff;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> gConEff;
 
   // Fourier coefficients of constraint force - used during de-aliasing
-  Eigen::VectorXd gsc;
-  Eigen::VectorXd gcs;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> gsc;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> gcs;
 
   // de-aliased constraint force - what enters the Fourier coefficients of the
   // forces
-  Eigen::VectorXd gCon;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> gCon;
 
   // Fourier coefficients of constraint force, de-aliased
-  Eigen::VectorXd frcon_e;
-  Eigen::VectorXd frcon_o;
-  Eigen::VectorXd fzcon_e;
-  Eigen::VectorXd fzcon_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> frcon_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> frcon_o;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> fzcon_e;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> fzcon_o;
 
  private:
   FlowControl& m_fc_;

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -142,14 +142,16 @@ absl::Status vmecpp::VmecInternalResults::LoadInto(
                 0) == 1) {
     READMEMBER(chipH);
   } else {
-    m_obj.chipH = Eigen::VectorXd::Zero(m_obj.phipH.size());
+    m_obj.chipH =
+        Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(m_obj.phipH.size());
   }
   // Legacy way of checking for dataset existence
   if (H5Lexists(from_file.getId(), absl::StrFormat("%s/currH", H5key).c_str(),
                 0) == 1) {
     READMEMBER(currH);
   } else {
-    m_obj.currH = Eigen::VectorXd::Zero(m_obj.phipH.size());
+    m_obj.currH =
+        Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(m_obj.phipH.size());
   }
   READMEMBER(phiF);
   READMEMBER(iotaF);
@@ -1027,11 +1029,11 @@ absl::Status vmecpp::WOutFileContents::LoadInto(WOutFileContents& m_obj,
   } else {
     // Legacy format: ns-1 sized arrays with old names.
     // Read into temporaries and pad to ns with a leading zero.
-    auto ReadHalfGridCompat = [&](Eigen::VectorXd& dest,
-                                  const std::string& old_name) {
-      Eigen::VectorXd tmp;
+    auto ReadHalfGridCompat = [&](auto& dest, const std::string& old_name) {
+      using DestT = std::remove_reference_t<decltype(dest)>;
+      DestT tmp;
       ReadH5Dataset(tmp, absl::StrFormat("%s/%s", H5key, old_name), from_file);
-      dest = Eigen::VectorXd::Zero(tmp.size() + 1);
+      dest = DestT::Zero(tmp.size() + 1);
       dest.tail(tmp.size()) = tmp;
     };
     ReadHalfGridCompat(m_obj.iotas, "iota_half");
@@ -1068,13 +1070,10 @@ absl::Status vmecpp::WOutFileContents::LoadInto(WOutFileContents& m_obj,
   // new format uses (mnmax, ns). Detect by checking if dimensions match.
   // Also handle half-grid arrays that changed from (ns-1, mnmax) to (mnmax,
   // ns).
-  auto ReadAndTranspose2D = [&](RowMatrixXd& dest, const std::string& name) {
-    RowMatrixXd tmp;
+  auto ReadAndTranspose2D = [&](auto& dest, const std::string& name) {
+    using DestT = std::remove_reference_t<decltype(dest)>;
+    DestT tmp;
     ReadH5Dataset(tmp, absl::StrFormat("%s/%s", H5key, name), from_file);
-    // If rows > cols, this is old (ns, mnmax) layout; transpose it.
-    // New layout is (mnmax, ns) where mnmax < ns is not guaranteed,
-    // so we check if the stored shape matches (mnmax, ns) or (ns, mnmax).
-    // We know mnmax and ns from already-read fields.
     if (tmp.rows() == m_obj.ns &&
         (tmp.cols() == m_obj.mnmax || tmp.cols() == m_obj.mnmax_nyq)) {
       dest = tmp.transpose();
@@ -1082,21 +1081,22 @@ absl::Status vmecpp::WOutFileContents::LoadInto(WOutFileContents& m_obj,
       dest = tmp;
     }
   };
-  auto ReadAndTransposePadHalfGrid2D =
-      [&](RowMatrixXd& dest, const std::string& name, int mnsize) {
-        RowMatrixXd tmp;
-        ReadH5Dataset(tmp, absl::StrFormat("%s/%s", H5key, name), from_file);
-        // Old format: (ns-1, mnsize) -> transpose and pad to (mnsize, ns)
-        if (tmp.rows() == m_obj.ns - 1 && tmp.cols() == mnsize) {
-          dest = RowMatrixXd::Zero(mnsize, m_obj.ns);
-          dest.rightCols(m_obj.ns - 1) = tmp.transpose();
-        } else if (tmp.rows() == m_obj.ns && tmp.cols() == mnsize) {
-          // Old full-grid format (ns, mnsize) e.g. bsubsmns -> transpose
-          dest = tmp.transpose();
-        } else {
-          dest = tmp;
-        }
-      };
+  auto ReadAndTransposePadHalfGrid2D = [&](auto& dest, const std::string& name,
+                                           int mnsize) {
+    using DestT = std::remove_reference_t<decltype(dest)>;
+    DestT tmp;
+    ReadH5Dataset(tmp, absl::StrFormat("%s/%s", H5key, name), from_file);
+    // Old format: (ns-1, mnsize) -> transpose and pad to (mnsize, ns)
+    if (tmp.rows() == m_obj.ns - 1 && tmp.cols() == mnsize) {
+      dest = DestT::Zero(mnsize, m_obj.ns);
+      dest.rightCols(m_obj.ns - 1) = tmp.transpose();
+    } else if (tmp.rows() == m_obj.ns && tmp.cols() == mnsize) {
+      // Old full-grid format (ns, mnsize) e.g. bsubsmns -> transpose
+      dest = tmp.transpose();
+    } else {
+      dest = tmp;
+    }
+  };
 
   ReadAndTranspose2D(m_obj.rmnc, "rmnc");
   ReadAndTranspose2D(m_obj.zmns, "zmns");
@@ -1572,89 +1572,104 @@ vmecpp::VmecInternalResults vmecpp::GatherDataFromThreads(
 
   results.nZnT_reduced = s.nThetaReduced * s.nZeta;
 
-  results.sqrtSH = VectorXd::Zero(results.num_half);
-  results.sqrtSF = VectorXd::Zero(results.num_full);
+  results.sqrtSH =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(results.num_half);
+  results.sqrtSF =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(results.num_full);
 
-  results.sm = VectorXd::Zero(results.num_half);
-  results.sp = VectorXd::Zero(results.num_half);
+  results.sm = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(results.num_half);
+  results.sp = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(results.num_half);
 
-  results.phipF = VectorXd::Zero(results.num_full);
-  results.chipF = VectorXd::Zero(results.num_full);
+  results.phipF =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(results.num_full);
+  results.chipF =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(results.num_full);
 
   // computed in RecomputeToroidalFlux here!
-  results.phiF = VectorXd::Zero(results.num_full);
+  results.phiF =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(results.num_full);
 
-  results.iotaF = VectorXd::Zero(results.num_full);
-  results.spectral_width = VectorXd::Zero(results.num_full);
+  results.iotaF =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(results.num_full);
+  results.spectral_width =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(results.num_full);
 
-  results.phipH = VectorXd::Zero(results.num_half);
-  results.chipH = VectorXd::Zero(results.num_half);
-  results.bvcoH = VectorXd::Zero(results.num_half);
-  results.dVdsH = VectorXd::Zero(results.num_half);
-  results.massH = VectorXd::Zero(results.num_half);
-  results.presH = VectorXd::Zero(results.num_half);
-  results.iotaH = VectorXd::Zero(results.num_half);
-  results.currH = VectorXd::Zero(results.num_half);
+  results.phipH =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(results.num_half);
+  results.chipH =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(results.num_half);
+  results.bvcoH =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(results.num_half);
+  results.dVdsH =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(results.num_half);
+  results.massH =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(results.num_half);
+  results.presH =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(results.num_half);
+  results.iotaH =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(results.num_half);
+  results.currH =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(results.num_half);
 
   // state vector
-  results.rmncc = RowMatrixXd::Zero(results.num_full, s.mnsize);
-  results.zmnsc = RowMatrixXd::Zero(results.num_full, s.mnsize);
-  results.lmnsc = RowMatrixXd::Zero(results.num_full, s.mnsize);
+  results.rmncc = RowMatrixXr::Zero(results.num_full, s.mnsize);
+  results.zmnsc = RowMatrixXr::Zero(results.num_full, s.mnsize);
+  results.lmnsc = RowMatrixXr::Zero(results.num_full, s.mnsize);
   if (s.lthreed) {
-    results.rmnss = RowMatrixXd::Zero(results.num_full, s.mnsize);
-    results.zmncs = RowMatrixXd::Zero(results.num_full, s.mnsize);
-    results.lmncs = RowMatrixXd::Zero(results.num_full, s.mnsize);
+    results.rmnss = RowMatrixXr::Zero(results.num_full, s.mnsize);
+    results.zmncs = RowMatrixXr::Zero(results.num_full, s.mnsize);
+    results.lmncs = RowMatrixXr::Zero(results.num_full, s.mnsize);
   }
   if (s.lasym) {
-    results.rmnsc = RowMatrixXd::Zero(results.num_full, s.mnsize);
-    results.zmncc = RowMatrixXd::Zero(results.num_full, s.mnsize);
-    results.lmncc = RowMatrixXd::Zero(results.num_full, s.mnsize);
+    results.rmnsc = RowMatrixXr::Zero(results.num_full, s.mnsize);
+    results.zmncc = RowMatrixXr::Zero(results.num_full, s.mnsize);
+    results.lmncc = RowMatrixXr::Zero(results.num_full, s.mnsize);
     if (s.lthreed) {
-      results.rmncs = RowMatrixXd::Zero(results.num_full, s.mnsize);
-      results.zmnss = RowMatrixXd::Zero(results.num_full, s.mnsize);
-      results.lmnss = RowMatrixXd::Zero(results.num_full, s.mnsize);
+      results.rmncs = RowMatrixXr::Zero(results.num_full, s.mnsize);
+      results.zmnss = RowMatrixXr::Zero(results.num_full, s.mnsize);
+      results.lmnss = RowMatrixXr::Zero(results.num_full, s.mnsize);
     }
   }
 
   // from inv-DFTs
-  results.r_e = RowMatrixXd::Zero(results.num_full, s.nZnT);
-  results.r_o = RowMatrixXd::Zero(results.num_full, s.nZnT);
-  results.z_e = RowMatrixXd::Zero(results.num_full, s.nZnT);
-  results.z_o = RowMatrixXd::Zero(results.num_full, s.nZnT);
+  results.r_e = RowMatrixXr::Zero(results.num_full, s.nZnT);
+  results.r_o = RowMatrixXr::Zero(results.num_full, s.nZnT);
+  results.z_e = RowMatrixXr::Zero(results.num_full, s.nZnT);
+  results.z_o = RowMatrixXr::Zero(results.num_full, s.nZnT);
 
-  results.ru_e = RowMatrixXd::Zero(results.num_full, s.nZnT);
-  results.ru_o = RowMatrixXd::Zero(results.num_full, s.nZnT);
-  results.zu_e = RowMatrixXd::Zero(results.num_full, s.nZnT);
-  results.zu_o = RowMatrixXd::Zero(results.num_full, s.nZnT);
-  results.rv_e = RowMatrixXd::Zero(results.num_full, s.nZnT);
-  results.rv_o = RowMatrixXd::Zero(results.num_full, s.nZnT);
-  results.zv_e = RowMatrixXd::Zero(results.num_full, s.nZnT);
-  results.zv_o = RowMatrixXd::Zero(results.num_full, s.nZnT);
+  results.ru_e = RowMatrixXr::Zero(results.num_full, s.nZnT);
+  results.ru_o = RowMatrixXr::Zero(results.num_full, s.nZnT);
+  results.zu_e = RowMatrixXr::Zero(results.num_full, s.nZnT);
+  results.zu_o = RowMatrixXr::Zero(results.num_full, s.nZnT);
+  results.rv_e = RowMatrixXr::Zero(results.num_full, s.nZnT);
+  results.rv_o = RowMatrixXr::Zero(results.num_full, s.nZnT);
+  results.zv_e = RowMatrixXr::Zero(results.num_full, s.nZnT);
+  results.zv_o = RowMatrixXr::Zero(results.num_full, s.nZnT);
 
   // from even-m and odd-m contributions
-  results.ruFull = RowMatrixXd::Zero(results.num_full, s.nZnT);
-  results.zuFull = RowMatrixXd::Zero(results.num_full, s.nZnT);
+  results.ruFull = RowMatrixXr::Zero(results.num_full, s.nZnT);
+  results.zuFull = RowMatrixXr::Zero(results.num_full, s.nZnT);
 
   // from Jacobian
-  results.r12 = RowMatrixXd::Zero(results.num_half, s.nZnT);
-  results.ru12 = RowMatrixXd::Zero(results.num_half, s.nZnT);
-  results.zu12 = RowMatrixXd::Zero(results.num_half, s.nZnT);
-  results.rs = RowMatrixXd::Zero(results.num_half, s.nZnT);
-  results.zs = RowMatrixXd::Zero(results.num_half, s.nZnT);
-  results.gsqrt = RowMatrixXd::Zero(results.num_half, s.nZnT);
+  results.r12 = RowMatrixXr::Zero(results.num_half, s.nZnT);
+  results.ru12 = RowMatrixXr::Zero(results.num_half, s.nZnT);
+  results.zu12 = RowMatrixXr::Zero(results.num_half, s.nZnT);
+  results.rs = RowMatrixXr::Zero(results.num_half, s.nZnT);
+  results.zs = RowMatrixXr::Zero(results.num_half, s.nZnT);
+  results.gsqrt = RowMatrixXr::Zero(results.num_half, s.nZnT);
 
   // metric elements
-  results.guu = RowMatrixXd::Zero(results.num_half, s.nZnT);
-  results.guv = RowMatrixXd::Zero(results.num_half, s.nZnT);
-  results.gvv = RowMatrixXd::Zero(results.num_half, s.nZnT);
+  results.guu = RowMatrixXr::Zero(results.num_half, s.nZnT);
+  results.guv = RowMatrixXr::Zero(results.num_half, s.nZnT);
+  results.gvv = RowMatrixXr::Zero(results.num_half, s.nZnT);
 
   // magnetic field
-  results.bsupu = RowMatrixXd::Zero(results.num_half, s.nZnT);
-  results.bsupv = RowMatrixXd::Zero(results.num_half, s.nZnT);
-  results.bsubu = RowMatrixXd::Zero(results.num_half, s.nZnT);
-  results.bsubv = RowMatrixXd::Zero(results.num_half, s.nZnT);
-  results.bsubvF = RowMatrixXd::Zero(results.num_full, s.nZnT);
-  results.total_pressure = RowMatrixXd::Zero(results.num_half, s.nZnT);
+  results.bsupu = RowMatrixXr::Zero(results.num_half, s.nZnT);
+  results.bsupv = RowMatrixXr::Zero(results.num_half, s.nZnT);
+  results.bsubu = RowMatrixXr::Zero(results.num_half, s.nZnT);
+  results.bsubv = RowMatrixXr::Zero(results.num_half, s.nZnT);
+  results.bsubvF = RowMatrixXr::Zero(results.num_full, s.nZnT);
+  results.total_pressure = RowMatrixXr::Zero(results.num_half, s.nZnT);
 
   const std::size_t num_threads = radial_partitioning.size();
   for (std::size_t thread_id = 0; thread_id < num_threads; ++thread_id) {
@@ -1896,17 +1911,17 @@ vmecpp::RemainingMetric vmecpp::ComputeRemainingMetric(
 
   // for bss
   remaining_metric.rv12 =
-      RowMatrixXd::Zero(vmec_internal_results.num_half, s.nZnT);
+      RowMatrixXr::Zero(vmec_internal_results.num_half, s.nZnT);
   remaining_metric.zv12 =
-      RowMatrixXd::Zero(vmec_internal_results.num_full, s.nZnT);
+      RowMatrixXr::Zero(vmec_internal_results.num_full, s.nZnT);
   remaining_metric.rs12 =
-      RowMatrixXd::Zero(vmec_internal_results.num_half, s.nZnT);
+      RowMatrixXr::Zero(vmec_internal_results.num_half, s.nZnT);
   remaining_metric.zs12 =
-      RowMatrixXd::Zero(vmec_internal_results.num_full, s.nZnT);
+      RowMatrixXr::Zero(vmec_internal_results.num_full, s.nZnT);
   remaining_metric.gsu =
-      RowMatrixXd::Zero(vmec_internal_results.num_half, s.nZnT);
+      RowMatrixXr::Zero(vmec_internal_results.num_half, s.nZnT);
   remaining_metric.gsv =
-      RowMatrixXd::Zero(vmec_internal_results.num_full, s.nZnT);
+      RowMatrixXr::Zero(vmec_internal_results.num_full, s.nZnT);
 
   for (int jH = 0; jH < vmec_internal_results.num_half; ++jH) {
     for (int kl = 0; kl < s.nZnT; ++kl) {
@@ -1962,10 +1977,10 @@ vmecpp::CylindricalComponentsOfB vmecpp::BCylindricalComponents(
     const RemainingMetric& remaining_metric) {
   CylindricalComponentsOfB b_cylindrical;
 
-  b_cylindrical.b_r = RowMatrixXd::Zero(vmec_internal_results.num_half, s.nZnT);
+  b_cylindrical.b_r = RowMatrixXr::Zero(vmec_internal_results.num_half, s.nZnT);
   b_cylindrical.b_phi =
-      RowMatrixXd::Zero(vmec_internal_results.num_half, s.nZnT);
-  b_cylindrical.b_z = RowMatrixXd::Zero(vmec_internal_results.num_half, s.nZnT);
+      RowMatrixXr::Zero(vmec_internal_results.num_half, s.nZnT);
+  b_cylindrical.b_z = RowMatrixXr::Zero(vmec_internal_results.num_half, s.nZnT);
 
   for (int jH = 0; jH < vmec_internal_results.num_half; ++jH) {
     for (int kl = 0; kl < s.nZnT; ++kl) {
@@ -1990,7 +2005,7 @@ vmecpp::BSubSHalf vmecpp::ComputeBSubSOnHalfGrid(
     const RemainingMetric& remaining_metric) {
   BSubSHalf bsubs_half;
   bsubs_half.bsubs_half =
-      RowMatrixXd::Zero(vmec_internal_results.num_half, s.nZnT);
+      RowMatrixXr::Zero(vmec_internal_results.num_half, s.nZnT);
 
   for (int jH = 0; jH < vmec_internal_results.num_half; ++jH) {
     for (int kl = 0; kl < s.nZnT; ++kl) {
@@ -2009,7 +2024,7 @@ vmecpp::BSubSFull vmecpp::PutBSubSOnFullGrid(
     const BSubSHalf& bsubs_half) {
   BSubSFull bsubs_full;
   bsubs_full.bsubs_full =
-      RowMatrixXd::Zero(vmec_internal_results.num_full, s.nZnT);
+      RowMatrixXr::Zero(vmec_internal_results.num_full, s.nZnT);
 
   // ignore axis and boundary for now
   for (int jF = 1; jF < vmec_internal_results.num_full - 1; ++jF) {
@@ -2031,19 +2046,19 @@ vmecpp::SymmetryDecomposedCovariantB vmecpp::DecomposeCovariantBBySymmetry(
     const BSubSFull& bsubs_full) {
   SymmetryDecomposedCovariantB decomposed_bcov;
 
-  decomposed_bcov.bsubs_s = RowMatrixXd::Zero(
+  decomposed_bcov.bsubs_s = RowMatrixXr::Zero(
       vmec_internal_results.num_full, vmec_internal_results.nZnT_reduced);
-  decomposed_bcov.bsubu_s = RowMatrixXd::Zero(
+  decomposed_bcov.bsubu_s = RowMatrixXr::Zero(
       vmec_internal_results.num_half, vmec_internal_results.nZnT_reduced);
-  decomposed_bcov.bsubv_s = RowMatrixXd::Zero(
+  decomposed_bcov.bsubv_s = RowMatrixXr::Zero(
       vmec_internal_results.num_half, vmec_internal_results.nZnT_reduced);
 
   if (s.lasym) {
-    decomposed_bcov.bsubs_a = RowMatrixXd::Zero(
+    decomposed_bcov.bsubs_a = RowMatrixXr::Zero(
         vmec_internal_results.num_full, vmec_internal_results.nZnT_reduced);
-    decomposed_bcov.bsubu_a = RowMatrixXd::Zero(
+    decomposed_bcov.bsubu_a = RowMatrixXr::Zero(
         vmec_internal_results.num_half, vmec_internal_results.nZnT_reduced);
-    decomposed_bcov.bsubv_a = RowMatrixXd::Zero(
+    decomposed_bcov.bsubv_a = RowMatrixXr::Zero(
         vmec_internal_results.num_half, vmec_internal_results.nZnT_reduced);
 
     // fsym_fft:
@@ -2135,15 +2150,15 @@ vmecpp::CovariantBDerivatives vmecpp::LowPassFilterCovariantB(
   CovariantBDerivatives covariant_b_derivatives;
 
   covariant_b_derivatives.bsubsu =
-      RowMatrixXd::Zero(m_vmec_internal_results.num_full, s.nZnT);
+      RowMatrixXr::Zero(m_vmec_internal_results.num_full, s.nZnT);
   covariant_b_derivatives.bsubsv =
-      RowMatrixXd::Zero(m_vmec_internal_results.num_full, s.nZnT);
+      RowMatrixXr::Zero(m_vmec_internal_results.num_full, s.nZnT);
 
   // TODO(jons): no split into (non-)stellarator-symmetric contributions?
   covariant_b_derivatives.bsubuv =
-      RowMatrixXd::Zero(m_vmec_internal_results.num_half, s.nZnT);
+      RowMatrixXr::Zero(m_vmec_internal_results.num_half, s.nZnT);
   covariant_b_derivatives.bsubvu =
-      RowMatrixXd::Zero(m_vmec_internal_results.num_half, s.nZnT);
+      RowMatrixXr::Zero(m_vmec_internal_results.num_half, s.nZnT);
 
   std::vector<double> bsubsu_s(m_vmec_internal_results.num_full * s.nZnT, 0.0);
   std::vector<double> bsubsv_s(m_vmec_internal_results.num_full * s.nZnT, 0.0);
@@ -2497,40 +2512,50 @@ vmecpp::JxBOutFileContents vmecpp::ComputeJxBOutputFileContents(
     const bool return_outputs_even_if_not_converged, VmecStatus vmec_status) {
   JxBOutFileContents jxbout;
 
-  jxbout.itheta = RowMatrixXd::Zero(vmec_internal_results.num_full, s.nZnT);
-  jxbout.izeta = RowMatrixXd::Zero(vmec_internal_results.num_full, s.nZnT);
-  jxbout.bdotk = RowMatrixXd::Zero(vmec_internal_results.num_full, s.nZnT);
+  jxbout.itheta = RowMatrixXr::Zero(vmec_internal_results.num_full, s.nZnT);
+  jxbout.izeta = RowMatrixXr::Zero(vmec_internal_results.num_full, s.nZnT);
+  jxbout.bdotk = RowMatrixXr::Zero(vmec_internal_results.num_full, s.nZnT);
 
-  jxbout.amaxfor = VectorXd::Zero(vmec_internal_results.num_full);
-  jxbout.aminfor = VectorXd::Zero(vmec_internal_results.num_full);
-  jxbout.avforce = VectorXd::Zero(vmec_internal_results.num_full);
-  jxbout.pprim = VectorXd::Zero(vmec_internal_results.num_full);
-  jxbout.jdotb = VectorXd::Zero(vmec_internal_results.num_full);
-  jxbout.bdotb = VectorXd::Zero(vmec_internal_results.num_full);
-  jxbout.bdotgradv = VectorXd::Zero(vmec_internal_results.num_full);
-  jxbout.jpar2 = VectorXd::Zero(vmec_internal_results.num_full);
-  jxbout.jperp2 = VectorXd::Zero(vmec_internal_results.num_full);
-  jxbout.phin = VectorXd::Zero(vmec_internal_results.num_full);
+  jxbout.amaxfor = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(
+      vmec_internal_results.num_full);
+  jxbout.aminfor = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(
+      vmec_internal_results.num_full);
+  jxbout.avforce = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(
+      vmec_internal_results.num_full);
+  jxbout.pprim = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(
+      vmec_internal_results.num_full);
+  jxbout.jdotb = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(
+      vmec_internal_results.num_full);
+  jxbout.bdotb = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(
+      vmec_internal_results.num_full);
+  jxbout.bdotgradv = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(
+      vmec_internal_results.num_full);
+  jxbout.jpar2 = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(
+      vmec_internal_results.num_full);
+  jxbout.jperp2 = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(
+      vmec_internal_results.num_full);
+  jxbout.phin = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(
+      vmec_internal_results.num_full);
 
   jxbout.phin[fc.ns - 1] = 1.0;
 
-  jxbout.jsupu3 = RowMatrixXd::Zero(vmec_internal_results.num_full, s.nZnT);
-  jxbout.jsupv3 = RowMatrixXd::Zero(vmec_internal_results.num_full, s.nZnT);
-  jxbout.jsups3 = RowMatrixXd::Zero(vmec_internal_results.num_half, s.nZnT);
+  jxbout.jsupu3 = RowMatrixXr::Zero(vmec_internal_results.num_full, s.nZnT);
+  jxbout.jsupv3 = RowMatrixXr::Zero(vmec_internal_results.num_full, s.nZnT);
+  jxbout.jsups3 = RowMatrixXr::Zero(vmec_internal_results.num_half, s.nZnT);
 
-  jxbout.bsupu3 = RowMatrixXd::Zero(vmec_internal_results.num_full, s.nZnT);
-  jxbout.bsupv3 = RowMatrixXd::Zero(vmec_internal_results.num_full, s.nZnT);
+  jxbout.bsupu3 = RowMatrixXr::Zero(vmec_internal_results.num_full, s.nZnT);
+  jxbout.bsupv3 = RowMatrixXr::Zero(vmec_internal_results.num_full, s.nZnT);
 
-  jxbout.jcrossb = RowMatrixXd::Zero(vmec_internal_results.num_full, s.nZnT);
-  jxbout.jxb_gradp = RowMatrixXd::Zero(vmec_internal_results.num_full, s.nZnT);
+  jxbout.jcrossb = RowMatrixXr::Zero(vmec_internal_results.num_full, s.nZnT);
+  jxbout.jxb_gradp = RowMatrixXr::Zero(vmec_internal_results.num_full, s.nZnT);
   jxbout.jdotb_sqrtg =
-      RowMatrixXd::Zero(vmec_internal_results.num_full, s.nZnT);
+      RowMatrixXr::Zero(vmec_internal_results.num_full, s.nZnT);
 
-  jxbout.sqrtg3 = RowMatrixXd::Zero(vmec_internal_results.num_full, s.nZnT);
+  jxbout.sqrtg3 = RowMatrixXr::Zero(vmec_internal_results.num_full, s.nZnT);
 
-  jxbout.bsubu3 = RowMatrixXd::Zero(vmec_internal_results.num_half, s.nZnT);
-  jxbout.bsubv3 = RowMatrixXd::Zero(vmec_internal_results.num_half, s.nZnT);
-  jxbout.bsubs3 = RowMatrixXd::Zero(vmec_internal_results.num_full, s.nZnT);
+  jxbout.bsubu3 = RowMatrixXr::Zero(vmec_internal_results.num_half, s.nZnT);
+  jxbout.bsubv3 = RowMatrixXr::Zero(vmec_internal_results.num_half, s.nZnT);
+  jxbout.bsubs3 = RowMatrixXr::Zero(vmec_internal_results.num_full, s.nZnT);
 
   std::vector<double> pprim(fc.ns, 0.0);
 
@@ -2872,25 +2897,38 @@ vmecpp::ComputeIntermediateMercierQuantities(
 
   MercierStabilityIntermediateQuantities mercier_intermediate;
 
-  mercier_intermediate.s = VectorXd::Zero(fc.ns);
-  mercier_intermediate.shear = VectorXd::Zero(fc.ns);
-  mercier_intermediate.vpp = VectorXd::Zero(fc.ns);
-  mercier_intermediate.d_pressure_d_s = VectorXd::Zero(fc.ns);
-  mercier_intermediate.d_toroidal_current_d_s = VectorXd::Zero(fc.ns);
-  mercier_intermediate.phip_realH = VectorXd::Zero(fc.ns - 1);
-  mercier_intermediate.phip_realF = VectorXd::Zero(fc.ns);
-  mercier_intermediate.vp_real = VectorXd::Zero(fc.ns - 1);
-  mercier_intermediate.torcur = VectorXd::Zero(fc.ns - 1);
+  mercier_intermediate.s =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier_intermediate.shear =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier_intermediate.vpp =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier_intermediate.d_pressure_d_s =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier_intermediate.d_toroidal_current_d_s =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier_intermediate.phip_realH =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns - 1);
+  mercier_intermediate.phip_realF =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier_intermediate.vp_real =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns - 1);
+  mercier_intermediate.torcur =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns - 1);
 
-  mercier_intermediate.gsqrt_full = RowMatrixXd::Zero(fc.ns, s.nZnT);
-  mercier_intermediate.bdotj = RowMatrixXd::Zero(fc.ns, s.nZnT);
-  mercier_intermediate.gpp = RowMatrixXd::Zero(fc.ns, s.nZnT);
-  mercier_intermediate.b2 = RowMatrixXd::Zero(fc.ns - 1, s.nZnT);
+  mercier_intermediate.gsqrt_full = RowMatrixXr::Zero(fc.ns, s.nZnT);
+  mercier_intermediate.bdotj = RowMatrixXr::Zero(fc.ns, s.nZnT);
+  mercier_intermediate.gpp = RowMatrixXr::Zero(fc.ns, s.nZnT);
+  mercier_intermediate.b2 = RowMatrixXr::Zero(fc.ns - 1, s.nZnT);
 
-  mercier_intermediate.tpp = VectorXd::Zero(fc.ns);
-  mercier_intermediate.tbb = VectorXd::Zero(fc.ns);
-  mercier_intermediate.tjb = VectorXd::Zero(fc.ns);
-  mercier_intermediate.tjj = VectorXd::Zero(fc.ns);
+  mercier_intermediate.tpp =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier_intermediate.tbb =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier_intermediate.tjb =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier_intermediate.tjj =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
 
   for (int jH = 0; jH < fc.ns - 1; ++jH) {
     // NOTE: phip_real should be > 0 to get the correct physical sign of
@@ -3080,24 +3118,27 @@ vmecpp::MercierFileContents vmecpp::ComputeMercierStability(
     const MercierStabilityIntermediateQuantities& mercier_intermediate) {
   MercierFileContents mercier;
 
-  mercier.s = VectorXd::Zero(fc.ns);
-  mercier.toroidal_flux = VectorXd::Zero(fc.ns);
-  mercier.iota = VectorXd::Zero(fc.ns);
-  mercier.shear = VectorXd::Zero(fc.ns);
-  mercier.d_volume_d_s = VectorXd::Zero(fc.ns);
-  mercier.well = VectorXd::Zero(fc.ns);
-  mercier.toroidal_current = VectorXd::Zero(fc.ns);
-  mercier.d_toroidal_current_d_s = VectorXd::Zero(fc.ns);
-  mercier.pressure = VectorXd::Zero(fc.ns);
-  mercier.d_pressure_d_s = VectorXd::Zero(fc.ns);
+  mercier.s = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier.toroidal_flux = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier.iota = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier.shear = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier.d_volume_d_s = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier.well = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier.toroidal_current =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier.d_toroidal_current_d_s =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier.pressure = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier.d_pressure_d_s =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
 
   // -------------------
 
-  mercier.DMerc = VectorXd::Zero(fc.ns);
-  mercier.Dshear = VectorXd::Zero(fc.ns);
-  mercier.Dwell = VectorXd::Zero(fc.ns);
-  mercier.Dcurr = VectorXd::Zero(fc.ns);
-  mercier.Dgeod = VectorXd::Zero(fc.ns);
+  mercier.DMerc = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier.Dshear = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier.Dwell = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier.Dcurr = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  mercier.Dgeod = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
 
   // first table in Mercier output file
   for (int jF = 1; jF < fc.ns - 1; ++jF) {
@@ -3195,27 +3236,43 @@ vmecpp::ComputeIntermediateThreed1FirstTableQuantities(
     const VmecInternalResults& vmec_internal_results) {
   Threed1FirstTableIntermediate threed1_first_table_intermediate;
 
-  threed1_first_table_intermediate.tau = RowMatrixXd::Zero(fc.ns - 1, s.nZnT);
+  threed1_first_table_intermediate.tau = RowMatrixXr::Zero(fc.ns - 1, s.nZnT);
 
   // [ns - 1]
-  threed1_first_table_intermediate.beta_vol = VectorXd::Zero(fc.ns - 1);
-  threed1_first_table_intermediate.overr = VectorXd::Zero(fc.ns - 1);
-  threed1_first_table_intermediate.bvcoH = VectorXd::Zero(fc.ns - 1);
-  threed1_first_table_intermediate.bucoH = VectorXd::Zero(fc.ns - 1);
+  threed1_first_table_intermediate.beta_vol =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns - 1);
+  threed1_first_table_intermediate.overr =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns - 1);
+  threed1_first_table_intermediate.bvcoH =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns - 1);
+  threed1_first_table_intermediate.bucoH =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns - 1);
 
   // [ns]
-  threed1_first_table_intermediate.presf = VectorXd::Zero(fc.ns);
-  threed1_first_table_intermediate.phipf_loc = VectorXd::Zero(fc.ns);
-  threed1_first_table_intermediate.phi1 = VectorXd::Zero(fc.ns);
-  threed1_first_table_intermediate.chi1 = VectorXd::Zero(fc.ns);
-  threed1_first_table_intermediate.chi = VectorXd::Zero(fc.ns);
-  threed1_first_table_intermediate.jcurv = VectorXd::Zero(fc.ns);
-  threed1_first_table_intermediate.jcuru = VectorXd::Zero(fc.ns);
-  threed1_first_table_intermediate.presgrad = VectorXd::Zero(fc.ns);
-  threed1_first_table_intermediate.vpphi = VectorXd::Zero(fc.ns);
-  threed1_first_table_intermediate.equif = VectorXd::Zero(fc.ns);
-  threed1_first_table_intermediate.bucof = VectorXd::Zero(fc.ns);
-  threed1_first_table_intermediate.bvcof = VectorXd::Zero(fc.ns);
+  threed1_first_table_intermediate.presf =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table_intermediate.phipf_loc =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table_intermediate.phi1 =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table_intermediate.chi1 =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table_intermediate.chi =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table_intermediate.jcurv =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table_intermediate.jcuru =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table_intermediate.presgrad =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table_intermediate.vpphi =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table_intermediate.equif =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table_intermediate.bucof =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table_intermediate.bvcof =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
 
   // NOTE:  S=normalized toroidal flux (0 - 1)
   //        U=poloidal angle (0 - 2*pi)
@@ -3442,20 +3499,33 @@ vmecpp::Threed1FirstTable vmecpp::ComputeThreed1FirstTable(
 
   Threed1FirstTable threed1_first_table;
 
-  threed1_first_table.s = VectorXd::Zero(fc.ns);
-  threed1_first_table.radial_force = VectorXd::Zero(fc.ns);
-  threed1_first_table.toroidal_flux = VectorXd::Zero(fc.ns);
-  threed1_first_table.iota = VectorXd::Zero(fc.ns);
-  threed1_first_table.avg_jsupu = VectorXd::Zero(fc.ns);
-  threed1_first_table.avg_jsupv = VectorXd::Zero(fc.ns);
-  threed1_first_table.d_volume_d_phi = VectorXd::Zero(fc.ns);
-  threed1_first_table.d_pressure_d_phi = VectorXd::Zero(fc.ns);
-  threed1_first_table.spectral_width = VectorXd::Zero(fc.ns);
-  threed1_first_table.pressure = VectorXd::Zero(fc.ns);
-  threed1_first_table.buco_full = VectorXd::Zero(fc.ns);
-  threed1_first_table.bvco_full = VectorXd::Zero(fc.ns);
-  threed1_first_table.j_dot_b = VectorXd::Zero(fc.ns);
-  threed1_first_table.b_dot_b = VectorXd::Zero(fc.ns);
+  threed1_first_table.s = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table.radial_force =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table.toroidal_flux =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table.iota =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table.avg_jsupu =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table.avg_jsupv =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table.d_volume_d_phi =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table.d_pressure_d_phi =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table.spectral_width =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table.pressure =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table.buco_full =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table.bvco_full =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table.j_dot_b =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  threed1_first_table.b_dot_b =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
 
   // NOTE: phipf = phipf_loc/(twopi), phipf_loc ACTUAL (twopi factor) Toroidal
   // flux derivative SPH/JDH (060211): remove twopi factors from <JSUPU,V>
@@ -3543,7 +3613,8 @@ vmecpp::ComputeIntermediateThreed1GeometricMagneticQuantities(
 
   // Calculate poloidal circumference and normal surface area and aspect ratio
   // Normal is | dr/du X dr/dv | = SQRT [R**2 guu + (RuZv - RvZu)**2]
-  intermediate.surf_area = VectorXd::Zero(s.nZnT);
+  intermediate.surf_area =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(s.nZnT);
   intermediate.circumference_sum = 0.0;
   for (int kl = 0; kl < s.nZnT; ++kl) {
     const int l = kl % s.nThetaEff;
@@ -3593,10 +3664,11 @@ vmecpp::ComputeIntermediateThreed1GeometricMagneticQuantities(
   // rshaf [= RT in Eq.(12), Phys Fluids B 5 (1993) 3119]
   //
   // Note: tau = |gsqrt|*wint
-  intermediate.btor_vac = VectorXd::Zero(s.nZnT);
-  intermediate.btor1 = VectorXd::Zero(s.nZnT);
-  intermediate.dbtor = VectorXd::Zero(s.nZnT);
-  intermediate.phat = VectorXd::Zero(s.nZnT);
+  intermediate.btor_vac =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(s.nZnT);
+  intermediate.btor1 = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(s.nZnT);
+  intermediate.dbtor = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(s.nZnT);
+  intermediate.phat = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(s.nZnT);
 
   // Eq. 20 in Shafranov
   intermediate.delphid_exact = 0.0;
@@ -3646,7 +3718,7 @@ vmecpp::ComputeIntermediateThreed1GeometricMagneticQuantities(
   intermediate.fpsi0 = 1.5 * threed1_first_table_intermediate.bvcoH[0] -
                        0.5 * threed1_first_table_intermediate.bvcoH[1];
 
-  intermediate.redge = VectorXd::Zero(s.nZnT);
+  intermediate.redge = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(s.nZnT);
   for (int kl = 0; kl < s.nZnT; ++kl) {
     const int lcfs_kl = (fc.ns - 1) * s.nZnT + kl;
     intermediate.redge[kl] =
@@ -3731,7 +3803,7 @@ vmecpp::ComputeIntermediateThreed1GeometricMagneticQuantities(
   // TODO(jons): figure out what fac is and assign a better name
   intermediate.fac =
       2.0 * M_PI * fc.deltaS * vmec_internal_results.sign_of_jacobian;
-  intermediate.r3v = VectorXd::Zero(fc.ns - 1);
+  intermediate.r3v = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns - 1);
   for (int jH = 0; jH < fc.ns - 1; ++jH) {
     intermediate.r3v[jH] = intermediate.fac * vmec_internal_results.phipH[jH] *
                            vmec_internal_results.iotaH[jH];
@@ -3845,13 +3917,14 @@ vmecpp::ComputeThreed1GeometricMagneticQuantities(
         vmec_internal_results.r_e(lcfs_kl) + vmec_internal_results.r_o(lcfs_kl);
     const double z =
         vmec_internal_results.z_e(lcfs_kl) + vmec_internal_results.z_o(lcfs_kl);
-    result.rmax_surf = std::max(result.rmax_surf, r);
-    result.rmin_surf = std::min(result.rmin_surf, r);
-    result.zmax_surf = std::max(result.zmax_surf, z);
+    result.rmax_surf = std::max(result.rmax_surf, static_cast<real_t>(r));
+    result.rmin_surf = std::min(result.rmin_surf, static_cast<real_t>(r));
+    result.zmax_surf = std::max(result.zmax_surf, static_cast<real_t>(z));
   }  // kl
 
-  result.bmin = RowMatrixXd::Ones(fc.ns - 1, s.nThetaReduced) * DBL_MAX;
-  result.bmax = RowMatrixXd::Zero(fc.ns - 1, s.nThetaReduced);
+  result.bmin = RowMatrixXr::Ones(fc.ns - 1, s.nThetaReduced) *
+                static_cast<real_t>(DBL_MAX);
+  result.bmax = RowMatrixXr::Zero(fc.ns - 1, s.nThetaReduced);
 
   for (int jH = 0; jH < fc.ns - 1; ++jH) {
     for (int k = 0; k < s.nZeta; ++k) {
@@ -3862,10 +3935,10 @@ vmecpp::ComputeThreed1GeometricMagneticQuantities(
         const double mod_b =
             std::sqrt(2.0 * (vmec_internal_results.total_pressure(index_half) -
                              vmec_internal_results.presH[jH]));
-        result.bmax(jH * s.nThetaReduced + l) =
-            std::max(result.bmax(jH * s.nThetaEff + l), mod_b);
-        result.bmin(jH * s.nThetaReduced + l) =
-            std::min(result.bmin(jH * s.nThetaEff + l), mod_b);
+        result.bmax(jH * s.nThetaReduced + l) = std::max(
+            result.bmax(jH * s.nThetaEff + l), static_cast<real_t>(mod_b));
+        result.bmin(jH * s.nThetaReduced + l) = std::min(
+            result.bmin(jH * s.nThetaEff + l), static_cast<real_t>(mod_b));
       }  // k
     }  // l
   }  // jH
@@ -3876,8 +3949,10 @@ vmecpp::ComputeThreed1GeometricMagneticQuantities(
   if (s.ntor > 0) {
     symmetry_planes_count = 2;
   }
-  result.waist = VectorXd::Zero(symmetry_planes_count);
-  result.height = VectorXd::Zero(symmetry_planes_count);
+  result.waist =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(symmetry_planes_count);
+  result.height =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(symmetry_planes_count);
 
   int symmetry_plane_index = 0;
   for (int k = 0; k < s.nZeta / 2 + 1; ++k) {
@@ -3902,7 +3977,7 @@ vmecpp::ComputeThreed1GeometricMagneticQuantities(
       const double z = vmec_internal_results.z_e(index_zeta) +
                        vmec_internal_results.z_o(index_zeta);
       result.height[symmetry_plane_index] =
-          std::max(result.height[symmetry_plane_index], z);
+          std::max(result.height[symmetry_plane_index], static_cast<real_t>(z));
     }  // l
     result.height[symmetry_plane_index] *= 2.0;
 
@@ -3930,15 +4005,16 @@ vmecpp::ComputeThreed1GeometricMagneticQuantities(
   result.rbtor = handover_storage.rBtor;
   result.rbtor0 = handover_storage.rBtor0;
 
-  result.psi = VectorXd::Zero(fc.ns);
+  result.psi = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
   for (int jF = 1; jF < fc.ns; ++jF) {
     const int jFi = jF - 1;
     const int jHi = jF - 1;
     result.psi[jF] = result.psi[jFi] + intermediate.r3v[jHi];
   }  // jF
 
-  result.loc_jpar_perp = VectorXd::Zero(fc.ns);
-  result.loc_jparPS_perp = VectorXd::Zero(fc.ns);
+  result.loc_jpar_perp = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  result.loc_jparPS_perp =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
   for (int jF = 1; jF < fc.ns; ++jF) {
     double jperp2 = DBL_EPSILON;
     if (jxbout.jperp2[jF] != 0.0) {
@@ -3955,11 +4031,11 @@ vmecpp::ComputeThreed1GeometricMagneticQuantities(
     }
   }  // jF
 
-  result.ygeo = VectorXd::Zero(2 * fc.ns);
-  result.yinden = VectorXd::Zero(2 * fc.ns);
-  result.yellip = VectorXd::Zero(2 * fc.ns);
-  result.ytrian = VectorXd::Zero(2 * fc.ns);
-  result.yshift = VectorXd::Zero(2 * fc.ns);
+  result.ygeo = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(2 * fc.ns);
+  result.yinden = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(2 * fc.ns);
+  result.yellip = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(2 * fc.ns);
+  result.ytrian = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(2 * fc.ns);
+  result.yshift = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(2 * fc.ns);
   for (int nplanes = 0; nplanes < 2; ++nplanes) {
     // phi = 0 deg -> first symmetry plane per toroidal module
     int k = 0;
@@ -4106,11 +4182,15 @@ vmecpp::Threed1AxisGeometry vmecpp::ComputeThreed1AxisGeometry(
     const VmecInternalResults& vmec_internal_results) {
   Threed1AxisGeometry result;
 
-  result.raxis_symm = VectorXd::Zero(s.ntor + 1);
-  result.zaxis_symm = VectorXd::Zero(s.ntor + 1);
+  result.raxis_symm =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(s.ntor + 1);
+  result.zaxis_symm =
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(s.ntor + 1);
   if (s.lasym) {
-    result.raxis_asym = VectorXd::Zero(s.ntor + 1);
-    result.zaxis_asym = VectorXd::Zero(s.ntor + 1);
+    result.raxis_asym =
+        Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(s.ntor + 1);
+    result.zaxis_asym =
+        Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(s.ntor + 1);
   }
 
   // magnetic axis is at radial index 0
@@ -4330,21 +4410,21 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
   wout.piota_type = indata.piota_type;
 
   // mass profile: am, am_aux_s, am_aux_f
-  wout.am = NonEmptyVectorOr(indata.am, 0.0);
-  wout.am_aux_s = NonEmptyVectorOr(indata.am_aux_s, -1.0);
-  wout.am_aux_f = NonEmptyVectorOr(indata.am_aux_f, 0.0);
-  wout.ac = NonEmptyVectorOr(indata.ac, 0.0);
-  wout.ac_aux_s = NonEmptyVectorOr(indata.ac_aux_s, -1.0);
-  wout.ac_aux_f = NonEmptyVectorOr(indata.ac_aux_f, 0.0);
-  wout.ai = NonEmptyVectorOr(indata.ai, 0.0);
-  wout.ai_aux_s = NonEmptyVectorOr(indata.ai_aux_s, -1.0);
-  wout.ai_aux_f = NonEmptyVectorOr(indata.ai_aux_f, 0.0);
+  wout.am = NonEmptyVectorOr(indata.am, 0.0).cast<real_t>();
+  wout.am_aux_s = NonEmptyVectorOr(indata.am_aux_s, -1.0).cast<real_t>();
+  wout.am_aux_f = NonEmptyVectorOr(indata.am_aux_f, 0.0).cast<real_t>();
+  wout.ac = NonEmptyVectorOr(indata.ac, 0.0).cast<real_t>();
+  wout.ac_aux_s = NonEmptyVectorOr(indata.ac_aux_s, -1.0).cast<real_t>();
+  wout.ac_aux_f = NonEmptyVectorOr(indata.ac_aux_f, 0.0).cast<real_t>();
+  wout.ai = NonEmptyVectorOr(indata.ai, 0.0).cast<real_t>();
+  wout.ai_aux_s = NonEmptyVectorOr(indata.ai_aux_s, -1.0).cast<real_t>();
+  wout.ai_aux_f = NonEmptyVectorOr(indata.ai_aux_f, 0.0).cast<real_t>();
 
   // Right-pad profile arrays to match Fortran VMEC output sizes.
   constexpr int kPreset = 21;
   constexpr int kNdfmax = 101;
 
-  auto PadVector = [](Eigen::VectorXd& vec, int target_size, double pad_value) {
+  auto PadVector = [](auto& vec, int target_size, double pad_value) {
     if (vec.size() < target_size) {
       const int old_size = vec.size();
       vec.conservativeResize(target_size);
@@ -4457,13 +4537,14 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
 
   wout.iotaf = m_vmec_internal_results.iotaF;
 
-  wout.q_factor = VectorXd::Ones(fc.ns) * DBL_MAX;
+  wout.q_factor = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Ones(fc.ns) *
+                  static_cast<real_t>(DBL_MAX);
 
-  wout.presf = VectorXd::Zero(fc.ns);
-  wout.phipf = VectorXd::Zero(fc.ns);
-  wout.chipf = VectorXd::Zero(fc.ns);
-  wout.jcuru = VectorXd::Zero(fc.ns);
-  wout.jcurv = VectorXd::Zero(fc.ns);
+  wout.presf = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  wout.phipf = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  wout.chipf = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  wout.jcuru = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  wout.jcurv = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
 
   for (int jF = 0; jF < fc.ns; ++jF) {
     if (wout.iotaf[jF] != 0.0) {
@@ -4481,25 +4562,25 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
   wout.chi = threed1_first_table_intermediate.chi;
   wout.specw = m_vmec_internal_results.spectral_width;
 
-  wout.mass = VectorXd::Zero(fc.ns);
-  wout.pres = VectorXd::Zero(fc.ns);
+  wout.mass = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
+  wout.pres = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
   for (int jH = 0; jH < fc.ns - 1; ++jH) {
     wout.mass[jH + 1] = m_vmec_internal_results.massH[jH] / MU_0;
     wout.pres[jH + 1] = m_vmec_internal_results.presH[jH] / MU_0;
   }  // jH
-  wout.iotas = VectorXd::Zero(fc.ns);
+  wout.iotas = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
   wout.iotas.tail(fc.ns - 1) = m_vmec_internal_results.iotaH;
-  wout.beta_vol = VectorXd::Zero(fc.ns);
+  wout.beta_vol = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
   wout.beta_vol.tail(fc.ns - 1) = threed1_first_table_intermediate.beta_vol;
-  wout.buco = VectorXd::Zero(fc.ns);
+  wout.buco = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
   wout.buco.tail(fc.ns - 1) = threed1_first_table_intermediate.bucoH;
-  wout.bvco = VectorXd::Zero(fc.ns);
+  wout.bvco = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
   wout.bvco.tail(fc.ns - 1) = threed1_first_table_intermediate.bvcoH;
-  wout.vp = VectorXd::Zero(fc.ns);
+  wout.vp = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
   wout.vp.tail(fc.ns - 1) = m_vmec_internal_results.dVdsH;
-  wout.phips = VectorXd::Zero(fc.ns);
+  wout.phips = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
   wout.phips.tail(fc.ns - 1) = m_vmec_internal_results.phipH;
-  wout.over_r = VectorXd::Zero(fc.ns);
+  wout.over_r = Eigen::Matrix<real_t, Eigen::Dynamic, 1>::Zero(fc.ns);
   wout.over_r.tail(fc.ns - 1) = threed1_first_table_intermediate.overr;
 
   wout.jdotb = jxbout.jdotb;
@@ -4576,9 +4657,9 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
   // CONVERT TO rmnc, zmns, lmns, etc EXTERNAL representation (without internal
   // mscale, nscale) IF B^v ~ phip + lamu, MUST DIVIDE BY phipf(js) below to
   // maintain old-style format
-  wout.rmnc = RowMatrixXd::Zero(s.mnmax, fc.ns);
-  wout.zmns = RowMatrixXd::Zero(s.mnmax, fc.ns);
-  wout.lmns_full = RowMatrixXd::Zero(s.mnmax, fc.ns);
+  wout.rmnc = RowMatrixXr::Zero(s.mnmax, fc.ns);
+  wout.zmns = RowMatrixXr::Zero(s.mnmax, fc.ns);
+  wout.lmns_full = RowMatrixXr::Zero(s.mnmax, fc.ns);
   for (int jF = 0; jF < fc.ns; ++jF) {
     std::vector<double> rmnc1(s.mnmax, 0.0);
     std::vector<double> zmns1(s.mnmax, 0.0);
@@ -4657,7 +4738,7 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
 
   // INTERPOLATE LAMBDA ONTO HALF-MESH FOR BACKWARDS CONSISTENCY WITH EARLIER
   // VERSIONS OF VMEC AND SMOOTHS POSSIBLE UNPHYSICAL "WIGGLE" ON RADIAL MESH
-  wout.lmns = RowMatrixXd::Zero(s.mnmax, fc.ns);
+  wout.lmns = RowMatrixXr::Zero(s.mnmax, fc.ns);
   for (int jH = 0; jH < fc.ns - 1; ++jH) {
     const int jFi = jH;
     const int jFo = jH + 1;
@@ -4712,30 +4793,30 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
   // Fourier-transform derived quantities for each surface individually
 
   // half-grid
-  wout.gmnc = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
-  wout.bmnc = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
-  wout.bsubumnc = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
-  wout.bsubvmnc = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
+  wout.gmnc = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
+  wout.bmnc = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
+  wout.bsubumnc = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
+  wout.bsubvmnc = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
 
   // Note: bsubsmns is a half-grid quantity,
   // but stored in Fortran VMEC fashion offset by 1 index to the right,
   // in order to also have the (wrong) extrapolation
   // beyond the axis on the j=0 grid point
   // for backwards compatibility.
-  wout.bsubsmns = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
+  wout.bsubsmns = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
 
-  wout.bsupumnc = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
-  wout.bsupvmnc = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
+  wout.bsupumnc = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
+  wout.bsupvmnc = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
 
   // Initialize asymmetric arrays for lasym=true cases
   if (s.lasym) {
-    wout.gmns = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
-    wout.bmns = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
-    wout.bsubumns = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
-    wout.bsubvmns = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
-    wout.bsubsmnc = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
-    wout.bsupumns = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
-    wout.bsupvmns = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
+    wout.gmns = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
+    wout.bmns = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
+    wout.bsubumns = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
+    wout.bsubvmns = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
+    wout.bsubsmnc = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
+    wout.bsupumns = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
+    wout.bsupvmns = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
   }
   for (int jH = 0; jH < fc.ns - 1; ++jH) {
     for (int mn_nyq = 0; mn_nyq < s.mnmax_nyq; ++mn_nyq) {
@@ -4868,9 +4949,9 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
     // internal mscale, nscale) IF B^v ~ phip + lamu, MUST DIVIDE BY phipf(js)
     // below to maintain old-style format
 
-    wout.rmns = RowMatrixXd::Zero(s.mnmax, fc.ns);
-    wout.zmnc = RowMatrixXd::Zero(s.mnmax, fc.ns);
-    wout.lmnc_full = RowMatrixXd::Zero(s.mnmax, fc.ns);
+    wout.rmns = RowMatrixXr::Zero(s.mnmax, fc.ns);
+    wout.zmnc = RowMatrixXr::Zero(s.mnmax, fc.ns);
+    wout.lmnc_full = RowMatrixXr::Zero(s.mnmax, fc.ns);
     for (int jF = 0; jF < fc.ns; ++jF) {
       std::vector<double> rmns1(s.mnmax, 0.0);
       std::vector<double> zmnc1(s.mnmax, 0.0);
@@ -4950,7 +5031,7 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
     // INTERPOLATE LAMBDA ONTO HALF-MESH FOR BACKWARDS CONSISTENCY WITH EARLIER
     // VERSIONS OF VMEC AND SMOOTHS POSSIBLE UNPHYSICAL "WIGGLE" ON RADIAL MESH
 
-    wout.lmnc = RowMatrixXd::Zero(s.mnmax, fc.ns);
+    wout.lmnc = RowMatrixXr::Zero(s.mnmax, fc.ns);
     for (int jH = 0; jH < fc.ns - 1; ++jH) {
       const int jFi = jH;
       const int jFo = jH + 1;
@@ -4992,11 +5073,11 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
   {
     const double ohs = 1.0 / fc.deltaS;
 
-    wout.currumnc = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
-    wout.currvmnc = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
+    wout.currumnc = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
+    wout.currvmnc = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
     if (s.lasym) {
-      wout.currumns = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
-      wout.currvmns = RowMatrixXd::Zero(s.mnmax_nyq, fc.ns);
+      wout.currumns = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
+      wout.currvmns = RowMatrixXr::Zero(s.mnmax_nyq, fc.ns);
     }
 
     // Interior full-grid points: j_f = 1 .. ns-2
@@ -5125,16 +5206,22 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
 
 void vmecpp::CompareWOut(const WOutFileContents& test_wout,
                          const WOutFileContents& expected_wout,
-                         double tolerance, bool check_equal_niter) {
+                         real_t tolerance, bool check_equal_niter) {
   CHECK_EQ(test_wout.signgs, expected_wout.signgs);
   CHECK_EQ(test_wout.gamma, expected_wout.gamma);
   CHECK_EQ(test_wout.pcurr_type, expected_wout.pcurr_type);
   CHECK_EQ(test_wout.pmass_type, expected_wout.pmass_type);
   CHECK_EQ(test_wout.piota_type, expected_wout.piota_type);
 
-  CHECK(IsVectorCloseRelAbs(expected_wout.am, test_wout.am, tolerance));
-  CHECK(IsVectorCloseRelAbs(expected_wout.ac, test_wout.ac, tolerance));
-  CHECK(IsVectorCloseRelAbs(expected_wout.ai, test_wout.ai, tolerance));
+  CHECK(IsVectorCloseRelAbs(expected_wout.am.cast<double>(),
+                            test_wout.am.cast<double>(),
+                            static_cast<double>(tolerance)));
+  CHECK(IsVectorCloseRelAbs(expected_wout.ac.cast<double>(),
+                            test_wout.ac.cast<double>(),
+                            static_cast<double>(tolerance)));
+  CHECK(IsVectorCloseRelAbs(expected_wout.ai.cast<double>(),
+                            test_wout.ai.cast<double>(),
+                            static_cast<double>(tolerance)));
 
   CHECK_EQ(test_wout.nfp, expected_wout.nfp);
   CHECK_EQ(test_wout.mpol, expected_wout.mpol);
@@ -5340,7 +5427,7 @@ void vmecpp::CompareWOut(const WOutFileContents& test_wout,
       // where the arrays are empty (e.g. loaded from old HDF5 files).
       if (expected_wout.currumnc.size() > 0 && test_wout.currumnc.size() > 0 &&
           jF > 0 && jF < ns - 1 && tolerance < 1.0e-2) {
-        const double curr_tol = std::max(tolerance * 10.0, 1.0e-4);
+        const real_t curr_tol = std::max(tolerance * 10.0L, 1.0e-4L);
         CHECK(IsCloseRelAbs(expected_wout.currumnc(mn_nyq, jF),
                             test_wout.currumnc(mn_nyq, jF), curr_tol))
             << "jF = " << jF << " mn_nyq = " << mn_nyq;

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
@@ -5,7 +5,7 @@
 #ifndef VMECPP_VMEC_OUTPUT_QUANTITIES_OUTPUT_QUANTITIES_H_
 #define VMECPP_VMEC_OUTPUT_QUANTITIES_OUTPUT_QUANTITIES_H_
 
-#include <Eigen/Dense>  // VectorXd
+#include <Eigen/Dense>
 #include <filesystem>
 #include <memory>
 #include <string>
@@ -15,6 +15,7 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "vmecpp/common/sizes/sizes.h"
+#include "vmecpp/common/util/real_type.h"
 #include "vmecpp/common/util/util.h"
 #include "vmecpp/common/vmec_indata/vmec_indata.h"
 #include "vmecpp/vmec/handover_storage/handover_storage.h"
@@ -37,149 +38,149 @@ struct VmecInternalResults {
   // nZeta * nThetaReduced: always one half-period (for DFTs)
   int nZnT_reduced;
 
-  Eigen::VectorXd sqrtSH;
-  Eigen::VectorXd sqrtSF;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sqrtSH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sqrtSF;
 
-  Eigen::VectorXd sm;
-  Eigen::VectorXd sp;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sm;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sp;
 
   // [ns] radial derivative of enclosed toroidal magnetic flux on full-grid
-  Eigen::VectorXd phipF;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> phipF;
 
   // [ns] radial derivative of enclosed poloidal magnetic flux on full-grid
-  Eigen::VectorXd chipF;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> chipF;
 
   // [ns - 1] radial derivative of enclosed toroidal magnetic flux on half-grid
-  Eigen::VectorXd phipH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> phipH;
 
   // [ns - 1] radial derivative of enclosed poloidal magnetic flux on half-grid
-  Eigen::VectorXd chipH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> chipH;
 
   // [ns - 1] enclosed current profile on half-grid
-  Eigen::VectorXd currH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> currH;
 
   // [ns] enclosed toroidal magnetic flux on full-grid; computed in
   // RecomputeToroidalFlux here!
-  Eigen::VectorXd phiF;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> phiF;
 
   // [ns] rotational transform on full-grid
-  Eigen::VectorXd iotaF;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> iotaF;
 
   // [ns] surface-averaged spectral width profile on full-grid
-  Eigen::VectorXd spectral_width;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> spectral_width;
 
   // enclosed poloidal current on half-grid
-  Eigen::VectorXd bvcoH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bvcoH;
 
   // [num_half] d(volume)/ds on half-grid
-  Eigen::VectorXd dVdsH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> dVdsH;
 
   // [num_half] mass profile on half-grid
-  Eigen::VectorXd massH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> massH;
 
   // [num_half] kinetic pressure on half-grid
-  Eigen::VectorXd presH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> presH;
 
   // [num_half] rotational transform profile on half-grid
-  Eigen::VectorXd iotaH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> iotaH;
 
   // -------------------
   // state vector
   // (num_full, mnsize)
-  RowMatrixXd rmncc;
-  RowMatrixXd rmnss;
-  RowMatrixXd rmnsc;
-  RowMatrixXd rmncs;
+  RowMatrixXr rmncc;
+  RowMatrixXr rmnss;
+  RowMatrixXr rmnsc;
+  RowMatrixXr rmncs;
 
-  RowMatrixXd zmnsc;
-  RowMatrixXd zmncs;
-  RowMatrixXd zmncc;
-  RowMatrixXd zmnss;
+  RowMatrixXr zmnsc;
+  RowMatrixXr zmncs;
+  RowMatrixXr zmncc;
+  RowMatrixXr zmnss;
 
-  RowMatrixXd lmnsc;
-  RowMatrixXd lmncs;
-  RowMatrixXd lmncc;
-  RowMatrixXd lmnss;
+  RowMatrixXr lmnsc;
+  RowMatrixXr lmncs;
+  RowMatrixXr lmncc;
+  RowMatrixXr lmnss;
 
   // -------------------
   // from inv-DFTs
 
   // (num_full, nZnT)
-  RowMatrixXd r_e;
-  RowMatrixXd r_o;
-  RowMatrixXd z_e;
-  RowMatrixXd z_o;
+  RowMatrixXr r_e;
+  RowMatrixXr r_o;
+  RowMatrixXr z_e;
+  RowMatrixXr z_o;
 
   // dX/dTheta for R, Z on full-grid
-  RowMatrixXd ru_e;
-  RowMatrixXd ru_o;
-  RowMatrixXd zu_e;
-  RowMatrixXd zu_o;
+  RowMatrixXr ru_e;
+  RowMatrixXr ru_o;
+  RowMatrixXr zu_e;
+  RowMatrixXr zu_o;
 
   // dX/dZeta for R, Z on full-grid
-  RowMatrixXd rv_e;
-  RowMatrixXd rv_o;
-  RowMatrixXd zv_e;
-  RowMatrixXd zv_o;
+  RowMatrixXr rv_e;
+  RowMatrixXr rv_o;
+  RowMatrixXr zv_e;
+  RowMatrixXr zv_o;
 
   // -------------------
   // from even-m and odd-m contributions
 
-  RowMatrixXd ruFull;
-  RowMatrixXd zuFull;
+  RowMatrixXr ruFull;
+  RowMatrixXr zuFull;
 
   // -------------------
   // from Jacobian calculation
 
   // R on half-grid
   // (num_half, nZnT)
-  RowMatrixXd r12;
+  RowMatrixXr r12;
 
   // dX/dTheta for R, Z on the half-grid
-  RowMatrixXd ru12;
-  RowMatrixXd zu12;
+  RowMatrixXr ru12;
+  RowMatrixXr zu12;
 
   // parts of dX/ds for R, Z on half-grid from Jacobian calculation
-  RowMatrixXd rs;
-  RowMatrixXd zs;
+  RowMatrixXr rs;
+  RowMatrixXr zs;
 
   // Jacobian on half-grid
   // (num_half, nZnT)
-  RowMatrixXd gsqrt;
+  RowMatrixXr gsqrt;
 
   // -------------------
   // metric elements
 
-  RowMatrixXd guu;
-  RowMatrixXd guv;
-  RowMatrixXd gvv;
+  RowMatrixXr guu;
+  RowMatrixXr guv;
+  RowMatrixXr gvv;
 
   // -------------------
   // magnetic field
 
   // contravariant magnetic field components on half-grid
   // (num_half, nZnT)
-  RowMatrixXd bsupu;
-  RowMatrixXd bsupv;
+  RowMatrixXr bsupu;
+  RowMatrixXr bsupv;
 
   // covariant magnetic field components on half-grid
   // (num_half, nZnT)
-  RowMatrixXd bsubu;
-  RowMatrixXd bsubv;
+  RowMatrixXr bsubu;
+  RowMatrixXr bsubv;
 
   // covariant magnetic field components on full-grid from lambda force
   // (num_full, nZnT)
-  RowMatrixXd bsubvF;
+  RowMatrixXr bsubvF;
 
   // (|B|^2 + mu_0 p) on half-grid
   // (num_half, nZnT)
-  RowMatrixXd total_pressure;
+  RowMatrixXr total_pressure;
 
   // -------------------
   // (more or less) directly from input data
 
   // mu_0 * curtor (from INDATA) -> prescribed toroidal current in A
-  double currv;
+  real_t currv;
 
   bool operator==(const VmecInternalResults&) const = default;
   bool operator!=(const VmecInternalResults& o) const { return !(*this == o); }
@@ -207,21 +208,21 @@ struct RemainingMetric {
 
   // dX/dZeta for R, Z on the half-grid
   // (num_half, nZnT)
-  RowMatrixXd rv12;
+  RowMatrixXr rv12;
   // (num_full, nZnT)
-  RowMatrixXd zv12;
+  RowMatrixXr zv12;
 
   // full dX/ds for R, Z on half-grid
   // (num_half, nZnT)
-  RowMatrixXd rs12;
+  RowMatrixXr rs12;
   // (num_full, nZnT)
-  RowMatrixXd zs12;
+  RowMatrixXr zs12;
 
   // metric elements on half-grid
   // (num_half, nZnT)
-  RowMatrixXd gsu;
+  RowMatrixXr gsu;
   // (num_full, nZnT)
-  RowMatrixXd gsv;
+  RowMatrixXr gsv;
 
   bool operator==(const RemainingMetric&) const = default;
   bool operator!=(const RemainingMetric& o) const { return !(*this == o); }
@@ -240,9 +241,9 @@ struct RemainingMetric {
 struct CylindricalComponentsOfB {
   // cylindrical components of magnetic field on half-grid
   // (num_half, nZnT)
-  RowMatrixXd b_r;
-  RowMatrixXd b_phi;
-  RowMatrixXd b_z;
+  RowMatrixXr b_r;
+  RowMatrixXr b_phi;
+  RowMatrixXr b_z;
 
   bool operator==(const CylindricalComponentsOfB&) const = default;
   bool operator!=(const CylindricalComponentsOfB& o) const {
@@ -264,7 +265,7 @@ struct CylindricalComponentsOfB {
 struct BSubSHalf {
   //  covariant magnetic field component on half-grid
   // (num_half, nZnT)
-  RowMatrixXd bsubs_half;
+  RowMatrixXr bsubs_half;
 
   bool operator==(const BSubSHalf&) const = default;
   bool operator!=(const BSubSHalf& o) const { return !(*this == o); }
@@ -283,7 +284,7 @@ struct BSubSHalf {
 struct BSubSFull {
   // covariant magnetic field component on full-grid
   // (num_full * nZnT)
-  RowMatrixXd bsubs_full;
+  RowMatrixXr bsubs_full;
 
   bool operator==(const BSubSFull&) const = default;
   bool operator!=(const BSubSFull& o) const { return !(*this == o); }
@@ -302,45 +303,45 @@ struct BSubSFull {
 struct SymmetryDecomposedCovariantB {
   // stellarator-symmetric B_s
   // (num_full, nZnT_reduced)
-  RowMatrixXd bsubs_s;
+  RowMatrixXr bsubs_s;
 
   // non-stellarator-symmetric B_s
   // (num_full, nZnT_reduced)
-  RowMatrixXd bsubs_a;
+  RowMatrixXr bsubs_a;
 
   // stellarator-symmetric B_theta
   // (num_half, nZnT_reduced)
-  RowMatrixXd bsubu_s;
+  RowMatrixXr bsubu_s;
 
   // non-stellarator-symmetric B_theta
   // (num_half, nZnT_reduced)
-  RowMatrixXd bsubu_a;
+  RowMatrixXr bsubu_a;
 
   //  stellarator-symmetric B_zeta
   // (num_half, nZnT_reduced)
-  RowMatrixXd bsubv_s;
+  RowMatrixXr bsubv_s;
 
   // non-stellarator-symmetric B_zeta
   // [num_half x nZnT_reduced]
-  RowMatrixXd bsubv_a;
+  RowMatrixXr bsubv_a;
 };
 
 struct CovariantBDerivatives {
   // d(B_s)/dTheta
   // (num_full, nZnT)
-  RowMatrixXd bsubsu;
+  RowMatrixXr bsubsu;
 
   // d(B_s)/dZeta
   // (num_full, nZnT)
-  RowMatrixXd bsubsv;
+  RowMatrixXr bsubsv;
 
   // d(B_theta)/dZeta
   // (num_half, nZnT)
-  RowMatrixXd bsubuv;
+  RowMatrixXr bsubuv;
 
   // d(B_zeta)/dTheta
   // (num_half, nZnT)
-  RowMatrixXd bsubvu;
+  RowMatrixXr bsubvu;
 
   bool operator==(const CovariantBDerivatives&) const = default;
   bool operator!=(const CovariantBDerivatives& o) const {
@@ -361,42 +362,42 @@ struct CovariantBDerivatives {
 
 struct JxBOutFileContents {
   // (num_full, nZnT)
-  RowMatrixXd itheta;
-  RowMatrixXd izeta;
-  RowMatrixXd bdotk;
+  RowMatrixXr itheta;
+  RowMatrixXr izeta;
+  RowMatrixXr bdotk;
 
-  Eigen::VectorXd amaxfor;
-  Eigen::VectorXd aminfor;
-  Eigen::VectorXd avforce;
-  Eigen::VectorXd pprim;
-  Eigen::VectorXd jdotb;
-  Eigen::VectorXd bdotb;
-  Eigen::VectorXd bdotgradv;
-  Eigen::VectorXd jpar2;
-  Eigen::VectorXd jperp2;
-  Eigen::VectorXd phin;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> amaxfor;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> aminfor;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> avforce;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> pprim;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> jdotb;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bdotb;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bdotgradv;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> jpar2;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> jperp2;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> phin;
 
   // (num_full, nZnT)
-  RowMatrixXd jsupu3;
-  RowMatrixXd jsupv3;
+  RowMatrixXr jsupu3;
+  RowMatrixXr jsupv3;
 
   // (num_half, nZnT)
-  RowMatrixXd jsups3;
+  RowMatrixXr jsups3;
 
   // (num_full, nZnT)
-  RowMatrixXd bsupu3;
-  RowMatrixXd bsupv3;
-  RowMatrixXd jcrossb;
-  RowMatrixXd jxb_gradp;
-  RowMatrixXd jdotb_sqrtg;
-  RowMatrixXd sqrtg3;
+  RowMatrixXr bsupu3;
+  RowMatrixXr bsupv3;
+  RowMatrixXr jcrossb;
+  RowMatrixXr jxb_gradp;
+  RowMatrixXr jdotb_sqrtg;
+  RowMatrixXr sqrtg3;
 
   // (num_half, nZnT)
-  RowMatrixXd bsubu3;
-  RowMatrixXd bsubv3;
+  RowMatrixXr bsubu3;
+  RowMatrixXr bsubv3;
 
   // (num_full, nZnT)
-  RowMatrixXd bsubs3;
+  RowMatrixXr bsubs3;
 
   bool operator==(const JxBOutFileContents&) const = default;
   bool operator!=(const JxBOutFileContents& o) const { return !(*this == o); }
@@ -415,58 +416,58 @@ struct JxBOutFileContents {
 
 struct MercierStabilityIntermediateQuantities {
   // normalized toroidal flux on full-grid
-  Eigen::VectorXd s;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> s;
 
   // magnetic shear == radial derivative of iota on full grid
-  Eigen::VectorXd shear;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> shear;
 
   // magnetic well == d^2V/ds^2 on full grid
-  Eigen::VectorXd vpp;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> vpp;
 
   // radial derivative of kinetic pressure on full grid
-  Eigen::VectorXd d_pressure_d_s;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> d_pressure_d_s;
 
   // d(I_tor)/ds on full grid
-  Eigen::VectorXd d_toroidal_current_d_s;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> d_toroidal_current_d_s;
 
   // real, physical d(phi)/ds on half-grid
-  Eigen::VectorXd phip_realH;
-  Eigen::VectorXd phip_realF;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> phip_realH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> phip_realF;
 
   // dV/d(PHI) on half mesh
-  Eigen::VectorXd vp_real;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> vp_real;
 
   // toroidal current on half-grid
-  Eigen::VectorXd torcur;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> torcur;
 
   // Jacobian on full-grid
   // (num_full, nZnT)
-  RowMatrixXd gsqrt_full;
+  RowMatrixXr gsqrt_full;
 
   // B \cdot j on full-grid
   // (num_full, nZnT)
-  RowMatrixXd bdotj;
+  RowMatrixXr bdotj;
 
   // 1.0 / gpp on full-grid
   // (num_full, nZnT)
   // TODO(jons): figure out what this really is
-  RowMatrixXd gpp;
+  RowMatrixXr gpp;
 
   // |B|^2 on half grid
   // (num_half, nZnT)
-  RowMatrixXd b2;
+  RowMatrixXr b2;
 
   // <1/B**2> on full-grid
-  Eigen::VectorXd tpp;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> tpp;
 
   // <b*b/|grad-phi|**3> on full-grid
-  Eigen::VectorXd tbb;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> tbb;
 
   // <j*b/|grad-phi|**3>
-  Eigen::VectorXd tjb;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> tjb;
 
   // <(j*b)2/b**2*|grad-phi|**3>
-  Eigen::VectorXd tjj;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> tjj;
 
   bool operator==(const MercierStabilityIntermediateQuantities&) const =
       default;
@@ -488,53 +489,53 @@ struct MercierStabilityIntermediateQuantities {
 
 struct MercierFileContents {
   // normalized toroidal flux on full-grid
-  Eigen::VectorXd s;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> s;
 
   // -------------------
 
   // toroidal magnetic flux on full-grid
-  Eigen::VectorXd toroidal_flux;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> toroidal_flux;
 
   // rotational transform on full grid
-  Eigen::VectorXd iota;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> iota;
 
   // magnetic shear == radial derivative of iota on full grid
-  Eigen::VectorXd shear;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> shear;
 
   // dV/ds on full grid
-  Eigen::VectorXd d_volume_d_s;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> d_volume_d_s;
 
   // magnetic well == d^2V/ds^2 on full grid
-  Eigen::VectorXd well;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> well;
 
   // I_tor on full grid
-  Eigen::VectorXd toroidal_current;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> toroidal_current;
 
   // d(I_tor)/ds on full grid
-  Eigen::VectorXd d_toroidal_current_d_s;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> d_toroidal_current_d_s;
 
   // kinetic pressure on full grid
-  Eigen::VectorXd pressure;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> pressure;
 
   // radial derivative of kinetic pressure on full grid
-  Eigen::VectorXd d_pressure_d_s;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> d_pressure_d_s;
 
   // -------------------
 
   // Mercier criterion on full grid
-  Eigen::VectorXd DMerc;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> DMerc;
 
   // shear contribution to Mercier criterion on full grid
-  Eigen::VectorXd Dshear;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> Dshear;
 
   // magnetic well contribution to Mercier criterion on full grid
-  Eigen::VectorXd Dwell;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> Dwell;
 
   // toroidal current contribution to Mercier criterion on full grid
-  Eigen::VectorXd Dcurr;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> Dcurr;
 
   // geodesic curvature contribution to Mercier criterion on full grid
-  Eigen::VectorXd Dgeod;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> Dgeod;
 
   bool operator==(const MercierFileContents&) const = default;
   bool operator!=(const MercierFileContents& o) const { return !(*this == o); }
@@ -554,56 +555,56 @@ struct MercierFileContents {
 struct Threed1FirstTableIntermediate {
   // ready-to-integrate Jacobian on half-grid
   // (num_half, nZnT)
-  RowMatrixXd tau;
+  RowMatrixXr tau;
 
   // [num_half] surface-averaged beta profile
-  Eigen::VectorXd beta_vol;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> beta_vol;
 
   // [num_half] <tau / R> / V'
   // TODO(jons): figure out what this really is
-  Eigen::VectorXd overr;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> overr;
 
   // plasma beta on magnetic axis
-  double beta_axis;
+  real_t beta_axis;
 
   // [num_full] pressure on full-grid
-  Eigen::VectorXd presf;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> presf;
 
   // [num_full] phip * 2 * pi * sign_of_jacobian on full-grid
-  Eigen::VectorXd phipf_loc;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> phipf_loc;
 
   // [num_full] toroidal flux profile on full-grid
-  Eigen::VectorXd phi1;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> phi1;
 
   // [num_full] poloidal flux profile on full-grid
-  Eigen::VectorXd chi1;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> chi1;
 
   // [num_full] 2 pi * poloidal flux profile on full-grid
-  Eigen::VectorXd chi;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> chi;
 
-  Eigen::VectorXd bvcoH;
-  Eigen::VectorXd bucoH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bvcoH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bucoH;
 
   // [num_full] toroidal current density profile on full-grid
-  Eigen::VectorXd jcurv;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> jcurv;
 
   // [num_full] poloidal current density profile on full-grid
-  Eigen::VectorXd jcuru;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> jcuru;
 
   // [num_full] radial derivative of pressure on full-grid
-  Eigen::VectorXd presgrad;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> presgrad;
 
   // [num_full] dV/d(phi) on full-grid
-  Eigen::VectorXd vpphi;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> vpphi;
 
   // [num_full] radial force balance residual on full-grid
-  Eigen::VectorXd equif;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> equif;
 
   // [num_full] toroidal current profile on full-grid
-  Eigen::VectorXd bucof;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bucof;
 
   // [num_full] poloidal current profile on full-grid
-  Eigen::VectorXd bvcof;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bvcof;
 
   bool operator==(const Threed1FirstTableIntermediate&) const = default;
   bool operator!=(const Threed1FirstTableIntermediate& o) const {
@@ -624,46 +625,46 @@ struct Threed1FirstTableIntermediate {
 
 struct Threed1FirstTable {
   // [num_full] S: normalized toroidal flux on full-grid
-  Eigen::VectorXd s;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> s;
 
   // [num_full] <RADIAL FORCE>: radial force balance residual on full-grid
-  Eigen::VectorXd radial_force;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> radial_force;
 
   // [num_full] TOROIDAL FLUX: toroidal flux profile on full-grid
-  Eigen::VectorXd toroidal_flux;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> toroidal_flux;
 
   // [num_full] IOTA: rotational transform profile on full-grid
-  Eigen::VectorXd iota;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> iota;
 
   // [num_full] <JSUPU>: surface-averaged poloidal current density on full-grid
-  Eigen::VectorXd avg_jsupu;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> avg_jsupu;
 
   // [num_full] <JSUPV>: surface-averaged toroidal current density on full-grid
-  Eigen::VectorXd avg_jsupv;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> avg_jsupv;
 
   // [num_full] d(VOL)/d(PHI): differential volume on full-grid
-  Eigen::VectorXd d_volume_d_phi;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> d_volume_d_phi;
 
   // [num_full] d(PRES)/d(PHI): radial derivative of pressure on full-grid
-  Eigen::VectorXd d_pressure_d_phi;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> d_pressure_d_phi;
 
   // [num_full] <M>: surface-averaged spectral width profile on full-grid
-  Eigen::VectorXd spectral_width;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> spectral_width;
 
   // [num_full] PRESF: pressure on full-grid in Pa (no mu_0!)
-  Eigen::VectorXd pressure;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> pressure;
 
   // [num_full] <BSUBU>: toroidal current profile on full-grid
-  Eigen::VectorXd buco_full;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> buco_full;
 
   // [num_full] <BSUBV>: poloidal current profile on full-grid
-  Eigen::VectorXd bvco_full;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bvco_full;
 
   // [num_full] <J.B>: parallel current density profile on full-grid
-  Eigen::VectorXd j_dot_b;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> j_dot_b;
 
   // [num_full] <B.B>: <|B|^2> profile on full-grid
-  Eigen::VectorXd b_dot_b;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> b_dot_b;
 
   bool operator==(const Threed1FirstTable&) const = default;
   bool operator!=(const Threed1FirstTable& o) const { return !(*this == o); }
@@ -680,48 +681,48 @@ struct Threed1FirstTable {
 };
 
 struct Threed1GeometricAndMagneticQuantitiesIntermediate {
-  double anorm;
-  double vnorm;
+  real_t anorm;
+  real_t vnorm;
 
   // differential surface area element |dS|, already with poloidal integration
   // weights
-  Eigen::VectorXd surf_area;
-  double circumference_sum;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> surf_area;
+  real_t circumference_sum;
 
-  double rcenin;
-  double aminr2in;
-  double bminz2in;
-  double bminz2;
+  real_t rcenin;
+  real_t aminr2in;
+  real_t bminz2in;
+  real_t bminz2;
 
-  double sump;
+  real_t sump;
 
-  Eigen::VectorXd btor_vac;
-  Eigen::VectorXd btor1;
-  Eigen::VectorXd dbtor;
-  Eigen::VectorXd phat;
-  Eigen::VectorXd redge;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> btor_vac;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> btor1;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> dbtor;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> phat;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> redge;
 
-  double delphid_exact;
-  double musubi;
-  double rshaf1;
-  double rshaf2;
-  double rshaf;
+  real_t delphid_exact;
+  real_t musubi;
+  real_t rshaf1;
+  real_t rshaf2;
+  real_t rshaf;
 
-  double fpsi0;
+  real_t fpsi0;
 
-  double sumbtot;
-  double sumbtor;
-  double sumbpol;
-  double sump20;
-  double sump2;
+  real_t sumbtot;
+  real_t sumbtor;
+  real_t sumbpol;
+  real_t sump20;
+  real_t sump2;
 
-  Eigen::VectorXd jPS2;
-  double jpar_perp_sum;
-  double jparPS_perp_sum;
-  double s2;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> jPS2;
+  real_t jpar_perp_sum;
+  real_t jparPS_perp_sum;
+  real_t s2;
 
-  double fac;
-  Eigen::VectorXd r3v;
+  real_t fac;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> r3v;
 
   bool operator==(
       const Threed1GeometricAndMagneticQuantitiesIntermediate&) const = default;
@@ -745,76 +746,76 @@ struct Threed1GeometricAndMagneticQuantitiesIntermediate {
 };
 
 struct Threed1GeometricAndMagneticQuantities {
-  double toroidal_flux;
+  real_t toroidal_flux;
 
-  double circum_p;
-  double surf_area_p;
+  real_t circum_p;
+  real_t surf_area_p;
 
-  double cross_area_p;
-  double volume_p;
+  real_t cross_area_p;
+  real_t volume_p;
 
-  double Rmajor_p;
-  double Aminor_p;
-  double aspect;
+  real_t Rmajor_p;
+  real_t Aminor_p;
+  real_t aspect;
 
-  double kappa_p;
-  double rcen;
+  real_t kappa_p;
+  real_t rcen;
 
   // volume-averaged minor radius
-  double aminr1;
+  real_t aminr1;
 
-  double pavg;
-  double factor;
+  real_t pavg;
+  real_t factor;
 
-  double b0;
+  real_t b0;
 
-  double rmax_surf;
-  double rmin_surf;
-  double zmax_surf;
+  real_t rmax_surf;
+  real_t rmin_surf;
+  real_t zmax_surf;
 
   // (num_half, nThetaReduced)
-  RowMatrixXd bmin;
+  RowMatrixXr bmin;
   // (num_half, nThetaReduced)
-  RowMatrixXd bmax;
+  RowMatrixXr bmax;
 
-  Eigen::VectorXd waist;
-  Eigen::VectorXd height;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> waist;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> height;
 
-  double betapol;
-  double betatot;
-  double betator;
-  double VolAvgB;
-  double IonLarmor;
+  real_t betapol;
+  real_t betatot;
+  real_t betator;
+  real_t VolAvgB;
+  real_t IonLarmor;
 
-  double jpar_perp;
-  double jparPS_perp;
+  real_t jpar_perp;
+  real_t jparPS_perp;
 
   // net toroidal current in A
-  double toroidal_current;
+  real_t toroidal_current;
 
-  double rbtor;
-  double rbtor0;
+  real_t rbtor;
+  real_t rbtor0;
 
   // poloidal magnetic flux on full-grid
-  Eigen::VectorXd psi;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> psi;
 
   // Geometric minor radius
-  Eigen::VectorXd ygeo;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> ygeo;
 
   // Geometric indentation
-  Eigen::VectorXd yinden;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> yinden;
 
   // Geometric ellipticity
-  Eigen::VectorXd yellip;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> yellip;
 
   // Geometric triangularity
-  Eigen::VectorXd ytrian;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> ytrian;
 
   // Geometric shift measured from magnetic axis
-  Eigen::VectorXd yshift;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> yshift;
 
-  Eigen::VectorXd loc_jpar_perp;
-  Eigen::VectorXd loc_jparPS_perp;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> loc_jpar_perp;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> loc_jparPS_perp;
 
   bool operator==(const Threed1GeometricAndMagneticQuantities&) const = default;
   bool operator!=(const Threed1GeometricAndMagneticQuantities& o) const {
@@ -835,20 +836,20 @@ struct Threed1GeometricAndMagneticQuantities {
 
 // Volume Integrals (Joules) and Volume Averages (Pascals)
 struct Threed1Volumetrics {
-  double int_p;
-  double avg_p;
+  real_t int_p;
+  real_t avg_p;
 
-  double int_bpol;
-  double avg_bpol;
+  real_t int_bpol;
+  real_t avg_bpol;
 
-  double int_btor;
-  double avg_btor;
+  real_t int_btor;
+  real_t avg_btor;
 
-  double int_modb;
-  double avg_modb;
+  real_t int_modb;
+  real_t avg_modb;
 
-  double int_ekin;
-  double avg_ekin;
+  real_t int_ekin;
+  real_t avg_ekin;
 
   bool operator==(const Threed1Volumetrics&) const = default;
   bool operator!=(const Threed1Volumetrics& o) const { return !(*this == o); }
@@ -869,19 +870,19 @@ struct Threed1Volumetrics {
 struct Threed1AxisGeometry {
   // [ntor + 1] stellarator-symmetric Fourier coefficients of axis: R * cos(n *
   // zeta)
-  Eigen::VectorXd raxis_symm;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> raxis_symm;
 
   // [ntor + 1] stellarator-symmetric Fourier coefficients of axis: Z * sin(n *
   // zeta)
-  Eigen::VectorXd zaxis_symm;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zaxis_symm;
 
   // [ntor + 1] non-stellarator-symmetric Fourier coefficients of axis: R *
   // sin(n * zeta)
-  Eigen::VectorXd raxis_asym;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> raxis_asym;
 
   // [ntor + 1] non-stellarator-symmetric Fourier coefficients of axis: Z *
   // cos(n * zeta)
-  Eigen::VectorXd zaxis_asym;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zaxis_asym;
 
   bool operator==(const Threed1AxisGeometry&) const = default;
   bool operator!=(const Threed1AxisGeometry& o) const { return !(*this == o); }
@@ -901,22 +902,22 @@ struct Threed1AxisGeometry {
 // beta values from volume averages over plasma
 struct Threed1Betas {
   // beta total
-  double betatot;
+  real_t betatot;
 
   // beta poloidal
-  double betapol;
+  real_t betapol;
 
   // beta toroidal
-  double betator;
+  real_t betator;
 
   // R * Btor-vac
-  double rbtor;
+  real_t rbtor;
 
   // Peak Beta (on axis)
-  double betaxis;
+  real_t betaxis;
 
   // Beta-star
-  double betstr;
+  real_t betstr;
 
   bool operator==(const Threed1Betas&) const = default;
   bool operator!=(const Threed1Betas& o) const { return !(*this == o); }
@@ -942,26 +943,26 @@ struct Threed1Betas {
 // The quantity lsubi gives the ratio of volume poloidal field energy
 // to the field energy estimated from the surface integral in Eq. (8).
 struct Threed1ShafranovIntegrals {
-  double scaling_ratio;
+  real_t scaling_ratio;
 
-  double r_lao;
-  double f_lao;
-  double f_geo;
+  real_t r_lao;
+  real_t f_lao;
+  real_t f_geo;
 
-  double smaleli;
-  double betai;
-  double musubi;
-  double lambda;
+  real_t smaleli;
+  real_t betai;
+  real_t musubi;
+  real_t lambda;
 
-  double s11;
-  double s12;
-  double s13;
-  double s2;
-  double s3;
+  real_t s11;
+  real_t s12;
+  real_t s13;
+  real_t s2;
+  real_t s3;
 
-  double delta1;
-  double delta2;
-  double delta3;
+  real_t delta1;
+  real_t delta2;
+  real_t delta3;
 
   bool operator==(const Threed1ShafranovIntegrals&) const = default;
   bool operator!=(const Threed1ShafranovIntegrals& o) const {
@@ -985,7 +986,7 @@ struct WOutFileContents {
   // copy of input data
 
   // version identifier for this VMEC implementation
-  double version_;
+  real_t version_;
 
   std::string input_extension;
 
@@ -993,7 +994,7 @@ struct WOutFileContents {
   int signgs;
 
   // adiabatic index
-  double gamma;
+  real_t gamma;
 
   // parameterization identifier for toroidal current profile
   std::string pcurr_type;
@@ -1006,33 +1007,33 @@ struct WOutFileContents {
 
   // pressure profile coefficients
   // interpretation depends on value of `pmass_type`
-  Eigen::VectorXd am;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> am;
 
   // toroidal current profile coefficients
   // interpretation depends on value of `pcurr_type`
-  Eigen::VectorXd ac;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> ac;
 
   // iota profile coefficients
   // interpretation depends on value of `piota_type`
-  Eigen::VectorXd ai;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> ai;
 
   // knots for discrete mass/pressure profile
-  Eigen::VectorXd am_aux_s;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> am_aux_s;
 
   // values for discrete mass/pressure profile
-  Eigen::VectorXd am_aux_f;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> am_aux_f;
 
   // knots for discrete toroidal current profile
-  Eigen::VectorXd ac_aux_s;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> ac_aux_s;
 
   // values for discrete toroidal current profile
-  Eigen::VectorXd ac_aux_f;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> ac_aux_f;
 
   // knots for discrete iota profile
-  Eigen::VectorXd ai_aux_s;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> ai_aux_s;
 
   // values for discrete iota profile
-  Eigen::VectorXd ai_aux_f;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> ai_aux_f;
 
   // number of toroidal field periods
   int nfp;
@@ -1080,19 +1081,19 @@ struct WOutFileContents {
   // scalar quantities
 
   // magnetic energy
-  double wb;
+  real_t wb;
 
   // thermal energy
-  double wp;
+  real_t wp;
 
   // maximum R of LCFS
-  double rmax_surf;
+  real_t rmax_surf;
 
   // minimum R of LCFS
-  double rmin_surf;
+  real_t rmin_surf;
 
   // maximum |Z| of LCFS
-  double zmax_surf;
+  real_t zmax_surf;
 
   // number of Fourier coefficients in state vector (R, Z, lambda)
   int mnmax;
@@ -1103,30 +1104,30 @@ struct WOutFileContents {
 
   int ier_flag;
 
-  double aspect;
+  real_t aspect;
 
-  double betatotal;
-  double betapol;
-  double betator;
-  double betaxis;
+  real_t betatotal;
+  real_t betapol;
+  real_t betator;
+  real_t betaxis;
 
-  double b0;
+  real_t b0;
 
-  double rbtor0;
-  double rbtor;
+  real_t rbtor0;
+  real_t rbtor;
 
-  double IonLarmor;
-  double volavgB;
+  real_t IonLarmor;
+  real_t volavgB;
 
-  double ctor;
+  real_t ctor;
 
-  double Aminor_p;
-  double Rmajor_p;
-  double volume;
+  real_t Aminor_p;
+  real_t Rmajor_p;
+  real_t volume;
 
-  double fsqr;
-  double fsqz;
-  double fsql;
+  real_t fsqr;
+  real_t fsqz;
+  real_t fsql;
 
   // Number of "time steps" of the force relaxation that were actually required
   // to achieve convergence. (How many of the maximum niter steps we ended up
@@ -1137,65 +1138,65 @@ struct WOutFileContents {
   // one-dimensional array quantities
 
   // full-grid: rotational_transform
-  Eigen::VectorXd iotaf;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> iotaf;
 
   // full-grid: 1 / iota (where iota != 0)
-  Eigen::VectorXd q_factor;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> q_factor;
 
   // full-grid: pressure in Pa
-  Eigen::VectorXd presf;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> presf;
 
   // full-grid: enclosed toroidal magnetic flux (phi) in Vs
-  Eigen::VectorXd phi;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> phi;
 
   // full-grid: toroidal flux differential (phi-prime)
-  Eigen::VectorXd phipf;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> phipf;
 
   // full-grid: enclosed poloidal magnetic flux (chi) in Vs
-  Eigen::VectorXd chi;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> chi;
 
   // full-grid: poloidal flux differential (chi-prime)
-  Eigen::VectorXd chipf;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> chipf;
 
-  Eigen::VectorXd jcuru;
-  Eigen::VectorXd jcurv;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> jcuru;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> jcurv;
 
   // Convergence quantities (one entry per time step)
   // Force residual at each iteration
-  Eigen::VectorXd fsqt;
-  Eigen::VectorXd force_residual_r;
-  Eigen::VectorXd force_residual_z;
-  Eigen::VectorXd force_residual_lambda;
-  Eigen::VectorXd delbsq;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> fsqt;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> force_residual_r;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> force_residual_z;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> force_residual_lambda;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> delbsq;
   Eigen::VectorXi restart_reason_timetrace;
 
   // Gradient of the energy at each iteration
-  Eigen::VectorXd wdot;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> wdot;
 
   // ---------
 
-  Eigen::VectorXd iotas;
-  Eigen::VectorXd mass;
-  Eigen::VectorXd pres;
-  Eigen::VectorXd beta_vol;
-  Eigen::VectorXd buco;
-  Eigen::VectorXd bvco;
-  Eigen::VectorXd vp;
-  Eigen::VectorXd specw;
-  Eigen::VectorXd phips;
-  Eigen::VectorXd over_r;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> iotas;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> mass;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> pres;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> beta_vol;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> buco;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bvco;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> vp;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> specw;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> phips;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> over_r;
 
-  Eigen::VectorXd jdotb;
-  Eigen::VectorXd bdotb;
-  Eigen::VectorXd bdotgradv;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> jdotb;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bdotb;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bdotgradv;
 
-  Eigen::VectorXd DMerc;
-  Eigen::VectorXd DShear;
-  Eigen::VectorXd DWell;
-  Eigen::VectorXd DCurr;
-  Eigen::VectorXd DGeod;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> DMerc;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> DShear;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> DWell;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> DCurr;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> DGeod;
 
-  Eigen::VectorXd equif;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> equif;
 
   std::vector<std::string> curlabel;
 
@@ -1213,102 +1214,102 @@ struct WOutFileContents {
   // -------------------
   // stellarator-symmetric Fourier coefficients
 
-  Eigen::VectorXd raxis_cc;
-  Eigen::VectorXd zaxis_cs;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> raxis_cc;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zaxis_cs;
 
   // full-grid: R
-  RowMatrixXd rmnc;
+  RowMatrixXr rmnc;
 
   // full-grid: Z
-  RowMatrixXd zmns;
+  RowMatrixXr zmns;
 
   // full-grid: lambda
   // NOTE: new with respect to Fortran VMEC
-  RowMatrixXd lmns_full;
+  RowMatrixXr lmns_full;
 
   // half-grid: lambda
-  RowMatrixXd lmns;
+  RowMatrixXr lmns;
 
   // half-grid: Jacobian
-  RowMatrixXd gmnc;
+  RowMatrixXr gmnc;
 
   // half-grid: |B|
-  RowMatrixXd bmnc;
+  RowMatrixXr bmnc;
 
   // half-grid: covariant B_\theta
-  RowMatrixXd bsubumnc;
+  RowMatrixXr bsubumnc;
 
   // half-grid: covariant B_\zeta
-  RowMatrixXd bsubvmnc;
+  RowMatrixXr bsubvmnc;
 
   // half-grid: covariant B_s
-  RowMatrixXd bsubsmns;
+  RowMatrixXr bsubsmns;
 
   // full-grid: covariant B_s
   // NOTE: new with respect to Fortran VMEC
-  RowMatrixXd bsubsmns_full;
+  RowMatrixXr bsubsmns_full;
 
   // half-grid: contravariant B^\theta
-  RowMatrixXd bsupumnc;
+  RowMatrixXr bsupumnc;
 
   // half-grid: contravariant B^\zeta
-  RowMatrixXd bsupvmnc;
+  RowMatrixXr bsupvmnc;
 
   // full-grid: sqrt(g) * J^\theta, Fourier coefficients (cos)
-  RowMatrixXd currumnc;
+  RowMatrixXr currumnc;
 
   // full-grid: sqrt(g) * J^\zeta, Fourier coefficients (cos)
-  RowMatrixXd currvmnc;
+  RowMatrixXr currvmnc;
 
   // -------------------
   // non-stellarator-symmetric Fourier coefficients
 
-  Eigen::VectorXd raxis_cs;
-  Eigen::VectorXd zaxis_cc;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> raxis_cs;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zaxis_cc;
 
   // full-grid: R
-  RowMatrixXd rmns;
+  RowMatrixXr rmns;
 
   // full-grid: Z
-  RowMatrixXd zmnc;
+  RowMatrixXr zmnc;
 
   // full-grid: lambda
   // NOTE: new with respect to Fortran VMEC
-  RowMatrixXd lmnc_full;
+  RowMatrixXr lmnc_full;
 
   // half-grid: lambda
-  RowMatrixXd lmnc;
+  RowMatrixXr lmnc;
 
   // half-grid: Jacobian
-  RowMatrixXd gmns;
+  RowMatrixXr gmns;
 
   // half-grid: |B|
-  RowMatrixXd bmns;
+  RowMatrixXr bmns;
 
   // half-grid: covariant B_\theta
-  RowMatrixXd bsubumns;
+  RowMatrixXr bsubumns;
 
   // half-grid: covariant B_\zeta
-  RowMatrixXd bsubvmns;
+  RowMatrixXr bsubvmns;
 
   // half-grid: covariant B_s
-  RowMatrixXd bsubsmnc;
+  RowMatrixXr bsubsmnc;
 
   // full-grid: covariant B_s
   // NOTE: new with respect to Fortran VMEC
-  RowMatrixXd bsubsmnc_full;
+  RowMatrixXr bsubsmnc_full;
 
   // half-grid: contravariant B^\theta
-  RowMatrixXd bsupumns;
+  RowMatrixXr bsupumns;
 
   // half-grid: contravariant B^\zeta
-  RowMatrixXd bsupvmns;
+  RowMatrixXr bsupvmns;
 
   // full-grid: sqrt(g) * J^\theta, Fourier coefficients (sin)
-  RowMatrixXd currumns;
+  RowMatrixXr currumns;
 
   // full-grid: sqrt(g) * J^\zeta, Fourier coefficients (sin)
-  RowMatrixXd currvmns;
+  RowMatrixXr currvmns;
 
   bool operator==(const WOutFileContents&) const = default;
   bool operator!=(const WOutFileContents& o) const { return !(*this == o); }
@@ -1522,7 +1523,7 @@ WOutFileContents ComputeWOutFileContents(
 // The comparison is performed using the specified tolerance in the "relabs"
 // metric.
 void CompareWOut(const WOutFileContents& test_wout,
-                 const WOutFileContents& expected_wout, double tolerance,
+                 const WOutFileContents& expected_wout, real_t tolerance,
                  bool check_equal_niter = true);
 }  // namespace vmecpp
 

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -31,30 +31,130 @@ using vmecpp::VmecINDATA;
 
 namespace {
 
-// Add a property that gets/sets an Eigen data members to a Pybind11 wrapper.
-// Simply using e.g. def_readwrite("mat", &WOutFileContents::mat) does
-// not work because, under the hood, def_readwrite casts the data member to
-// const before returning it from the getter (so the "write" part of
-// "readwrite" refers to the data member itself, but not its contents). The
-// getter function added here instead allows modification of the matrix or
-// vector elements themselves.
+// Add a property that gets/sets an Eigen data member to a Pybind11 wrapper,
+// converting between the internal real_t (long double) storage and Python's
+// float64 (double) numpy arrays at the I/O boundary.
 //
-// Use as: def_eigen_property(pywrapperclass, "rmnc", &WOutFileContents::rmnc);
+// For VmecINDATA members that are already double (RowMatrixXd / VectorXd),
+// the getter returns a non-const reference so Python can mutate elements.
+//
+// For output struct members that use RowMatrixXr / Eigen::Matrix<real_t,...>,
+// the getter copies and casts to double for Python; the setter casts back.
+//
+// Use as: DefEigenProperty(pywrapperclass, "rmnc", &WOutFileContents::rmnc);
 template <typename PywrapperClass, typename EigenMatrix, typename Class>
 void DefEigenProperty(PywrapperClass &pywrapper, const std::string &name,
                       EigenMatrix Class::*member_ptr) {
-  static_assert(std::is_same_v<EigenMatrix, vmecpp::RowMatrixXd> ||
+  static_assert(
+      std::is_same_v<EigenMatrix, vmecpp::RowMatrixXd> ||
+      std::is_same_v<EigenMatrix, Eigen::VectorXd> ||
+      std::is_same_v<EigenMatrix, Eigen::VectorXi> ||
+      std::is_same_v<EigenMatrix, vmecpp::RowMatrixXr> ||
+      std::is_same_v<EigenMatrix,
+                     Eigen::Matrix<vmecpp::real_t, Eigen::Dynamic, 1>>);
+
+  if constexpr (std::is_same_v<EigenMatrix, vmecpp::RowMatrixXd> ||
                 std::is_same_v<EigenMatrix, Eigen::VectorXd> ||
-                std::is_same_v<EigenMatrix, Eigen::VectorXi>);
-  // similar to what pybind11's def_readwrite does, but returning a non-const
-  // value from the getter
-  auto getter = [member_ptr](Class &obj) -> EigenMatrix & {
-    return obj.*member_ptr;
-  };
-  auto setter = [member_ptr](Class &obj, const EigenMatrix &val) {
-    obj.*member_ptr = val;
-  };
-  pywrapper.def_property(name.c_str(), getter, setter);
+                std::is_same_v<EigenMatrix, Eigen::VectorXi>) {
+    // double storage: return mutable reference so Python can modify elements
+    auto getter = [member_ptr](Class &obj) -> EigenMatrix & {
+      return obj.*member_ptr;
+    };
+    auto setter = [member_ptr](Class &obj, const EigenMatrix &val) {
+      obj.*member_ptr = val;
+    };
+    pywrapper.def_property(name.c_str(), getter, setter);
+  } else if constexpr (std::is_same_v<
+                           EigenMatrix,
+                           Eigen::Matrix<vmecpp::real_t, Eigen::Dynamic, 1>>) {
+    // real_t column vector: cast to double and expose as 1-D numpy array
+    auto getter = [member_ptr](const Class &obj) -> Eigen::VectorXd {
+      return (obj.*member_ptr).template cast<double>();
+    };
+    auto setter = [member_ptr](Class &obj, const Eigen::VectorXd &val) {
+      obj.*member_ptr = val.cast<vmecpp::real_t>();
+    };
+    pywrapper.def_property(name.c_str(), getter, setter);
+  } else {
+    // real_t row-major matrix: cast to double row-major matrix
+    auto getter = [member_ptr](const Class &obj) -> vmecpp::RowMatrixXd {
+      return (obj.*member_ptr).template cast<double>();
+    };
+    auto setter = [member_ptr](Class &obj, const vmecpp::RowMatrixXd &val) {
+      obj.*member_ptr = val.cast<vmecpp::real_t>();
+    };
+    pywrapper.def_property(name.c_str(), getter, setter);
+  }
+}
+
+// Add a readonly property for an Eigen real_t member, returning a double copy.
+// Use instead of def_readonly for RowMatrixXr / Eigen::Matrix<real_t,...>
+// members since pybind11 has no built-in caster for long double.
+template <typename PywrapperClass, typename EigenMatrix, typename Class>
+void DefEigenReadonly(PywrapperClass &pywrapper, const std::string &name,
+                      EigenMatrix Class::*member_ptr) {
+  if constexpr (std::is_same_v<EigenMatrix, Eigen::Matrix<vmecpp::real_t,
+                                                          Eigen::Dynamic, 1>>) {
+    pywrapper.def_property_readonly(
+        name.c_str(), [member_ptr](const Class &obj) -> Eigen::VectorXd {
+          return (obj.*member_ptr).template cast<double>();
+        });
+  } else {
+    pywrapper.def_property_readonly(
+        name.c_str(), [member_ptr](const Class &obj) -> vmecpp::RowMatrixXd {
+          return (obj.*member_ptr).template cast<double>();
+        });
+  }
+}
+
+// Add a readonly property for a real_t scalar member, returning a double.
+template <typename PywrapperClass, typename Class>
+void DefRealReadonly(PywrapperClass &pywrapper, const std::string &name,
+                     vmecpp::real_t Class::*member_ptr) {
+  pywrapper.def_property_readonly(name.c_str(),
+                                  [member_ptr](const Class &obj) -> double {
+                                    return static_cast<double>(obj.*member_ptr);
+                                  });
+}
+
+// Add a property that gets/sets a real_t scalar member as a Python float
+// (double). Needed because pybind11 has no built-in caster for long double.
+template <typename PywrapperClass, typename Class>
+void DefRealProperty(PywrapperClass &pywrapper, const std::string &name,
+                     vmecpp::real_t Class::*member_ptr) {
+  pywrapper.def_property(
+      name.c_str(),
+      [member_ptr](const Class &obj) -> double {
+        return static_cast<double>(obj.*member_ptr);
+      },
+      [member_ptr](Class &obj, double val) {
+        obj.*member_ptr = static_cast<vmecpp::real_t>(val);
+      });
+}
+
+// Add a property that gets/sets a std::vector<real_t> member as a Python list
+// of floats (doubles).
+template <typename PywrapperClass, typename Class>
+void DefRealVecProperty(PywrapperClass &pywrapper, const std::string &name,
+                        std::vector<vmecpp::real_t> Class::*member_ptr) {
+  pywrapper.def_property(
+      name.c_str(),
+      [member_ptr](const Class &obj) -> std::vector<double> {
+        const auto &v = obj.*member_ptr;
+        std::vector<double> out;
+        out.reserve(v.size());
+        for (auto x : v) {
+          out.push_back(static_cast<double>(x));
+        }
+        return out;
+      },
+      [member_ptr](Class &obj, const std::vector<double> &val) {
+        auto &v = obj.*member_ptr;
+        v.resize(val.size());
+        for (std::size_t i = 0; i < val.size(); ++i) {
+          v[i] = static_cast<vmecpp::real_t>(val[i]);
+        }
+      });
 }
 
 template <typename T>
@@ -218,403 +318,337 @@ PYBIND11_MODULE(_vmecpp, m) {
 
   py::class_<vmecpp::VmecCheckpoint>(m, "VmecCheckpoint");
 
-  py::class_<vmecpp::JxBOutFileContents>(m, "JxBOutFileContents")
-      .def_readonly("itheta", &vmecpp::JxBOutFileContents::itheta)
-      .def_readonly("izeta", &vmecpp::JxBOutFileContents::izeta)
-      .def_readonly("bdotk", &vmecpp::JxBOutFileContents::bdotk)
-      //
-      .def_readonly("amaxfor", &vmecpp::JxBOutFileContents::amaxfor)
-      .def_readonly("aminfor", &vmecpp::JxBOutFileContents::aminfor)
-      .def_readonly("avforce", &vmecpp::JxBOutFileContents::avforce)
-      .def_readonly("pprim", &vmecpp::JxBOutFileContents::pprim)
-      .def_readonly("jdotb", &vmecpp::JxBOutFileContents::jdotb)
-      .def_readonly("bdotb", &vmecpp::JxBOutFileContents::bdotb)
-      .def_readonly("bdotgradv", &vmecpp::JxBOutFileContents::bdotgradv)
-      .def_readonly("jpar2", &vmecpp::JxBOutFileContents::jpar2)
-      .def_readonly("jperp2", &vmecpp::JxBOutFileContents::jperp2)
-      .def_readonly("phin", &vmecpp::JxBOutFileContents::phin)
-      //
-      .def_readonly("jsupu3", &vmecpp::JxBOutFileContents::jsupu3)
-      .def_readonly("jsupv3", &vmecpp::JxBOutFileContents::jsupv3)
-      .def_readonly("jsups3", &vmecpp::JxBOutFileContents::jsups3)
-      .def_readonly("bsupu3", &vmecpp::JxBOutFileContents::bsupu3)
-      .def_readonly("bsupv3", &vmecpp::JxBOutFileContents::bsupv3)
-      .def_readonly("jcrossb", &vmecpp::JxBOutFileContents::jcrossb)
-      .def_readonly("jxb_gradp", &vmecpp::JxBOutFileContents::jxb_gradp)
-      .def_readonly("jdotb_sqrtg", &vmecpp::JxBOutFileContents::jdotb_sqrtg)
-      .def_readonly("sqrtg3", &vmecpp::JxBOutFileContents::sqrtg3)
-      .def_readonly("bsubu3", &vmecpp::JxBOutFileContents::bsubu3)
-      .def_readonly("bsubv3", &vmecpp::JxBOutFileContents::bsubv3)
-      .def_readonly("bsubs3", &vmecpp::JxBOutFileContents::bsubs3);
+  {
+    auto c = py::class_<vmecpp::JxBOutFileContents>(m, "JxBOutFileContents");
+    DefEigenReadonly(c, "itheta", &vmecpp::JxBOutFileContents::itheta);
+    DefEigenReadonly(c, "izeta", &vmecpp::JxBOutFileContents::izeta);
+    DefEigenReadonly(c, "bdotk", &vmecpp::JxBOutFileContents::bdotk);
+    DefEigenReadonly(c, "amaxfor", &vmecpp::JxBOutFileContents::amaxfor);
+    DefEigenReadonly(c, "aminfor", &vmecpp::JxBOutFileContents::aminfor);
+    DefEigenReadonly(c, "avforce", &vmecpp::JxBOutFileContents::avforce);
+    DefEigenReadonly(c, "pprim", &vmecpp::JxBOutFileContents::pprim);
+    DefEigenReadonly(c, "jdotb", &vmecpp::JxBOutFileContents::jdotb);
+    DefEigenReadonly(c, "bdotb", &vmecpp::JxBOutFileContents::bdotb);
+    DefEigenReadonly(c, "bdotgradv", &vmecpp::JxBOutFileContents::bdotgradv);
+    DefEigenReadonly(c, "jpar2", &vmecpp::JxBOutFileContents::jpar2);
+    DefEigenReadonly(c, "jperp2", &vmecpp::JxBOutFileContents::jperp2);
+    DefEigenReadonly(c, "phin", &vmecpp::JxBOutFileContents::phin);
+    DefEigenReadonly(c, "jsupu3", &vmecpp::JxBOutFileContents::jsupu3);
+    DefEigenReadonly(c, "jsupv3", &vmecpp::JxBOutFileContents::jsupv3);
+    DefEigenReadonly(c, "jsups3", &vmecpp::JxBOutFileContents::jsups3);
+    DefEigenReadonly(c, "bsupu3", &vmecpp::JxBOutFileContents::bsupu3);
+    DefEigenReadonly(c, "bsupv3", &vmecpp::JxBOutFileContents::bsupv3);
+    DefEigenReadonly(c, "jcrossb", &vmecpp::JxBOutFileContents::jcrossb);
+    DefEigenReadonly(c, "jxb_gradp", &vmecpp::JxBOutFileContents::jxb_gradp);
+    DefEigenReadonly(c, "jdotb_sqrtg",
+                     &vmecpp::JxBOutFileContents::jdotb_sqrtg);
+    DefEigenReadonly(c, "sqrtg3", &vmecpp::JxBOutFileContents::sqrtg3);
+    DefEigenReadonly(c, "bsubu3", &vmecpp::JxBOutFileContents::bsubu3);
+    DefEigenReadonly(c, "bsubv3", &vmecpp::JxBOutFileContents::bsubv3);
+    DefEigenReadonly(c, "bsubs3", &vmecpp::JxBOutFileContents::bsubs3);
+  }
 
-  py::class_<vmecpp::MercierFileContents>(m, "MercierFileContents")
-      .def_readonly("s", &vmecpp::MercierFileContents::s)
-      //
-      .def_readonly("toroidal_flux",
-                    &vmecpp::MercierFileContents::toroidal_flux)
-      .def_readonly("iota", &vmecpp::MercierFileContents::iota)
-      .def_readonly("shear", &vmecpp::MercierFileContents::shear)
-      .def_readonly("d_volume_d_s", &vmecpp::MercierFileContents::d_volume_d_s)
-      .def_readonly("well", &vmecpp::MercierFileContents::well)
-      .def_readonly("toroidal_current",
-                    &vmecpp::MercierFileContents::toroidal_current)
-      .def_readonly("d_toroidal_current_d_s",
-                    &vmecpp::MercierFileContents::d_toroidal_current_d_s)
-      .def_readonly("pressure", &vmecpp::MercierFileContents::pressure)
-      .def_readonly("d_pressure_d_s",
-                    &vmecpp::MercierFileContents::d_pressure_d_s)
-      //
-      .def_readonly("DMerc", &vmecpp::MercierFileContents::DMerc)
-      .def_readonly("Dshear", &vmecpp::MercierFileContents::Dshear)
-      .def_readonly("Dwell", &vmecpp::MercierFileContents::Dwell)
-      .def_readonly("Dcurr", &vmecpp::MercierFileContents::Dcurr)
-      .def_readonly("Dgeod", &vmecpp::MercierFileContents::Dgeod);
+  {
+    auto c = py::class_<vmecpp::MercierFileContents>(m, "MercierFileContents");
+    DefEigenReadonly(c, "s", &vmecpp::MercierFileContents::s);
+    DefEigenReadonly(c, "toroidal_flux",
+                     &vmecpp::MercierFileContents::toroidal_flux);
+    DefEigenReadonly(c, "iota", &vmecpp::MercierFileContents::iota);
+    DefEigenReadonly(c, "shear", &vmecpp::MercierFileContents::shear);
+    DefEigenReadonly(c, "d_volume_d_s",
+                     &vmecpp::MercierFileContents::d_volume_d_s);
+    DefEigenReadonly(c, "well", &vmecpp::MercierFileContents::well);
+    DefEigenReadonly(c, "toroidal_current",
+                     &vmecpp::MercierFileContents::toroidal_current);
+    DefEigenReadonly(c, "d_toroidal_current_d_s",
+                     &vmecpp::MercierFileContents::d_toroidal_current_d_s);
+    DefEigenReadonly(c, "pressure", &vmecpp::MercierFileContents::pressure);
+    DefEigenReadonly(c, "d_pressure_d_s",
+                     &vmecpp::MercierFileContents::d_pressure_d_s);
+    DefEigenReadonly(c, "DMerc", &vmecpp::MercierFileContents::DMerc);
+    DefEigenReadonly(c, "Dshear", &vmecpp::MercierFileContents::Dshear);
+    DefEigenReadonly(c, "Dwell", &vmecpp::MercierFileContents::Dwell);
+    DefEigenReadonly(c, "Dcurr", &vmecpp::MercierFileContents::Dcurr);
+    DefEigenReadonly(c, "Dgeod", &vmecpp::MercierFileContents::Dgeod);
+  }
 
-  py::class_<vmecpp::Threed1FirstTable>(m, "Threed1FirstTable")
-      .def_readonly("s", &vmecpp::Threed1FirstTable::s)
-      .def_readonly("radial_force", &vmecpp::Threed1FirstTable::radial_force)
-      .def_readonly("toroidal_flux", &vmecpp::Threed1FirstTable::toroidal_flux)
-      .def_readonly("iota", &vmecpp::Threed1FirstTable::iota)
-      .def_readonly("avg_jsupu", &vmecpp::Threed1FirstTable::avg_jsupu)
-      .def_readonly("avg_jsupv", &vmecpp::Threed1FirstTable::avg_jsupv)
-      .def_readonly("d_volume_d_phi",
-                    &vmecpp::Threed1FirstTable::d_volume_d_phi)
-      .def_readonly("d_pressure_d_phi",
-                    &vmecpp::Threed1FirstTable::d_pressure_d_phi)
-      .def_readonly("spectral_width",
-                    &vmecpp::Threed1FirstTable::spectral_width)
-      .def_readonly("pressure", &vmecpp::Threed1FirstTable::pressure)
-      .def_readonly("buco_full", &vmecpp::Threed1FirstTable::buco_full)
-      .def_readonly("bvco_full", &vmecpp::Threed1FirstTable::bvco_full)
-      .def_readonly("j_dot_b", &vmecpp::Threed1FirstTable::j_dot_b)
-      .def_readonly("b_dot_b", &vmecpp::Threed1FirstTable::b_dot_b);
+  {
+    auto c = py::class_<vmecpp::Threed1FirstTable>(m, "Threed1FirstTable");
+    DefEigenReadonly(c, "s", &vmecpp::Threed1FirstTable::s);
+    DefEigenReadonly(c, "radial_force",
+                     &vmecpp::Threed1FirstTable::radial_force);
+    DefEigenReadonly(c, "toroidal_flux",
+                     &vmecpp::Threed1FirstTable::toroidal_flux);
+    DefEigenReadonly(c, "iota", &vmecpp::Threed1FirstTable::iota);
+    DefEigenReadonly(c, "avg_jsupu", &vmecpp::Threed1FirstTable::avg_jsupu);
+    DefEigenReadonly(c, "avg_jsupv", &vmecpp::Threed1FirstTable::avg_jsupv);
+    DefEigenReadonly(c, "d_volume_d_phi",
+                     &vmecpp::Threed1FirstTable::d_volume_d_phi);
+    DefEigenReadonly(c, "d_pressure_d_phi",
+                     &vmecpp::Threed1FirstTable::d_pressure_d_phi);
+    DefEigenReadonly(c, "spectral_width",
+                     &vmecpp::Threed1FirstTable::spectral_width);
+    DefEigenReadonly(c, "pressure", &vmecpp::Threed1FirstTable::pressure);
+    DefEigenReadonly(c, "buco_full", &vmecpp::Threed1FirstTable::buco_full);
+    DefEigenReadonly(c, "bvco_full", &vmecpp::Threed1FirstTable::bvco_full);
+    DefEigenReadonly(c, "j_dot_b", &vmecpp::Threed1FirstTable::j_dot_b);
+    DefEigenReadonly(c, "b_dot_b", &vmecpp::Threed1FirstTable::b_dot_b);
+  }
 
-  py::class_<vmecpp::Threed1GeometricAndMagneticQuantities>(
-      m, "Threed1GeometricAndMagneticQuantities")
-      .def_readonly(
-          "toroidal_flux",
-          &vmecpp::Threed1GeometricAndMagneticQuantities::toroidal_flux)
-      //
-      .def_readonly("circum_p",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::circum_p)
-      .def_readonly("surf_area_p",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::surf_area_p)
-      //
-      .def_readonly(
-          "cross_area_p",
-          &vmecpp::Threed1GeometricAndMagneticQuantities::cross_area_p)
-      .def_readonly("volume_p",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::volume_p)
-      //
-      .def_readonly("Rmajor_p",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::Rmajor_p)
-      .def_readonly("Aminor_p",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::Aminor_p)
-      .def_readonly("aspect",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::aspect)
-      //
-      .def_readonly("kappa_p",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::kappa_p)
-      .def_readonly("rcen",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::rcen)
-      //
-      .def_readonly("aminr1",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::aminr1)
-      //
-      .def_readonly("pavg",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::pavg)
-      .def_readonly("factor",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::factor)
-      //
-      .def_readonly("b0", &vmecpp::Threed1GeometricAndMagneticQuantities::b0)
-      //
-      .def_readonly("rmax_surf",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::rmax_surf)
-      .def_readonly("rmin_surf",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::rmin_surf)
-      .def_readonly("zmax_surf",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::zmax_surf)
-      //
-      .def_readonly("bmin",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::bmin)
-      .def_readonly("bmax",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::bmax)
-      //
-      .def_readonly("waist",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::waist)
-      .def_readonly("height",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::height)
-      //
-      .def_readonly("betapol",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::betapol)
-      .def_readonly("betatot",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::betatot)
-      .def_readonly("betator",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::betator)
-      .def_readonly("VolAvgB",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::VolAvgB)
-      .def_readonly("IonLarmor",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::IonLarmor)
-      //
-      .def_readonly("jpar_perp",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::jpar_perp)
-      .def_readonly("jparPS_perp",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::jparPS_perp)
-      //
-      .def_readonly(
-          "toroidal_current",
-          &vmecpp::Threed1GeometricAndMagneticQuantities::toroidal_current)
-      //
-      .def_readonly("rbtor",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::rbtor)
-      .def_readonly("rbtor0",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::rbtor0)
-      //
-      .def_readonly("psi", &vmecpp::Threed1GeometricAndMagneticQuantities::psi)
-      .def_readonly("ygeo",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::ygeo)
-      .def_readonly("yinden",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::yinden)
-      .def_readonly("yellip",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::yellip)
-      .def_readonly("ytrian",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::ytrian)
-      .def_readonly("yshift",
-                    &vmecpp::Threed1GeometricAndMagneticQuantities::yshift)
-      //
-      .def_readonly(
-          "loc_jpar_perp",
-          &vmecpp::Threed1GeometricAndMagneticQuantities::loc_jpar_perp)
-      .def_readonly(
-          "loc_jparPS_perp",
-          &vmecpp::Threed1GeometricAndMagneticQuantities::loc_jparPS_perp);
+  {
+    using T = vmecpp::Threed1GeometricAndMagneticQuantities;
+    auto c = py::class_<T>(m, "Threed1GeometricAndMagneticQuantities");
+    DefRealReadonly(c, "toroidal_flux", &T::toroidal_flux);
+    DefRealReadonly(c, "circum_p", &T::circum_p);
+    DefRealReadonly(c, "surf_area_p", &T::surf_area_p);
+    DefRealReadonly(c, "cross_area_p", &T::cross_area_p);
+    DefRealReadonly(c, "volume_p", &T::volume_p);
+    DefRealReadonly(c, "Rmajor_p", &T::Rmajor_p);
+    DefRealReadonly(c, "Aminor_p", &T::Aminor_p);
+    DefRealReadonly(c, "aspect", &T::aspect);
+    DefRealReadonly(c, "kappa_p", &T::kappa_p);
+    DefRealReadonly(c, "rcen", &T::rcen);
+    DefRealReadonly(c, "aminr1", &T::aminr1);
+    DefRealReadonly(c, "pavg", &T::pavg);
+    DefRealReadonly(c, "factor", &T::factor);
+    DefRealReadonly(c, "b0", &T::b0);
+    DefRealReadonly(c, "rmax_surf", &T::rmax_surf);
+    DefRealReadonly(c, "rmin_surf", &T::rmin_surf);
+    DefRealReadonly(c, "zmax_surf", &T::zmax_surf);
+    DefEigenReadonly(c, "bmin", &T::bmin);
+    DefEigenReadonly(c, "bmax", &T::bmax);
+    DefEigenReadonly(c, "waist", &T::waist);
+    DefEigenReadonly(c, "height", &T::height);
+    DefRealReadonly(c, "betapol", &T::betapol);
+    DefRealReadonly(c, "betatot", &T::betatot);
+    DefRealReadonly(c, "betator", &T::betator);
+    DefRealReadonly(c, "VolAvgB", &T::VolAvgB);
+    DefRealReadonly(c, "IonLarmor", &T::IonLarmor);
+    DefRealReadonly(c, "jpar_perp", &T::jpar_perp);
+    DefRealReadonly(c, "jparPS_perp", &T::jparPS_perp);
+    DefRealReadonly(c, "toroidal_current", &T::toroidal_current);
+    DefRealReadonly(c, "rbtor", &T::rbtor);
+    DefRealReadonly(c, "rbtor0", &T::rbtor0);
+    DefEigenReadonly(c, "psi", &T::psi);
+    DefEigenReadonly(c, "ygeo", &T::ygeo);
+    DefEigenReadonly(c, "yinden", &T::yinden);
+    DefEigenReadonly(c, "yellip", &T::yellip);
+    DefEigenReadonly(c, "ytrian", &T::ytrian);
+    DefEigenReadonly(c, "yshift", &T::yshift);
+    DefEigenReadonly(c, "loc_jpar_perp", &T::loc_jpar_perp);
+    DefEigenReadonly(c, "loc_jparPS_perp", &T::loc_jparPS_perp);
+  }
 
-  py::class_<vmecpp::Threed1Volumetrics>(m, "Threed1Volumetrics")
-      .def_readonly("int_p", &vmecpp::Threed1Volumetrics::int_p)
-      .def_readonly("avg_p", &vmecpp::Threed1Volumetrics::avg_p)
-      //
-      .def_readonly("int_bpol", &vmecpp::Threed1Volumetrics::int_bpol)
-      .def_readonly("avg_bpol", &vmecpp::Threed1Volumetrics::avg_bpol)
-      //
-      .def_readonly("int_btor", &vmecpp::Threed1Volumetrics::int_btor)
-      .def_readonly("avg_btor", &vmecpp::Threed1Volumetrics::avg_btor)
-      //
-      .def_readonly("int_modb", &vmecpp::Threed1Volumetrics::int_modb)
-      .def_readonly("avg_modb", &vmecpp::Threed1Volumetrics::avg_modb)
-      //
-      .def_readonly("int_ekin", &vmecpp::Threed1Volumetrics::int_ekin)
-      .def_readonly("avg_ekin", &vmecpp::Threed1Volumetrics::avg_ekin);
+  {
+    auto c = py::class_<vmecpp::Threed1Volumetrics>(m, "Threed1Volumetrics");
+    DefRealReadonly(c, "int_p", &vmecpp::Threed1Volumetrics::int_p);
+    DefRealReadonly(c, "avg_p", &vmecpp::Threed1Volumetrics::avg_p);
+    DefRealReadonly(c, "int_bpol", &vmecpp::Threed1Volumetrics::int_bpol);
+    DefRealReadonly(c, "avg_bpol", &vmecpp::Threed1Volumetrics::avg_bpol);
+    DefRealReadonly(c, "int_btor", &vmecpp::Threed1Volumetrics::int_btor);
+    DefRealReadonly(c, "avg_btor", &vmecpp::Threed1Volumetrics::avg_btor);
+    DefRealReadonly(c, "int_modb", &vmecpp::Threed1Volumetrics::int_modb);
+    DefRealReadonly(c, "avg_modb", &vmecpp::Threed1Volumetrics::avg_modb);
+    DefRealReadonly(c, "int_ekin", &vmecpp::Threed1Volumetrics::int_ekin);
+    DefRealReadonly(c, "avg_ekin", &vmecpp::Threed1Volumetrics::avg_ekin);
+  }
 
-  py::class_<vmecpp::Threed1AxisGeometry>(m, "Threed1AxisGeometry")
-      .def_readonly("raxis_symm", &vmecpp::Threed1AxisGeometry::raxis_symm)
-      .def_readonly("zaxis_symm", &vmecpp::Threed1AxisGeometry::zaxis_symm)
-      .def_readonly("raxis_asym", &vmecpp::Threed1AxisGeometry::raxis_asym)
-      .def_readonly("zaxis_asym", &vmecpp::Threed1AxisGeometry::zaxis_asym);
+  {
+    auto c = py::class_<vmecpp::Threed1AxisGeometry>(m, "Threed1AxisGeometry");
+    DefEigenReadonly(c, "raxis_symm", &vmecpp::Threed1AxisGeometry::raxis_symm);
+    DefEigenReadonly(c, "zaxis_symm", &vmecpp::Threed1AxisGeometry::zaxis_symm);
+    DefEigenReadonly(c, "raxis_asym", &vmecpp::Threed1AxisGeometry::raxis_asym);
+    DefEigenReadonly(c, "zaxis_asym", &vmecpp::Threed1AxisGeometry::zaxis_asym);
+  }
 
-  py::class_<vmecpp::Threed1Betas>(m, "Threed1Betas")
-      .def_readonly("betatot", &vmecpp::Threed1Betas::betatot)
-      .def_readonly("betapol", &vmecpp::Threed1Betas::betapol)
-      .def_readonly("betator", &vmecpp::Threed1Betas::betator)
-      .def_readonly("rbtor", &vmecpp::Threed1Betas::rbtor)
-      .def_readonly("betaxis", &vmecpp::Threed1Betas::betaxis)
-      .def_readonly("betstr", &vmecpp::Threed1Betas::betstr);
+  {
+    auto c = py::class_<vmecpp::Threed1Betas>(m, "Threed1Betas");
+    DefRealReadonly(c, "betatot", &vmecpp::Threed1Betas::betatot);
+    DefRealReadonly(c, "betapol", &vmecpp::Threed1Betas::betapol);
+    DefRealReadonly(c, "betator", &vmecpp::Threed1Betas::betator);
+    DefRealReadonly(c, "rbtor", &vmecpp::Threed1Betas::rbtor);
+    DefRealReadonly(c, "betaxis", &vmecpp::Threed1Betas::betaxis);
+    DefRealReadonly(c, "betstr", &vmecpp::Threed1Betas::betstr);
+  }
 
-  py::class_<vmecpp::Threed1ShafranovIntegrals>(m, "Threed1ShafranovIntegrals")
-      .def_readonly("scaling_ratio",
-                    &vmecpp::Threed1ShafranovIntegrals::scaling_ratio)
-      //
-      .def_readonly("r_lao", &vmecpp::Threed1ShafranovIntegrals::r_lao)
-      .def_readonly("f_lao", &vmecpp::Threed1ShafranovIntegrals::f_lao)
-      .def_readonly("f_geo", &vmecpp::Threed1ShafranovIntegrals::f_geo)
-      //
-      .def_readonly("smaleli", &vmecpp::Threed1ShafranovIntegrals::smaleli)
-      .def_readonly("betai", &vmecpp::Threed1ShafranovIntegrals::betai)
-      .def_readonly("musubi", &vmecpp::Threed1ShafranovIntegrals::musubi)
-      .def_readonly("lambda", &vmecpp::Threed1ShafranovIntegrals::lambda)
-      //
-      .def_readonly("s11", &vmecpp::Threed1ShafranovIntegrals::s11)
-      .def_readonly("s12", &vmecpp::Threed1ShafranovIntegrals::s12)
-      .def_readonly("s13", &vmecpp::Threed1ShafranovIntegrals::s13)
-      .def_readonly("s2", &vmecpp::Threed1ShafranovIntegrals::s2)
-      .def_readonly("s3", &vmecpp::Threed1ShafranovIntegrals::s3)
-      //
-      .def_readonly("delta1", &vmecpp::Threed1ShafranovIntegrals::delta1)
-      .def_readonly("delta2", &vmecpp::Threed1ShafranovIntegrals::delta2)
-      .def_readonly("delta3", &vmecpp::Threed1ShafranovIntegrals::delta3);
+  {
+    using T = vmecpp::Threed1ShafranovIntegrals;
+    auto c = py::class_<T>(m, "Threed1ShafranovIntegrals");
+    DefRealReadonly(c, "scaling_ratio", &T::scaling_ratio);
+    DefRealReadonly(c, "r_lao", &T::r_lao);
+    DefRealReadonly(c, "f_lao", &T::f_lao);
+    DefRealReadonly(c, "f_geo", &T::f_geo);
+    DefRealReadonly(c, "smaleli", &T::smaleli);
+    DefRealReadonly(c, "betai", &T::betai);
+    DefRealReadonly(c, "musubi", &T::musubi);
+    DefRealReadonly(c, "lambda", &T::lambda);
+    DefRealReadonly(c, "s11", &T::s11);
+    DefRealReadonly(c, "s12", &T::s12);
+    DefRealReadonly(c, "s13", &T::s13);
+    DefRealReadonly(c, "s2", &T::s2);
+    DefRealReadonly(c, "s3", &T::s3);
+    DefRealReadonly(c, "delta1", &T::delta1);
+    DefRealReadonly(c, "delta2", &T::delta2);
+    DefRealReadonly(c, "delta3", &T::delta3);
+  }
 
-  py::class_<vmecpp::WOutFileContents>(m, "WOutFileContents")
-      .def(py::init<const vmecpp::WOutFileContents &>(), py::arg("wout"))
-      .def(py::init())
-      .def_readwrite("version_", &vmecpp::WOutFileContents::version_)
-      .def_readwrite("input_extension",
-                     &vmecpp::WOutFileContents::input_extension)
-      //
-      .def_readwrite("signgs", &vmecpp::WOutFileContents::signgs)
-      //
-      .def_readwrite("gamma", &vmecpp::WOutFileContents::gamma)
-      //
-      .def_readwrite("pcurr_type", &vmecpp::WOutFileContents::pcurr_type)
-      .def_readwrite("pmass_type", &vmecpp::WOutFileContents::pmass_type)
-      .def_readwrite("piota_type", &vmecpp::WOutFileContents::piota_type)
-      //
-      .def_readwrite("am", &vmecpp::WOutFileContents::am)
-      .def_readwrite("ac", &vmecpp::WOutFileContents::ac)
-      .def_readwrite("ai", &vmecpp::WOutFileContents::ai)
-      //
-      .def_readwrite("am_aux_s", &vmecpp::WOutFileContents::am_aux_s)
-      .def_readwrite("am_aux_f", &vmecpp::WOutFileContents::am_aux_f)
-      //
-      .def_readwrite("ac_aux_s", &vmecpp::WOutFileContents::ac_aux_s)
-      .def_readwrite("ac_aux_f", &vmecpp::WOutFileContents::ac_aux_f)
-      //
-      .def_readwrite("ai_aux_s", &vmecpp::WOutFileContents::ai_aux_s)
-      .def_readwrite("ai_aux_f", &vmecpp::WOutFileContents::ai_aux_f)
-      //
-      .def_readwrite("nfp", &vmecpp::WOutFileContents::nfp)
-      .def_readwrite("mpol", &vmecpp::WOutFileContents::mpol)
-      .def_readwrite("ntor", &vmecpp::WOutFileContents::ntor)
-      .def_readwrite("lasym", &vmecpp::WOutFileContents::lasym)
-      .def_readwrite("lrfp", &vmecpp::WOutFileContents::lrfp)
-      //
-      .def_readwrite("ns", &vmecpp::WOutFileContents::ns)
-      .def_readwrite("ftolv", &vmecpp::WOutFileContents::ftolv)
-      .def_readwrite("niter", &vmecpp::WOutFileContents::niter)
-      //
-      .def_readwrite("lfreeb", &vmecpp::WOutFileContents::lfreeb)
-      .def_readwrite("mgrid_file", &vmecpp::WOutFileContents::mgrid_file)
-      .def_readwrite("nextcur", &vmecpp::WOutFileContents::nextcur)
-      .def_readwrite("extcur", &vmecpp::WOutFileContents::extcur)
-      .def_readwrite("mgrid_mode", &vmecpp::WOutFileContents::mgrid_mode)
-      //
-      .def_readwrite("wb", &vmecpp::WOutFileContents::wb)
-      .def_readwrite("wp", &vmecpp::WOutFileContents::wp)
-      //
-      .def_readwrite("rmax_surf", &vmecpp::WOutFileContents::rmax_surf)
-      .def_readwrite("rmin_surf", &vmecpp::WOutFileContents::rmin_surf)
-      .def_readwrite("zmax_surf", &vmecpp::WOutFileContents::zmax_surf)
-      //
-      .def_readwrite("mnmax", &vmecpp::WOutFileContents::mnmax)
-      .def_readwrite("mnmax_nyq", &vmecpp::WOutFileContents::mnmax_nyq)
-      //
-      .def_readwrite("ier_flag", &vmecpp::WOutFileContents::ier_flag)
-      //
-      .def_readwrite("aspect", &vmecpp::WOutFileContents::aspect)
-      //
-      .def_readwrite("betatotal", &vmecpp::WOutFileContents::betatotal)
-      .def_readwrite("betapol", &vmecpp::WOutFileContents::betapol)
-      .def_readwrite("betator", &vmecpp::WOutFileContents::betator)
-      .def_readwrite("betaxis", &vmecpp::WOutFileContents::betaxis)
-      //
-      .def_readwrite("b0", &vmecpp::WOutFileContents::b0)
-      //
-      .def_readwrite("rbtor0", &vmecpp::WOutFileContents::rbtor0)
-      .def_readwrite("rbtor", &vmecpp::WOutFileContents::rbtor)
-      //
-      .def_readwrite("IonLarmor", &vmecpp::WOutFileContents::IonLarmor)
-      .def_readwrite("volavgB", &vmecpp::WOutFileContents::volavgB)
-      //
-      .def_readwrite("ctor", &vmecpp::WOutFileContents::ctor)
-      //
-      .def_readwrite("Aminor_p", &vmecpp::WOutFileContents::Aminor_p)
-      .def_readwrite("Rmajor_p", &vmecpp::WOutFileContents::Rmajor_p)
-      .def_readwrite("volume", &vmecpp::WOutFileContents::volume)
-      //
-      .def_readwrite("fsqr", &vmecpp::WOutFileContents::fsqr)
-      .def_readwrite("fsqz", &vmecpp::WOutFileContents::fsqz)
-      .def_readwrite("fsql", &vmecpp::WOutFileContents::fsql)
-      .def_readwrite("itfsq", &vmecpp::WOutFileContents::itfsq)
-      //
-      .def_readwrite("iotaf", &vmecpp::WOutFileContents::iotaf)
-      .def_readwrite("q_factor", &vmecpp::WOutFileContents::q_factor)
-      .def_readwrite("presf", &vmecpp::WOutFileContents::presf)
-      .def_readwrite("phi", &vmecpp::WOutFileContents::phi)
-      .def_readwrite("phipf", &vmecpp::WOutFileContents::phipf)
-      .def_readwrite("chi", &vmecpp::WOutFileContents::chi)
-      .def_readwrite("chipf", &vmecpp::WOutFileContents::chipf)
-      .def_readwrite("jcuru", &vmecpp::WOutFileContents::jcuru)
-      .def_readwrite("jcurv", &vmecpp::WOutFileContents::jcurv)
-      //
-      .def_readwrite("force_residual_r",
-                     &vmecpp::WOutFileContents::force_residual_r)
-      .def_readwrite("force_residual_z",
-                     &vmecpp::WOutFileContents::force_residual_z)
-      .def_readwrite("force_residual_lambda",
-                     &vmecpp::WOutFileContents::force_residual_lambda)
-      .def_readwrite("fsqt", &vmecpp::WOutFileContents::fsqt)
-      .def_readwrite("delbsq", &vmecpp::WOutFileContents::delbsq)
-      .def_readwrite("wdot", &vmecpp::WOutFileContents::wdot)
-      .def_readwrite("restart_reason_timetrace",
-                     &vmecpp::WOutFileContents::restart_reason_timetrace)
-      //
-      .def_readwrite("iotas", &vmecpp::WOutFileContents::iotas)
-      .def_readwrite("mass", &vmecpp::WOutFileContents::mass)
-      .def_readwrite("pres", &vmecpp::WOutFileContents::pres)
-      .def_readwrite("beta_vol", &vmecpp::WOutFileContents::beta_vol)
-      .def_readwrite("buco", &vmecpp::WOutFileContents::buco)
-      .def_readwrite("bvco", &vmecpp::WOutFileContents::bvco)
-      .def_readwrite("vp", &vmecpp::WOutFileContents::vp)
-      .def_readwrite("specw", &vmecpp::WOutFileContents::specw)
-      .def_readwrite("phips", &vmecpp::WOutFileContents::phips)
-      .def_readwrite("over_r", &vmecpp::WOutFileContents::over_r)
-      //
-      .def_readwrite("jdotb", &vmecpp::WOutFileContents::jdotb)
-      .def_readwrite("bdotb", &vmecpp::WOutFileContents::bdotb)
-      .def_readwrite("bdotgradv", &vmecpp::WOutFileContents::bdotgradv)
-      //
-      .def_readwrite("DMerc", &vmecpp::WOutFileContents::DMerc)
-      .def_readwrite("DShear", &vmecpp::WOutFileContents::DShear)
-      .def_readwrite("DWell", &vmecpp::WOutFileContents::DWell)
-      .def_readwrite("DCurr", &vmecpp::WOutFileContents::DCurr)
-      .def_readwrite("DGeod", &vmecpp::WOutFileContents::DGeod)
-      //
-      .def_readwrite("equif", &vmecpp::WOutFileContents::equif)
-      //
-      .def_readwrite("curlabel", &vmecpp::WOutFileContents::curlabel)
-      //
-      .def_readwrite("potvac", &vmecpp::WOutFileContents::potvac)
-      //
-      .def_readwrite("xm", &vmecpp::WOutFileContents::xm)
-      .def_readwrite("xn", &vmecpp::WOutFileContents::xn)
-      .def_readwrite("xm_nyq", &vmecpp::WOutFileContents::xm_nyq)
-      .def_readwrite("xn_nyq", &vmecpp::WOutFileContents::xn_nyq)
-      //
-      .def_readwrite("raxis_cc", &vmecpp::WOutFileContents::raxis_cc)
-      .def_readwrite("zaxis_cs", &vmecpp::WOutFileContents::zaxis_cs)
-      //
-      .def_readwrite("rmnc", &vmecpp::WOutFileContents::rmnc)
-      .def_readwrite("zmns", &vmecpp::WOutFileContents::zmns)
-      .def_readwrite("lmns_full", &vmecpp::WOutFileContents::lmns_full)
-      .def_readwrite("lmns", &vmecpp::WOutFileContents::lmns)
-      .def_readwrite("gmnc", &vmecpp::WOutFileContents::gmnc)
-      .def_readwrite("bmnc", &vmecpp::WOutFileContents::bmnc)
-      .def_readwrite("bsubumnc", &vmecpp::WOutFileContents::bsubumnc)
-      .def_readwrite("bsubvmnc", &vmecpp::WOutFileContents::bsubvmnc)
-      .def_readwrite("bsubsmns", &vmecpp::WOutFileContents::bsubsmns)
-      .def_readwrite("bsubsmns_full", &vmecpp::WOutFileContents::bsubsmns_full)
-      .def_readwrite("bsupumnc", &vmecpp::WOutFileContents::bsupumnc)
-      .def_readwrite("bsupvmnc", &vmecpp::WOutFileContents::bsupvmnc)
-      //
-      .def_readwrite("currumnc", &vmecpp::WOutFileContents::currumnc)
-      .def_readwrite("currvmnc", &vmecpp::WOutFileContents::currvmnc)
-      //
-      .def_readwrite("raxis_cs", &vmecpp::WOutFileContents::raxis_cs)
-      .def_readwrite("zaxis_cc", &vmecpp::WOutFileContents::zaxis_cc)
-      // non-stellarator symmetric
-      .def_readwrite("rmns", &vmecpp::WOutFileContents::rmns)
-      .def_readwrite("zmnc", &vmecpp::WOutFileContents::zmnc)
-      .def_readwrite("lmnc_full", &vmecpp::WOutFileContents::lmnc_full)
-      .def_readwrite("lmnc", &vmecpp::WOutFileContents::lmnc)
-      .def_readwrite("gmns", &vmecpp::WOutFileContents::gmns)
-      .def_readwrite("bmns", &vmecpp::WOutFileContents::bmns)
-      .def_readwrite("bsubumns", &vmecpp::WOutFileContents::bsubumns)
-      .def_readwrite("bsubvmns", &vmecpp::WOutFileContents::bsubvmns)
-      .def_readwrite("bsubsmnc", &vmecpp::WOutFileContents::bsubsmnc)
-      .def_readwrite("bsubsmnc_full", &vmecpp::WOutFileContents::bsubsmnc_full)
-      .def_readwrite("bsupumns", &vmecpp::WOutFileContents::bsupumns)
-      .def_readwrite("bsupvmns", &vmecpp::WOutFileContents::bsupvmns)
-      //
-      .def_readwrite("currumns", &vmecpp::WOutFileContents::currumns)
-      .def_readwrite("currvmns", &vmecpp::WOutFileContents::currvmns);
+  auto pywout =
+      py::class_<vmecpp::WOutFileContents>(m, "WOutFileContents")
+          .def(py::init<const vmecpp::WOutFileContents &>(), py::arg("wout"))
+          .def(py::init())
+          //
+          .def_readwrite("input_extension",
+                         &vmecpp::WOutFileContents::input_extension)
+          //
+          .def_readwrite("signgs", &vmecpp::WOutFileContents::signgs)
+          //
+          .def_readwrite("pcurr_type", &vmecpp::WOutFileContents::pcurr_type)
+          .def_readwrite("pmass_type", &vmecpp::WOutFileContents::pmass_type)
+          .def_readwrite("piota_type", &vmecpp::WOutFileContents::piota_type)
+          //
+          .def_readwrite("nfp", &vmecpp::WOutFileContents::nfp)
+          .def_readwrite("mpol", &vmecpp::WOutFileContents::mpol)
+          .def_readwrite("ntor", &vmecpp::WOutFileContents::ntor)
+          .def_readwrite("lasym", &vmecpp::WOutFileContents::lasym)
+          .def_readwrite("lrfp", &vmecpp::WOutFileContents::lrfp)
+          //
+          .def_readwrite("ns", &vmecpp::WOutFileContents::ns)
+          .def_readwrite("ftolv", &vmecpp::WOutFileContents::ftolv)
+          .def_readwrite("niter", &vmecpp::WOutFileContents::niter)
+          //
+          .def_readwrite("lfreeb", &vmecpp::WOutFileContents::lfreeb)
+          .def_readwrite("mgrid_file", &vmecpp::WOutFileContents::mgrid_file)
+          .def_readwrite("nextcur", &vmecpp::WOutFileContents::nextcur)
+          .def_readwrite("extcur", &vmecpp::WOutFileContents::extcur)
+          .def_readwrite("mgrid_mode", &vmecpp::WOutFileContents::mgrid_mode)
+          //
+          .def_readwrite("mnmax", &vmecpp::WOutFileContents::mnmax)
+          .def_readwrite("mnmax_nyq", &vmecpp::WOutFileContents::mnmax_nyq)
+          //
+          .def_readwrite("ier_flag", &vmecpp::WOutFileContents::ier_flag)
+          //
+          .def_readwrite("itfsq", &vmecpp::WOutFileContents::itfsq)
+          //
+          .def_readwrite("restart_reason_timetrace",
+                         &vmecpp::WOutFileContents::restart_reason_timetrace)
+          //
+          .def_readwrite("curlabel", &vmecpp::WOutFileContents::curlabel)
+          //
+          .def_readwrite("potvac", &vmecpp::WOutFileContents::potvac)
+          //
+          .def_readwrite("xm", &vmecpp::WOutFileContents::xm)
+          .def_readwrite("xn", &vmecpp::WOutFileContents::xn)
+          .def_readwrite("xm_nyq", &vmecpp::WOutFileContents::xm_nyq)
+          .def_readwrite("xn_nyq", &vmecpp::WOutFileContents::xn_nyq);
+
+  // real_t scalars: exposed as Python float (double) with explicit cast
+  DefRealProperty(pywout, "version_", &vmecpp::WOutFileContents::version_);
+  DefRealProperty(pywout, "gamma", &vmecpp::WOutFileContents::gamma);
+  DefRealProperty(pywout, "wb", &vmecpp::WOutFileContents::wb);
+  DefRealProperty(pywout, "wp", &vmecpp::WOutFileContents::wp);
+  DefRealProperty(pywout, "rmax_surf", &vmecpp::WOutFileContents::rmax_surf);
+  DefRealProperty(pywout, "rmin_surf", &vmecpp::WOutFileContents::rmin_surf);
+  DefRealProperty(pywout, "zmax_surf", &vmecpp::WOutFileContents::zmax_surf);
+  DefRealProperty(pywout, "aspect", &vmecpp::WOutFileContents::aspect);
+  DefRealProperty(pywout, "betatotal", &vmecpp::WOutFileContents::betatotal);
+  DefRealProperty(pywout, "betapol", &vmecpp::WOutFileContents::betapol);
+  DefRealProperty(pywout, "betator", &vmecpp::WOutFileContents::betator);
+  DefRealProperty(pywout, "betaxis", &vmecpp::WOutFileContents::betaxis);
+  DefRealProperty(pywout, "b0", &vmecpp::WOutFileContents::b0);
+  DefRealProperty(pywout, "rbtor0", &vmecpp::WOutFileContents::rbtor0);
+  DefRealProperty(pywout, "rbtor", &vmecpp::WOutFileContents::rbtor);
+  DefRealProperty(pywout, "IonLarmor", &vmecpp::WOutFileContents::IonLarmor);
+  DefRealProperty(pywout, "volavgB", &vmecpp::WOutFileContents::volavgB);
+  DefRealProperty(pywout, "ctor", &vmecpp::WOutFileContents::ctor);
+  DefRealProperty(pywout, "Aminor_p", &vmecpp::WOutFileContents::Aminor_p);
+  DefRealProperty(pywout, "Rmajor_p", &vmecpp::WOutFileContents::Rmajor_p);
+  DefRealProperty(pywout, "volume", &vmecpp::WOutFileContents::volume);
+  DefRealProperty(pywout, "fsqr", &vmecpp::WOutFileContents::fsqr);
+  DefRealProperty(pywout, "fsqz", &vmecpp::WOutFileContents::fsqz);
+  DefRealProperty(pywout, "fsql", &vmecpp::WOutFileContents::fsql);
+
+  // Eigen::Matrix<real_t,...> 1D and 2D arrays: cast to double at boundary
+  DefEigenProperty(pywout, "am", &vmecpp::WOutFileContents::am);
+  DefEigenProperty(pywout, "ac", &vmecpp::WOutFileContents::ac);
+  DefEigenProperty(pywout, "ai", &vmecpp::WOutFileContents::ai);
+  DefEigenProperty(pywout, "am_aux_s", &vmecpp::WOutFileContents::am_aux_s);
+  DefEigenProperty(pywout, "am_aux_f", &vmecpp::WOutFileContents::am_aux_f);
+  DefEigenProperty(pywout, "ac_aux_s", &vmecpp::WOutFileContents::ac_aux_s);
+  DefEigenProperty(pywout, "ac_aux_f", &vmecpp::WOutFileContents::ac_aux_f);
+  DefEigenProperty(pywout, "ai_aux_s", &vmecpp::WOutFileContents::ai_aux_s);
+  DefEigenProperty(pywout, "ai_aux_f", &vmecpp::WOutFileContents::ai_aux_f);
+  DefEigenProperty(pywout, "iotaf", &vmecpp::WOutFileContents::iotaf);
+  DefEigenProperty(pywout, "q_factor", &vmecpp::WOutFileContents::q_factor);
+  DefEigenProperty(pywout, "presf", &vmecpp::WOutFileContents::presf);
+  DefEigenProperty(pywout, "phi", &vmecpp::WOutFileContents::phi);
+  DefEigenProperty(pywout, "phipf", &vmecpp::WOutFileContents::phipf);
+  DefEigenProperty(pywout, "chi", &vmecpp::WOutFileContents::chi);
+  DefEigenProperty(pywout, "chipf", &vmecpp::WOutFileContents::chipf);
+  DefEigenProperty(pywout, "jcuru", &vmecpp::WOutFileContents::jcuru);
+  DefEigenProperty(pywout, "jcurv", &vmecpp::WOutFileContents::jcurv);
+  DefEigenProperty(pywout, "force_residual_r",
+                   &vmecpp::WOutFileContents::force_residual_r);
+  DefEigenProperty(pywout, "force_residual_z",
+                   &vmecpp::WOutFileContents::force_residual_z);
+  DefEigenProperty(pywout, "force_residual_lambda",
+                   &vmecpp::WOutFileContents::force_residual_lambda);
+  DefEigenProperty(pywout, "fsqt", &vmecpp::WOutFileContents::fsqt);
+  DefEigenProperty(pywout, "delbsq", &vmecpp::WOutFileContents::delbsq);
+  DefEigenProperty(pywout, "wdot", &vmecpp::WOutFileContents::wdot);
+  DefEigenProperty(pywout, "iotas", &vmecpp::WOutFileContents::iotas);
+  DefEigenProperty(pywout, "mass", &vmecpp::WOutFileContents::mass);
+  DefEigenProperty(pywout, "pres", &vmecpp::WOutFileContents::pres);
+  DefEigenProperty(pywout, "beta_vol", &vmecpp::WOutFileContents::beta_vol);
+  DefEigenProperty(pywout, "buco", &vmecpp::WOutFileContents::buco);
+  DefEigenProperty(pywout, "bvco", &vmecpp::WOutFileContents::bvco);
+  DefEigenProperty(pywout, "vp", &vmecpp::WOutFileContents::vp);
+  DefEigenProperty(pywout, "specw", &vmecpp::WOutFileContents::specw);
+  DefEigenProperty(pywout, "phips", &vmecpp::WOutFileContents::phips);
+  DefEigenProperty(pywout, "over_r", &vmecpp::WOutFileContents::over_r);
+  DefEigenProperty(pywout, "jdotb", &vmecpp::WOutFileContents::jdotb);
+  DefEigenProperty(pywout, "bdotb", &vmecpp::WOutFileContents::bdotb);
+  DefEigenProperty(pywout, "bdotgradv", &vmecpp::WOutFileContents::bdotgradv);
+  DefEigenProperty(pywout, "DMerc", &vmecpp::WOutFileContents::DMerc);
+  DefEigenProperty(pywout, "DShear", &vmecpp::WOutFileContents::DShear);
+  DefEigenProperty(pywout, "DWell", &vmecpp::WOutFileContents::DWell);
+  DefEigenProperty(pywout, "DCurr", &vmecpp::WOutFileContents::DCurr);
+  DefEigenProperty(pywout, "DGeod", &vmecpp::WOutFileContents::DGeod);
+  DefEigenProperty(pywout, "equif", &vmecpp::WOutFileContents::equif);
+  DefEigenProperty(pywout, "raxis_cc", &vmecpp::WOutFileContents::raxis_cc);
+  DefEigenProperty(pywout, "zaxis_cs", &vmecpp::WOutFileContents::zaxis_cs);
+  DefEigenProperty(pywout, "rmnc", &vmecpp::WOutFileContents::rmnc);
+  DefEigenProperty(pywout, "zmns", &vmecpp::WOutFileContents::zmns);
+  DefEigenProperty(pywout, "lmns_full", &vmecpp::WOutFileContents::lmns_full);
+  DefEigenProperty(pywout, "lmns", &vmecpp::WOutFileContents::lmns);
+  DefEigenProperty(pywout, "gmnc", &vmecpp::WOutFileContents::gmnc);
+  DefEigenProperty(pywout, "bmnc", &vmecpp::WOutFileContents::bmnc);
+  DefEigenProperty(pywout, "bsubumnc", &vmecpp::WOutFileContents::bsubumnc);
+  DefEigenProperty(pywout, "bsubvmnc", &vmecpp::WOutFileContents::bsubvmnc);
+  DefEigenProperty(pywout, "bsubsmns", &vmecpp::WOutFileContents::bsubsmns);
+  DefEigenProperty(pywout, "bsubsmns_full",
+                   &vmecpp::WOutFileContents::bsubsmns_full);
+  DefEigenProperty(pywout, "bsupumnc", &vmecpp::WOutFileContents::bsupumnc);
+  DefEigenProperty(pywout, "bsupvmnc", &vmecpp::WOutFileContents::bsupvmnc);
+  DefEigenProperty(pywout, "currumnc", &vmecpp::WOutFileContents::currumnc);
+  DefEigenProperty(pywout, "currvmnc", &vmecpp::WOutFileContents::currvmnc);
+  DefEigenProperty(pywout, "raxis_cs", &vmecpp::WOutFileContents::raxis_cs);
+  DefEigenProperty(pywout, "zaxis_cc", &vmecpp::WOutFileContents::zaxis_cc);
+  // non-stellarator symmetric
+  DefEigenProperty(pywout, "rmns", &vmecpp::WOutFileContents::rmns);
+  DefEigenProperty(pywout, "zmnc", &vmecpp::WOutFileContents::zmnc);
+  DefEigenProperty(pywout, "lmnc_full", &vmecpp::WOutFileContents::lmnc_full);
+  DefEigenProperty(pywout, "lmnc", &vmecpp::WOutFileContents::lmnc);
+  DefEigenProperty(pywout, "gmns", &vmecpp::WOutFileContents::gmns);
+  DefEigenProperty(pywout, "bmns", &vmecpp::WOutFileContents::bmns);
+  DefEigenProperty(pywout, "bsubumns", &vmecpp::WOutFileContents::bsubumns);
+  DefEigenProperty(pywout, "bsubvmns", &vmecpp::WOutFileContents::bsubvmns);
+  DefEigenProperty(pywout, "bsubsmnc", &vmecpp::WOutFileContents::bsubsmnc);
+  DefEigenProperty(pywout, "bsubsmnc_full",
+                   &vmecpp::WOutFileContents::bsubsmnc_full);
+  DefEigenProperty(pywout, "bsupumns", &vmecpp::WOutFileContents::bsupumns);
+  DefEigenProperty(pywout, "bsupvmns", &vmecpp::WOutFileContents::bsupvmns);
+  DefEigenProperty(pywout, "currumns", &vmecpp::WOutFileContents::currumns);
+  DefEigenProperty(pywout, "currvmns", &vmecpp::WOutFileContents::currvmns);
 
   py::class_<vmecpp::OutputQuantities>(m, "OutputQuantities")
       .def_readonly("jxbout", &vmecpp::OutputQuantities::jxbout)

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
@@ -24,7 +24,7 @@ namespace vmecpp {
 RadialProfiles::RadialProfiles(const RadialPartitioning* r,
                                HandoverStorage* m_h, const VmecINDATA* id,
                                const FlowControl* fc, int signOfJacobian,
-                               double pDamp)
+                               real_t pDamp)
     : r_(*r),
       m_h_(*m_h),
       id_(*id),
@@ -249,7 +249,7 @@ std::string RadialProfiles::profileTypeToString(ProfileType profileType) {
 /** Compute the maximum toroidal and poloidal magnetic fluxes. */
 void RadialProfiles::computeMagneticFluxes() {
   maxToroidalFlux = signOfJacobian * id_.phiedge / (2.0 * M_PI);
-  double edgeToroidalFluxFromProfile = torflux(1.0);
+  real_t edgeToroidalFluxFromProfile = torflux(1.0);
   if (edgeToroidalFluxFromProfile != 0.0) {
     maxToroidalFlux /= edgeToroidalFluxFromProfile;
   }
@@ -258,7 +258,7 @@ void RadialProfiles::computeMagneticFluxes() {
   // This assumes that the same scaling factor (=phiedge) is used for phi' and
   // chi'.
   maxPoloidalFlux = maxToroidalFlux;
-  double edgePoloidalFluxFromProfile = polflux(1.0);
+  real_t edgePoloidalFluxFromProfile = polflux(1.0);
   if (edgePoloidalFluxFromProfile != 0.0) {
     maxPoloidalFlux /= edgePoloidalFluxFromProfile;
   }
@@ -269,8 +269,8 @@ void RadialProfiles::computeMagneticFluxes() {
  * @param x evaluation position
  * @return d(aphi)/dx at x
  */
-double RadialProfiles::torfluxDeriv(double x) {
-  double torflux_deriv = 0.0;
+real_t RadialProfiles::torfluxDeriv(real_t x) {
+  real_t torflux_deriv = 0.0;
   for (int i = static_cast<int>(id_.aphi.size()) - 1; i >= 0; i--) {
     torflux_deriv = x * torflux_deriv + (i + 1) * id_.aphi[i];
   }
@@ -283,10 +283,10 @@ double RadialProfiles::torfluxDeriv(double x) {
  * @param x
  * @return
  */
-double RadialProfiles::torflux(double x) {
+real_t RadialProfiles::torflux(real_t x) {
   //  Analytic evaluation of the polynomial (0 at x=0)
   //  using Horner's method
-  double torflux = 0.0;
+  real_t torflux = 0.0;
   for (int i = static_cast<int>(id_.aphi.size()) - 1; i >= 0; i--) {
     torflux = x * torflux + id_.aphi[i];
   }
@@ -299,15 +299,15 @@ double RadialProfiles::torflux(double x) {
  * @param x
  * @return
  */
-double RadialProfiles::polfluxDeriv(double x) {
+real_t RadialProfiles::polfluxDeriv(real_t x) {
   // figure out what toroidal flux x corresponds to
-  double tf = std::min(torflux(x), 1.0);
+  real_t tf = std::min(torflux(x), 1.0L);
 
   // profiles are always specified in toroidal flux --> eval at toroidal flux
   // corresponding to x
-  double iota = evalIotaProfile(tf);
+  real_t iota = evalIotaProfile(tf);
 
-  double polflux_deriv = iota * torfluxDeriv(x);
+  real_t polflux_deriv = iota * torfluxDeriv(x);
   return polflux_deriv;
 }
 
@@ -318,14 +318,14 @@ double RadialProfiles::polfluxDeriv(double x) {
  * @param x
  * @return
  */
-double RadialProfiles::polflux(double x) {
+real_t RadialProfiles::polflux(real_t x) {
   // trapezoidal integration outwards from 0 to x in N=100 steps
   const int N = 100;
-  double delta_x = x / N;
+  real_t delta_x = x / N;
 
-  double polflux = 0.0;
+  real_t polflux = 0.0;
   for (int i = 0; i <= N; ++i) {
-    double contribution = polfluxDeriv(i * delta_x);
+    real_t contribution = polfluxDeriv(i * delta_x);
     if (i == 0 || i == N) {
       polflux += 0.5 * contribution;
     } else {
@@ -337,42 +337,49 @@ double RadialProfiles::polflux(double x) {
   return polflux;
 }
 
-double RadialProfiles::evalMassProfile(double x) {
+real_t RadialProfiles::evalMassProfile(real_t x) {
   // apply bloating factor
   // only allowed for current and pressure profile (checked in
   // VmecIndata.sanitize())
-  double normX = std::min(fabs(x * id_.bloat), 1.0);
+  real_t normX = std::min(static_cast<real_t>(std::fabs(x * id_.bloat)), 1.0L);
 
-  double p = evalProfileFunction(pmassType, id_.am, id_.am_aux_s, id_.am_aux_f,
+  real_t p = evalProfileFunction(pmassType, id_.am.cast<real_t>().eval(),
+                                 id_.am_aux_s.cast<real_t>().eval(),
+                                 id_.am_aux_f.cast<real_t>().eval(),
                                  /*shouldIntegrate=*/false, normX);
 
   return p * pressureScalingFactor;
 }
 
-double RadialProfiles::evalIotaProfile(double x) {
-  double p = evalProfileFunction(piotaType, id_.ai, id_.ai_aux_s, id_.ai_aux_f,
+real_t RadialProfiles::evalIotaProfile(real_t x) {
+  real_t p = evalProfileFunction(piotaType, id_.ai.cast<real_t>().eval(),
+                                 id_.ai_aux_s.cast<real_t>().eval(),
+                                 id_.ai_aux_f.cast<real_t>().eval(),
                                  /*shouldIntegrate=*/false, x);
 
   return p;
 }
 
-double RadialProfiles::evalCurrProfile(double x) {
+real_t RadialProfiles::evalCurrProfile(real_t x) {
   // apply bloating factor
   // only allowed for current and pressure profile (checked in
   // VmecIndata.sanitize())
-  double normX = std::min(std::abs(x * id_.bloat), 1.0);
+  real_t normX = std::min(std::abs(x * id_.bloat), 1.0L);
 
-  double p = evalProfileFunction(pcurrType, id_.ac, id_.ac_aux_s, id_.ac_aux_f,
+  real_t p = evalProfileFunction(pcurrType, id_.ac.cast<real_t>().eval(),
+                                 id_.ac_aux_s.cast<real_t>().eval(),
+                                 id_.ac_aux_f.cast<real_t>().eval(),
                                  /*shouldIntegrate=*/true, normX);
 
   return p;
 }
 
-double RadialProfiles::evalProfileFunction(const ProfileParameterization& param,
-                                           const Eigen::VectorXd& coeffs,
-                                           const Eigen::VectorXd& splineKnots,
-                                           const Eigen::VectorXd& splineValues,
-                                           bool shouldIntegrate, double normX) {
+real_t RadialProfiles::evalProfileFunction(
+    const ProfileParameterization& param,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineKnots,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineValues,
+    bool shouldIntegrate, real_t normX) {
   switch (param) {
     case ProfileParameterization::POWER_SERIES:
       return evalPowerSeries(coeffs, normX, shouldIntegrate);
@@ -422,14 +429,15 @@ double RadialProfiles::evalProfileFunction(const ProfileParameterization& param,
   return 0.0;
 }
 
-double RadialProfiles::evalPowerSeries(const Eigen::VectorXd& coeffs, double x,
-                                       bool should_integrate) {
-  double ret = 0.0;
+real_t RadialProfiles::evalPowerSeries(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs, real_t x,
+    bool should_integrate) {
+  real_t ret = 0.0;
 
-  for (Eigen::VectorXd::Index i = coeffs.size() - 1; i >= 0; i--) {
-    const double coeff = coeffs[i];
+  for (Eigen::Index i = coeffs.size() - 1; i >= 0; i--) {
+    const real_t coeff = coeffs[i];
     if (should_integrate) {
-      ret = x * ret + coeff / static_cast<double>(i + 1);
+      ret = x * ret + coeff / static_cast<real_t>(i + 1);
     } else {
       ret = x * ret + coeff;
     }
@@ -440,25 +448,27 @@ double RadialProfiles::evalPowerSeries(const Eigen::VectorXd& coeffs, double x,
   return ret;
 }
 
-double RadialProfiles::evalPowerSeriesI(const Eigen::VectorXd& coeffs,
-                                        double x) {
-  double ret = 0.0;
-  for (Eigen::VectorXd::Index i = coeffs.size() - 1; i >= 0; i--) {
-    const double coeff = coeffs[i];
+real_t RadialProfiles::evalPowerSeriesI(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs, real_t x) {
+  real_t ret = 0.0;
+  for (Eigen::Index i = coeffs.size() - 1; i >= 0; i--) {
+    const real_t coeff = coeffs[i];
     ret = (ret + coeff) * x;
   }
   return ret;
 }
 
-double RadialProfiles::evalGaussTrunc(const Eigen::VectorXd& coeffs, double x) {
+real_t RadialProfiles::evalGaussTrunc(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs, real_t x) {
   // TODO(jons): implement `gauss_trunc`
   (void)coeffs;
   (void)x;
   return 0.0;
 }
 
-double RadialProfiles::evalSumAtan(const Eigen::VectorXd& coeffs, double x) {
-  double ret = 0.0;
+real_t RadialProfiles::evalSumAtan(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs, real_t x) {
+  real_t ret = 0.0;
 
   if (coeffs.size() > 0) {
     ret = coeffs[0];
@@ -506,14 +516,15 @@ double RadialProfiles::evalSumAtan(const Eigen::VectorXd& coeffs, double x) {
   return ret;
 }
 
-double RadialProfiles::evalTwoLorentz(const Eigen::VectorXd& coeffs, double x) {
+real_t RadialProfiles::evalTwoLorentz(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs, real_t x) {
   if (coeffs.size() < 8) {
     LOG(WARNING)
         << "too few coefficients for 'two_lorentz' profile; need 8, got "
         << coeffs.size() << "\n";
     return 0.0;
   }
-  double ret = 0.0;
+  real_t ret = 0.0;
   ret =
       coeffs[0] *
       (coeffs[1] *
@@ -539,14 +550,15 @@ double RadialProfiles::evalTwoLorentz(const Eigen::VectorXd& coeffs, double x) {
   return ret;
 }
 
-double RadialProfiles::evalTwoPower(const Eigen::VectorXd& coeffs, double x,
-                                    bool shouldIntegrate) {
+real_t RadialProfiles::evalTwoPower(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs, real_t x,
+    bool shouldIntegrate) {
   if (coeffs.size() < 3) {
     LOG(WARNING) << "too few coefficients for 'two_power' profile; need 3, got "
                  << coeffs.size() << "\n";
     return 0.0;
   }
-  double ret = 0.0;
+  real_t ret = 0.0;
   if (!shouldIntegrate) {
     // p(s) = am(0) * [1 - s**am(1)]**am(2)
     ret = coeffs[0] * std::pow(1.0 - std::pow(x, coeffs[1]), coeffs[2]);
@@ -566,7 +578,7 @@ double RadialProfiles::evalTwoPower(const Eigen::VectorXd& coeffs, double x,
 
     ret = 0.0;
     for (int i = 0; i < ngl; ++i) {
-      const double xp = x * glx[i];
+      const real_t xp = x * glx[i];
       ret += glw[i] * coeffs[0] *
              std::pow(1.0 - std::pow(xp, coeffs[1]), coeffs[2]);
     }
@@ -575,16 +587,17 @@ double RadialProfiles::evalTwoPower(const Eigen::VectorXd& coeffs, double x,
   return ret;
 }
 
-double RadialProfiles::evalTwoPowerGs(const Eigen::VectorXd& coeffs, double x) {
+real_t RadialProfiles::evalTwoPowerGs(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs, real_t x) {
   // TODO(jons): implement `two_power_gs`
   (void)coeffs;
   (void)x;
   return 0.0;
 }
 
-double RadialProfiles::evalAkima(const Eigen::VectorXd& splineKnots,
-                                 const Eigen::VectorXd& splineValues,
-                                 double x) {
+real_t RadialProfiles::evalAkima(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineKnots,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineValues, real_t x) {
   // TODO(jons): implement `akima_spline`
   (void)splineKnots;
   (void)splineValues;
@@ -592,9 +605,9 @@ double RadialProfiles::evalAkima(const Eigen::VectorXd& splineKnots,
   return 0.0;
 }
 
-double RadialProfiles::evalAkimaIntegrated(const Eigen::VectorXd& splineKnots,
-                                           const Eigen::VectorXd& splineValues,
-                                           double x) {
+real_t RadialProfiles::evalAkimaIntegrated(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineKnots,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineValues, real_t x) {
   // TODO(jons): implement `akima_spline_i`
   (void)splineKnots;
   (void)splineValues;
@@ -602,9 +615,9 @@ double RadialProfiles::evalAkimaIntegrated(const Eigen::VectorXd& splineKnots,
   return 0.0;
 }
 
-double RadialProfiles::evalCubic(const Eigen::VectorXd& splineKnots,
-                                 const Eigen::VectorXd& splineValues,
-                                 double x) {
+real_t RadialProfiles::evalCubic(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineKnots,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineValues, real_t x) {
   // TODO(jons): implement `cubic_spline`
   (void)splineKnots;
   (void)splineValues;
@@ -612,9 +625,9 @@ double RadialProfiles::evalCubic(const Eigen::VectorXd& splineKnots,
   return 0.0;
 }
 
-double RadialProfiles::evalCubicIntegrated(const Eigen::VectorXd& splineKnots,
-                                           const Eigen::VectorXd& splineValues,
-                                           double x) {
+real_t RadialProfiles::evalCubicIntegrated(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineKnots,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineValues, real_t x) {
   // TODO(jons): implement `cubic_spline_i`
   (void)splineKnots;
   (void)splineValues;
@@ -623,14 +636,16 @@ double RadialProfiles::evalCubicIntegrated(const Eigen::VectorXd& splineKnots,
   return 0.0;
 }
 
-double RadialProfiles::evalPedestal(const Eigen::VectorXd& coeffs, double x) {
+real_t RadialProfiles::evalPedestal(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs, real_t x) {
   // TODO(jons): implement `pedestal`
   (void)coeffs;
   (void)x;
   return 0.0;
 }
 
-double RadialProfiles::evalRational(const Eigen::VectorXd& coeffs, double x) {
+real_t RadialProfiles::evalRational(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs, real_t x) {
   // TODO(jons): implement `rational`
   (void)coeffs;
   (void)x;
@@ -639,9 +654,9 @@ double RadialProfiles::evalRational(const Eigen::VectorXd& coeffs, double x) {
 
 // Linear interpolation between closest points and associated knots.
 // Clamp the profile if x is outside the range of knots.
-double RadialProfiles::evalLineSegment(const Eigen::VectorXd& splineKnots,
-                                       const Eigen::VectorXd& splineValues,
-                                       double x) {
+real_t RadialProfiles::evalLineSegment(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineKnots,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineValues, real_t x) {
   const int n = static_cast<int>(splineKnots.size());
   if (n < 2 || n != static_cast<int>(splineValues.size())) {
     return 0.0;
@@ -655,31 +670,31 @@ double RadialProfiles::evalLineSegment(const Eigen::VectorXd& splineKnots,
     // x is below the first knot
     return splineValues[0];
   }
-  const double x0 = *it;
-  const double x1 = *(it + 1);
+  const real_t x0 = *it;
+  const real_t x1 = *(it + 1);
   int ilow = static_cast<int>(std::distance(splineKnots.begin(), it));
-  const double y0 = splineValues[ilow];
-  const double y1 = splineValues[ilow + 1];
-  const double t = (x - x0) / (x1 - x0);
+  const real_t y0 = splineValues[ilow];
+  const real_t y1 = splineValues[ilow + 1];
+  const real_t t = (x - x0) / (x1 - x0);
   return (1.0 - t) * y0 + t * y1;
 }
 
-double RadialProfiles::evalLineSegmentIntegrated(
-    const Eigen::VectorXd& splineKnots, const Eigen::VectorXd& splineValues,
-    double x) {
+real_t RadialProfiles::evalLineSegmentIntegrated(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineKnots,
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineValues, real_t x) {
   const int n = static_cast<int>(splineKnots.size());
   if (n < 2 || n != static_cast<int>(splineValues.size())) {
     return 0.0;
   }
 
-  auto integrate_segment = [](double x0, double x1, double y0, double y1) {
-    const double m = (y1 - y0) / (x1 - x0);
-    const double b = y0 - m * x0;
+  auto integrate_segment = [](real_t x0, real_t x1, real_t y0, real_t y1) {
+    const real_t m = (y1 - y0) / (x1 - x0);
+    const real_t b = y0 - m * x0;
     return m * 0.5 * (x1 * x1 - x0 * x0) + b * (x1 - x0);
   };
 
-  double xi = x;
-  double result = 0.0;
+  real_t xi = x;
+  real_t result = 0.0;
 
   if (xi <= splineKnots[0]) {
     result += integrate_segment(0.0, xi, splineValues[0],
@@ -694,10 +709,10 @@ double RadialProfiles::evalLineSegmentIntegrated(
     ++idx;
   }
 
-  const double x0 = splineKnots[idx];
-  const double x1 = std::min(xi, splineKnots[idx + 1]);
-  const double y0 = splineValues[idx];
-  const double y1 = splineValues[idx + 1];
+  const real_t x0 = splineKnots[idx];
+  const real_t x1 = std::min(xi, splineKnots[idx + 1]);
+  const real_t y0 = splineValues[idx];
+  const real_t y1 = splineValues[idx + 1];
   result += integrate_segment(x0, x1, y0, y1);
 
   if (xi > splineKnots[n - 1]) {
@@ -708,8 +723,8 @@ double RadialProfiles::evalLineSegmentIntegrated(
   return result;
 }
 
-double RadialProfiles::evalNiceQuadratic(const Eigen::VectorXd& coeffs,
-                                         double x) {
+real_t RadialProfiles::evalNiceQuadratic(
+    const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs, real_t x) {
   // TODO(jons): implement `nice_quadratic`
   (void)coeffs;
   (void)x;
@@ -720,7 +735,7 @@ void RadialProfiles::evalRadialProfiles(bool haveToFlipTheta,
                                         VmecConstants& m_vmecconst) {
   // R_00 of initial boundary is ~ major radius
   // and used as normalization factor for mass profile
-  const double r00 = id_.rbc(0, id_.ntor);
+  const real_t r00 = id_.rbc(0, id_.ntor);
 
   // scale profile of enclosed toroidal current to prescribed net toroidal
   // current,
@@ -728,7 +743,7 @@ void RadialProfiles::evalRadialProfiles(bool haveToFlipTheta,
 
   // only scale current profile if value at edge is "sufficiently non-zero"
   // outermost value of enclosed current profile -->
-  const double edgeCurrent = evalCurrProfile(1.0);
+  const real_t edgeCurrent = evalCurrProfile(1.0);
   Itor = 0.0;
   // TODO(jons): eps*currv instead of eps*curtor?
   if (std::abs(edgeCurrent) > std::abs(DBL_EPSILON * id_.curtor)) {
@@ -737,11 +752,11 @@ void RadialProfiles::evalRadialProfiles(bool haveToFlipTheta,
     Itor = signOfJacobian * currv / (2.0 * M_PI * edgeCurrent);
   }
 
-  double local_rmsPhiP = 0.0;
+  real_t local_rmsPhiP = 0.0;
 
   // half-grid
   for (int jH = r_.nsMinH; jH < r_.nsMaxH; ++jH) {
-    const double halfGridPos = (jH + 0.5) / (fc_.ns - 1.0);
+    const real_t halfGridPos = (jH + 0.5) / (fc_.ns - 1.0);
 
     // normalized toroidal flux array
     sqrtSH[jH - r_.nsMinH] = std::sqrt(halfGridPos);
@@ -749,7 +764,7 @@ void RadialProfiles::evalRadialProfiles(bool haveToFlipTheta,
     phipH[jH - r_.nsMinH] = maxToroidalFlux * torfluxDeriv(halfGridPos);
     chipH[jH - r_.nsMinH] = maxToroidalFlux * polfluxDeriv(halfGridPos);
 
-    const double toroidalFlux = std::min(torflux(halfGridPos), 1.0);
+    const real_t toroidalFlux = std::min(torflux(halfGridPos), 1.0L);
     iotaH[jH - r_.nsMinH] = evalIotaProfile(toroidalFlux);
     currH[jH - r_.nsMinH] = evalCurrProfile(toroidalFlux);
 
@@ -767,13 +782,14 @@ void RadialProfiles::evalRadialProfiles(bool haveToFlipTheta,
     // mass profile
 
     // effectively vpnorm == phipH[jH]
-    const double vpnorm = maxToroidalFlux * torfluxDeriv(halfGridPos);
-    const double massEvalPos = std::min(halfGridPos, id_.spres_ped);
+    const real_t vpnorm = maxToroidalFlux * torfluxDeriv(halfGridPos);
+    const real_t massEvalPos =
+        std::min(halfGridPos, static_cast<real_t>(id_.spres_ped));
     // if (massEvalPos > id_.spres_ped) {
     //     massEvalPos = id_.spres_ped;
     // }
-    const double massEvalTorFlux = std::min(torflux(massEvalPos), 1.0);
-    const double mass = evalMassProfile(massEvalTorFlux);
+    const real_t massEvalTorFlux = std::min(torflux(massEvalPos), 1.0L);
+    const real_t mass = evalMassProfile(massEvalTorFlux);
     massH[jH - r_.nsMinH] = mass * std::pow(std::abs(vpnorm) * r00, id_.gamma);
 
     // This must be done over UNIQUE half-grid points !!!
@@ -789,11 +805,11 @@ void RadialProfiles::evalRadialProfiles(bool haveToFlipTheta,
 
   // ------------------------------------------
 
-  const double sqrtS1 = sqrt(1.0 / (fc_.ns - 1));
+  const real_t sqrtS1 = sqrt(1.0 / (fc_.ns - 1));
 
   // full-grid
   for (int jF1 = r_.nsMinF1; jF1 < r_.nsMaxF1; ++jF1) {
-    const double fullGridPos = jF1 / (fc_.ns - 1.0);
+    const real_t fullGridPos = jF1 / (fc_.ns - 1.0);
 
     // normalized toroidal flux array
     sqrtSF[jF1 - r_.nsMinF1] = std::sqrt(fullGridPos);
@@ -801,7 +817,7 @@ void RadialProfiles::evalRadialProfiles(bool haveToFlipTheta,
     phipF[jF1 - r_.nsMinF1] = maxToroidalFlux * torfluxDeriv(fullGridPos);
     chipF[jF1 - r_.nsMinF1] = maxToroidalFlux * polfluxDeriv(fullGridPos);
 
-    const double toroidalFlux = std::min(torflux(fullGridPos), 1.0);
+    const real_t toroidalFlux = std::min(torflux(fullGridPos), 1.0L);
     iotaF[jF1 - r_.nsMinF1] = evalIotaProfile(toroidalFlux);
 
     // TODO(jons): this is still weird
@@ -852,7 +868,7 @@ void RadialProfiles::AccumulateVolumeAveragedSpectralWidth() const {
       const int jFi = jH;
       const int jFo = jH + 1;
 
-      const double spectral_width_on_half_grid =
+      const real_t spectral_width_on_half_grid =
           (spectral_width[jFo - r_.nsMinF1] +
            spectral_width[jFi - r_.nsMinF1]) /
           2.0;

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.h
@@ -25,7 +25,7 @@ class RadialProfiles {
  public:
   RadialProfiles(const RadialPartitioning* s, HandoverStorage* m_h,
                  const VmecINDATA* id, const FlowControl* fc,
-                 int signOfJacobian, double pDamp);
+                 int signOfJacobian, real_t pDamp);
 
   // update profile parameterizations based on p****_type strings
   void setupInputProfiles();
@@ -40,14 +40,14 @@ class RadialProfiles {
   std::string profileTypeToString(ProfileType profileType);
 
   void computeMagneticFluxes();
-  double torfluxDeriv(double x);
-  double torflux(double x);
-  double polfluxDeriv(double x);
-  double polflux(double x);
+  real_t torfluxDeriv(real_t x);
+  real_t torflux(real_t x);
+  real_t polfluxDeriv(real_t x);
+  real_t polflux(real_t x);
 
-  double evalMassProfile(double x);
-  double evalIotaProfile(double x);
-  double evalCurrProfile(double x);
+  real_t evalMassProfile(real_t x);
+  real_t evalIotaProfile(real_t x);
+  real_t evalCurrProfile(real_t x);
 
   // Evaluate the radial profile function specified by the given
   // parameterization, which can be either an analytical function (in which case
@@ -71,37 +71,51 @@ class RadialProfiles {
   // In the end, for the current profile, this method should always return the
   // enclosed toroidal current profile.
   // TODO(jons): This function is wearing way too many hats. Chunk it up.
-  double evalProfileFunction(const ProfileParameterization& param,
-                             const Eigen::VectorXd& coeffs,
-                             const Eigen::VectorXd& splineKnots,
-                             const Eigen::VectorXd& splineValues,
-                             bool shouldIntegrate, double normX);
+  real_t evalProfileFunction(
+      const ProfileParameterization& param,
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs,
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineKnots,
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineValues,
+      bool shouldIntegrate, real_t normX);
 
-  double evalPowerSeries(const Eigen::VectorXd& coeffs, double x,
-                         bool should_integrate);
-  double evalPowerSeriesI(const Eigen::VectorXd& coeffs, double x);
-  double evalGaussTrunc(const Eigen::VectorXd& coeffs, double x);
-  double evalSumAtan(const Eigen::VectorXd& coeffs, double x);
-  double evalTwoLorentz(const Eigen::VectorXd& coeffs, double x);
-  double evalTwoPower(const Eigen::VectorXd& coeffs, double x,
-                      bool shouldIntegrate);
-  double evalTwoPowerGs(const Eigen::VectorXd& coeffs, double x);
-  double evalAkima(const Eigen::VectorXd& splineKnots,
-                   const Eigen::VectorXd& splineValues, double x);
-  double evalAkimaIntegrated(const Eigen::VectorXd& splineKnots,
-                             const Eigen::VectorXd& splineValues, double x);
-  double evalCubic(const Eigen::VectorXd& splineKnots,
-                   const Eigen::VectorXd& splineValues, double x);
-  double evalCubicIntegrated(const Eigen::VectorXd& splineKnots,
-                             const Eigen::VectorXd& splineValues, double x);
-  double evalPedestal(const Eigen::VectorXd& coeffs, double x);
-  double evalRational(const Eigen::VectorXd& coeffs, double x);
-  double evalLineSegment(const Eigen::VectorXd& splineKnots,
-                         const Eigen::VectorXd& splineValues, double x);
-  double evalLineSegmentIntegrated(const Eigen::VectorXd& splineKnots,
-                                   const Eigen::VectorXd& splineValues,
-                                   double x);
-  double evalNiceQuadratic(const Eigen::VectorXd& coeffs, double x);
+  real_t evalPowerSeries(const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs,
+                         real_t x, bool should_integrate);
+  real_t evalPowerSeriesI(
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs, real_t x);
+  real_t evalGaussTrunc(const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs,
+                        real_t x);
+  real_t evalSumAtan(const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs,
+                     real_t x);
+  real_t evalTwoLorentz(const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs,
+                        real_t x);
+  real_t evalTwoPower(const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs,
+                      real_t x, bool shouldIntegrate);
+  real_t evalTwoPowerGs(const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs,
+                        real_t x);
+  real_t evalAkima(const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineKnots,
+                   const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineValues,
+                   real_t x);
+  real_t evalAkimaIntegrated(
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineKnots,
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineValues, real_t x);
+  real_t evalCubic(const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineKnots,
+                   const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineValues,
+                   real_t x);
+  real_t evalCubicIntegrated(
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineKnots,
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineValues, real_t x);
+  real_t evalPedestal(const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs,
+                      real_t x);
+  real_t evalRational(const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs,
+                      real_t x);
+  real_t evalLineSegment(
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineKnots,
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineValues, real_t x);
+  real_t evalLineSegmentIntegrated(
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineKnots,
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& splineValues, real_t x);
+  real_t evalNiceQuadratic(
+      const Eigen::Matrix<real_t, Eigen::Dynamic, 1>& coeffs, real_t x);
 
   // Accumulate contributions to volume-averaged spectral width <M>.
   void AccumulateVolumeAveragedSpectralWidth() const;
@@ -113,72 +127,72 @@ class RadialProfiles {
   ProfileParameterization pcurrType;
 
   // half-grid
-  Eigen::VectorXd phipH;
-  Eigen::VectorXd chipH;
-  Eigen::VectorXd iotaH;
-  Eigen::VectorXd currH;
-  Eigen::VectorXd massH;
-  Eigen::VectorXd sqrtSH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> phipH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> chipH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> iotaH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> currH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> massH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sqrtSH;
 
   // full-grid
-  Eigen::VectorXd phipF;
-  Eigen::VectorXd chipF;
-  Eigen::VectorXd iotaF;
-  Eigen::VectorXd sqrtSF;
-  Eigen::VectorXd radialBlending;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> phipF;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> chipF;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> iotaF;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sqrtSF;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> radialBlending;
 
   // ---------------------------------
 
-  double currv;
-  double Itor;
+  real_t currv;
+  real_t Itor;
 
-  double maxToroidalFlux;
-  double maxPoloidalFlux;
+  real_t maxToroidalFlux;
+  real_t maxPoloidalFlux;
 
-  double pressureScalingFactor;
+  real_t pressureScalingFactor;
 
   /** sm[j] = sqrt(s_{j-1/2}) / sqrt(s_j) for all force-j (numFull) */
-  Eigen::VectorXd sm;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sm;
 
   /** sp[j] = sqrt(s_{j+1/2}) / sqrt(s_j) for all force-j (numFull) */
-  Eigen::VectorXd sp;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sp;
 
   // part 2: derived radial profiles
 
   /** differential volume, half-grid */
-  Eigen::VectorXd dVdsH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> dVdsH;
 
   /** kinetic pressure, half-grid */
-  Eigen::VectorXd presH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> presH;
 
   /** enclosed poloidal current, half-grid */
-  Eigen::VectorXd bvcoH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bvcoH;
 
   /** enclosed toroidal current, half-grid */
-  Eigen::VectorXd bucoH;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bucoH;
 
   /** poloidal current density, interior full-grid */
-  Eigen::VectorXd jcuruF;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> jcuruF;
 
   /** toroidal current density, interior full-grid */
-  Eigen::VectorXd jcurvF;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> jcurvF;
 
   /** pressure gradient, interior full-grid */
-  Eigen::VectorXd presgradF;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> presgradF;
 
   /** differential volume, interior full-grid */
-  Eigen::VectorXd dVdsF;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> dVdsF;
 
   /** radial force balance residual, interior full-grid */
-  Eigen::VectorXd equiF;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> equiF;
 
   // [nsMinF1 ... nsMaxF1] surface-averaged spectral width profile on full-grid
-  Eigen::VectorXd spectral_width;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> spectral_width;
 
   // ---------------------------------
 
   /** [ns x 2] 1/sqrtSF for odd-m; 1 for even-m */
-  Eigen::VectorXd scalxc;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> scalxc;
 
  private:
   const RadialPartitioning& r_;
@@ -187,7 +201,7 @@ class RadialProfiles {
   const FlowControl& fc_;
 
   const int signOfJacobian;
-  const double pDamp;
+  const real_t pDamp;
 
   std::vector<ProfileParameterizationData> ALL_PARAMS;
 

--- a/src/vmecpp/cpp/vmecpp/vmec/thread_local_storage/thread_local_storage.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/thread_local_storage/thread_local_storage.h
@@ -19,39 +19,39 @@ class ThreadLocalStorage {
   explicit ThreadLocalStorage(const Sizes* s);
 
   // inv-DFT of geometry
-  Eigen::VectorXd r1e_i;
-  Eigen::VectorXd r1o_i;
-  Eigen::VectorXd rue_i;
-  Eigen::VectorXd ruo_i;
-  Eigen::VectorXd rve_i;
-  Eigen::VectorXd rvo_i;
-  Eigen::VectorXd z1e_i;
-  Eigen::VectorXd z1o_i;
-  Eigen::VectorXd zue_i;
-  Eigen::VectorXd zuo_i;
-  Eigen::VectorXd zve_i;
-  Eigen::VectorXd zvo_i;
-  Eigen::VectorXd lue_i;
-  Eigen::VectorXd luo_i;
-  Eigen::VectorXd lve_i;
-  Eigen::VectorXd lvo_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> r1e_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> r1o_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rue_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> ruo_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rve_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rvo_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> z1e_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> z1o_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zue_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zuo_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zve_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zvo_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> lue_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> luo_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> lve_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> lvo_i;
 
   // hybrid lambda forces
-  Eigen::VectorXd bsubu_i;
-  Eigen::VectorXd bsubv_i;
-  Eigen::VectorXd gvv_gsqrt_i;  // gvv / gsqrt
-  Eigen::VectorXd guv_bsupu_i;  // guv * bsupu
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bsubu_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bsubv_i;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> gvv_gsqrt_i;  // gvv / gsqrt
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> guv_bsupu_i;  // guv * bsupu
 
   // R, Z MHD forces
-  Eigen::VectorXd P_i;      // r12 * totalPressure = P
-  Eigen::VectorXd rup_i;    // ru12 * P
-  Eigen::VectorXd zup_i;    // zu12 * P
-  Eigen::VectorXd rsp_i;    //   rs * P
-  Eigen::VectorXd zsp_i;    //   zs * P
-  Eigen::VectorXd taup_i;   //  tau * P
-  Eigen::VectorXd gbubu_i;  // gsqrt * bsupu * bsupu
-  Eigen::VectorXd gbubv_i;  // gsqrt * bsupu * bsupv
-  Eigen::VectorXd gbvbv_i;  // gsqrt * bsupv * bsupv
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> P_i;      // r12 * totalPressure = P
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rup_i;    // ru12 * P
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zup_i;    // zu12 * P
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> rsp_i;    //   rs * P
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> zsp_i;    //   zs * P
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> taup_i;   //  tau * P
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> gbubu_i;  // gsqrt * bsupu * bsupu
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> gbubv_i;  // gsqrt * bsupu * bsupv
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> gbvbv_i;  // gsqrt * bsupv * bsupv
 };
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -421,7 +421,7 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
 // initialize_radial quantities, return true if a checkpoint was reached
 bool Vmec::InitializeRadial(
     VmecCheckpoint checkpoint, int iterations_before_checkpointing, int nsval,
-    int ns_old, double& m_delt0,
+    int ns_old, real_t& m_delt0,
     const std::optional<HotRestartState>& initial_state) {
   // Stage info output is now handled by logger_.BeginStage() in run().
 
@@ -527,23 +527,23 @@ bool Vmec::InitializeRadial(
         if (indata_.free_boundary_method == FreeBoundaryMethod::NESTOR) {
           fb_[thread_id] = std::make_unique<Nestor>(
               &s_, tp_[thread_id].get(), &mgrid_,
-              std::span<double>(matrixShare.data(), matrixShare.size()),
-              std::span<double>(bvecShare.data(), bvecShare.size()),
-              std::span<double>(h_.vacuum_magnetic_pressure.data(),
+              std::span<real_t>(matrixShare.data(), matrixShare.size()),
+              std::span<real_t>(bvecShare.data(), bvecShare.size()),
+              std::span<real_t>(h_.vacuum_magnetic_pressure.data(),
                                 h_.vacuum_magnetic_pressure.size()),
               std::span<int>(iPiv.data(), iPiv.size()),
-              std::span<double>(h_.vacuum_b_r.data(), h_.vacuum_b_r.size()),
-              std::span<double>(h_.vacuum_b_phi.data(), h_.vacuum_b_phi.size()),
-              std::span<double>(h_.vacuum_b_z.data(), h_.vacuum_b_z.size()));
+              std::span<real_t>(h_.vacuum_b_r.data(), h_.vacuum_b_r.size()),
+              std::span<real_t>(h_.vacuum_b_phi.data(), h_.vacuum_b_phi.size()),
+              std::span<real_t>(h_.vacuum_b_z.data(), h_.vacuum_b_z.size()));
         } else if (indata_.free_boundary_method ==
                    FreeBoundaryMethod::ONLY_COILS) {
           fb_[thread_id] = std::make_unique<OnlyCoils>(
               &s_, tp_[thread_id].get(), &mgrid_,
-              std::span<double>(h_.vacuum_magnetic_pressure.data(),
+              std::span<real_t>(h_.vacuum_magnetic_pressure.data(),
                                 h_.vacuum_magnetic_pressure.size()),
-              std::span<double>(h_.vacuum_b_r.data(), h_.vacuum_b_r.size()),
-              std::span<double>(h_.vacuum_b_phi.data(), h_.vacuum_b_phi.size()),
-              std::span<double>(h_.vacuum_b_z.data(), h_.vacuum_b_z.size()));
+              std::span<real_t>(h_.vacuum_b_r.data(), h_.vacuum_b_r.size()),
+              std::span<real_t>(h_.vacuum_b_phi.data(), h_.vacuum_b_phi.size()),
+              std::span<real_t>(h_.vacuum_b_z.data(), h_.vacuum_b_z.size()));
         } else {
           LOG(FATAL) << absl::StrCat("free boundary method '",
                                      ToString(indata_.free_boundary_method),
@@ -651,7 +651,7 @@ bool Vmec::InitializeRadial(
 
       // TODO(jons): what exactly happens here?
       // Why do we mask potential changes on `indata_.delt` by passing a copy?
-      double delt_for_restart_iter = indata_.delt;
+      real_t delt_for_restart_iter = indata_.delt;
       RestartIteration(delt_for_restart_iter, thread_id);
     }
 
@@ -910,7 +910,7 @@ absl::StatusOr<Vmec::SolveEqLoopStatus> Vmec::SolveEquilibriumLoop(
 #endif  // _OPENMP
       {
         // fc_.ijacob is incremented in RestartIteration
-        const double scale = fc_.ijacob < 50 ? 0.98 : 0.96;
+        const real_t scale = fc_.ijacob < 50 ? 0.98 : 0.96;
 
         fc_.delt0r = scale * indata_.delt;
 
@@ -1082,7 +1082,7 @@ absl::StatusOr<Vmec::SolveEqLoopStatus> Vmec::SolveEquilibriumLoop(
 }
 
 // aligned visually with restart_iter.f90
-void Vmec::RestartIteration(double& m_delt0r, int thread_id) {
+void Vmec::RestartIteration(real_t& m_delt0r, int thread_id) {
 #ifdef _OPENMP
 #pragma omp barrier
 #endif  // _OPENMP
@@ -1152,7 +1152,7 @@ void Vmec::RestartIteration(double& m_delt0r, int thread_id) {
 
 absl::StatusOr<bool> Vmec::Evolve(VmecCheckpoint checkpoint,
                                   int iterations_before_checkpointing,
-                                  double time_step, int thread_id,
+                                  real_t time_step, int thread_id,
                                   bool& m_liter_flag) {
 #ifdef _OPENMP
 #pragma omp single
@@ -1205,7 +1205,7 @@ absl::StatusOr<bool> Vmec::Evolve(VmecCheckpoint checkpoint,
 #endif  // _OPENMP
   {
     // sum of preconditioned force residuals in current iteration
-    const double fsq1 = fc_.fsqr1 + fc_.fsqz1 + fc_.fsql1;
+    const real_t fsq1 = fc_.fsqr1 + fc_.fsqz1 + fc_.fsql1;
 
     if (iter2_ == iter1_) {
       // initialize all entries in otau to 0.15/time_step --> required for
@@ -1216,16 +1216,18 @@ absl::StatusOr<bool> Vmec::Evolve(VmecCheckpoint checkpoint,
     // shift elements for averaging to the left to make space at end for new
     // entry (oldest entry ends up at the end and will be overwritten later)
     {
-      Eigen::VectorXd tmp = invTau_.tail(invTau_.size() - 1);
+      Eigen::Matrix<real_t, Eigen::Dynamic, 1> tmp =
+          invTau_.tail(invTau_.size() - 1);
       invTau_.head(invTau_.size() - 1) = tmp;
     }
 
     if (iter2_ > iter1_) {
-      double invtau_numerator = 0.;
+      real_t invtau_numerator = 0.;
       if (fsq1 != 0.) {
         // fsq is 1 (first iteration) or fsq1 from previous iteration
         // fsq1/fsq is y_n assuming monotonic decrease of energy
-        invtau_numerator = std::min(std::abs(std::log(fsq1 / fc_.fsq)), 0.15);
+        invtau_numerator = std::min(std::abs(std::log(fsq1 / fc_.fsq)),
+                                    static_cast<real_t>(0.15));
       }
 
       // overwrite oldest entry (at last index after rotation above) with the
@@ -1254,11 +1256,11 @@ absl::StatusOr<bool> Vmec::Evolve(VmecCheckpoint checkpoint,
   }
 
   // averaging over ndamp entries : 1/ndamp*sum(invTau)
-  const double otav = invTau_.sum() / kNDamp;
+  const real_t otav = invTau_.sum() / kNDamp;
 
-  const double dtau = time_step * otav / 2.0;
-  const double b1 = 1.0 - dtau;
-  const double fac = 1.0 / (1.0 + dtau);
+  const real_t dtau = time_step * otav / 2.0;
+  const real_t b1 = 1.0 - dtau;
+  const real_t fac = 1.0 / (1.0 + dtau);
 
   // THIS IS THE TIME-STEP ALGORITHM. IT IS ESSENTIALLY A CONJUGATE
   // GRADIENT METHOD, WITHOUT THE LINE SEARCHES (FLETCHER-REEVES),
@@ -1268,7 +1270,7 @@ absl::StatusOr<bool> Vmec::Evolve(VmecCheckpoint checkpoint,
   return false;
 }
 
-void Vmec::Printout(double delt0r, int thread_id, int iter2) {
+void Vmec::Printout(real_t delt0r, int thread_id, int iter2) {
 #ifdef _OPENMP
 #pragma omp single
 #endif  // _OPENMP
@@ -1286,19 +1288,19 @@ void Vmec::Printout(double delt0r, int thread_id, int iter2) {
 
     // radial location of magnetic axis at zeta = 0
     const GeometricOffset& geometric_offset = h_.GetGeometricOffset();
-    double r00 = geometric_offset.r_00;
+    real_t r00 = geometric_offset.r_00;
 
     // MHD energy (in SI units, i.e., Joules?)
-    double energy = h_.mhdEnergy * 4.0 * M_PI * M_PI;
+    real_t energy = h_.mhdEnergy * 4.0 * M_PI * M_PI;
 
     // volume-averaged beta
-    double betaVolAvg = h_.thermalEnergy / h_.magneticEnergy;
+    real_t betaVolAvg = h_.thermalEnergy / h_.magneticEnergy;
 
     // volume-averaged spectral width <M>
-    double volAvgM = h_.VolumeAveragedSpectralWidth();
+    real_t volAvgM = h_.VolumeAveragedSpectralWidth();
 
     // mismatch in |B|^2 at LCFS for free-boundary
-    double delbsq = m_[thread_id]->get_delbsq();
+    real_t delbsq = m_[thread_id]->get_delbsq();
 
     logger_.LogIteration(iter2, fc_.fsqr, fc_.fsqz, fc_.fsql, fc_.fsqr1,
                          fc_.fsqz1, fc_.fsql1, delt0r, r00, energy, betaVolAvg,
@@ -1323,7 +1325,7 @@ absl::StatusOr<bool> Vmec::UpdateForwardModel(
   // triggered at activation of vacuum forces.
   // all threads return the same value for this flag.
   if (need_restart) {
-    double delt0 = indata_.delt;
+    real_t delt0 = indata_.delt;
     RestartIteration(delt0, thread_id);
 
 #ifdef _OPENMP
@@ -1340,7 +1342,7 @@ absl::StatusOr<bool> Vmec::UpdateForwardModel(
   return reached_checkpoint;
 }
 
-void Vmec::PerformTimeStep(double fac, double b1, double time_step,
+void Vmec::PerformTimeStep(real_t fac, real_t b1, real_t time_step,
                            int thread_id) {
 #ifdef _OPENMP
 #pragma omp barrier
@@ -1360,8 +1362,8 @@ void Vmec::PerformTimeStep(double fac, double b1, double time_step,
 // velocity_scale == fac
 // conjugation_parameter == b1
 void Vmec::performTimeStep(const Sizes& s, const FlowControl& fc,
-                           const RadialPartitioning& r, double velocity_scale,
-                           double conjugation_parameter, double time_step,
+                           const RadialPartitioning& r, real_t velocity_scale,
+                           real_t conjugation_parameter, real_t time_step,
                            FourierGeometry& m_decomposed_x,
                            FourierVelocity& m_decomposed_v,
                            const FourierForces& decomposed_f,
@@ -1651,7 +1653,7 @@ void Vmec::InterpolateToNextMultigridStep(
   // ON ENTRY, XOLD = X(COARSE MESH) * SCALXC(COARSE MESH)
   // ON EXIT,  XNEW = X(NEW MESH)   [ NOT SCALED BY 1/SQRTS ]
 
-  const double hs_old = 1.0 / (ns_old - 1.0);
+  const real_t hs_old = 1.0 / (ns_old - 1.0);
 
   const int num_threads_new = static_cast<int>(r_new.size());
   const int num_threads_old = static_cast<int>(r_old.size());
@@ -1760,8 +1762,8 @@ void Vmec::InterpolateToNextMultigridStep(
 
       // interpolation weight
       xint[jNew] = (sj[jNew] - s1[jNew]) / hs_old;
-      xint[jNew] = std::min(1.0, xint[jNew]);
-      xint[jNew] = std::max(0.0, xint[jNew]);
+      xint[jNew] = std::min(static_cast<real_t>(1.0), xint[jNew]);
+      xint[jNew] = std::max(static_cast<real_t>(0.0), xint[jNew]);
 
       // now need to figure out source threads, which have js1 and js2
       // and the target thread that has jNew
@@ -1797,7 +1799,7 @@ void Vmec::InterpolateToNextMultigridStep(
                   (s_.ntor + 1) +
               n;
 
-          const double scalxc =
+          const real_t scalxc =
               p[thread_id]
                   ->scalxc[(jNew - r_new[thread_id]->nsMinF1) * 2 + m_parity];
 

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
@@ -96,7 +96,7 @@ class Vmec {
   static constexpr int kSignOfJacobian = -1;
 
   // scaling factor for blending between two different ways to compute B^zeta
-  static constexpr double kPDamp = 0.05;
+  static constexpr real_t kPDamp = 0.05L;
 
   // Factory method for creating a Vmec instance.
   // Handles mgrid loading for free-boundary runs with proper error handling.
@@ -119,19 +119,19 @@ class Vmec {
 
   bool InitializeRadial(
       VmecCheckpoint checkpoint, int maximum_iterations, int nsval, int ns_old,
-      double& m_delt0,
+      real_t& m_delt0,
       const std::optional<HotRestartState>& initial_state = std::nullopt);
   absl::StatusOr<bool> SolveEquilibrium(VmecCheckpoint checkpoint,
                                         int maximum_iterations);
-  void RestartIteration(double& m_delt0r, int thread_id);
+  void RestartIteration(real_t& m_delt0r, int thread_id);
   absl::StatusOr<bool> Evolve(VmecCheckpoint checkpoint, int maximum_iterations,
-                              double time_step, int thread_id,
+                              real_t time_step, int thread_id,
                               bool& m_liter_flag);
-  void Printout(double delt0r, int thread_id, int iter2);
+  void Printout(real_t delt0r, int thread_id, int iter2);
   absl::StatusOr<bool> UpdateForwardModel(VmecCheckpoint checkpoint,
                                           int maximum_iterations,
                                           int thread_id);
-  void PerformTimeStep(double fac, double b1, double time_step, int thread_id);
+  void PerformTimeStep(real_t fac, real_t b1, real_t time_step, int thread_id);
   void InterpolateToNextMultigridStep(
       int ns_new, int ns_old,
       const std::vector<std::unique_ptr<RadialProfiles>>& p,
@@ -154,8 +154,8 @@ class Vmec {
               const FourierForces& decomposed_f, const FlowControl& fc);
 
   void performTimeStep(const Sizes& s, const FlowControl& fc,
-                       const RadialPartitioning& r, double velocityScale,
-                       double conjugationParameter, double time_step,
+                       const RadialPartitioning& r, real_t velocityScale,
+                       real_t conjugationParameter, real_t time_step,
                        FourierGeometry& m_decomposed_x,
                        FourierVelocity& m_decomposed_v,
                        const FourierForces& decomposed_f,
@@ -197,17 +197,17 @@ class Vmec {
   std::vector<std::unique_ptr<FourierForces>> physical_f_;
   std::vector<std::unique_ptr<FourierVelocity>> decomposed_v_;
 
-  Eigen::VectorXd sj;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> sj;
   Eigen::VectorXi js1;
   Eigen::VectorXi js2;
-  Eigen::VectorXd s1;
-  Eigen::VectorXd xint;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> s1;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> xint;
   std::vector<std::unique_ptr<FourierGeometry>> old_xc_scaled_;
   std::vector<std::unique_ptr<RadialPartitioning>> old_r_;
 
-  Eigen::VectorXd matrixShare;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> matrixShare;
   Eigen::VectorXi iPiv;
-  Eigen::VectorXd bvecShare;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> bvecShare;
 
  private:
   enum class SolveEqLoopStatus : std::uint8_t {
@@ -257,7 +257,7 @@ class Vmec {
   // history size for averaging of 1/tau
   static constexpr int kNDamp = 10;
 
-  Eigen::VectorXd invTau_;
+  Eigen::Matrix<real_t, Eigen::Dynamic, 1> invTau_;
 
   // iter2 at last update of preconditioner update
   int last_preconditioner_update_;

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec_constants/vmec_algorithm_constants.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec_constants/vmec_algorithm_constants.h
@@ -9,6 +9,8 @@
 #include <cmath>
 #include <numbers>
 
+#include "vmecpp/common/util/real_type.h"
+
 namespace vmecpp {
 
 /**
@@ -34,7 +36,7 @@ static constexpr int kSignOfJacobian = -1;
  * Historical name: kPDamp from Fortran VMEC.
  * Also defined in vmec.h as kPDamp.
  */
-static constexpr double kMagneticFieldBlendingFactor = 0.05;
+static constexpr real_t kMagneticFieldBlendingFactor = 0.05L;
 
 /**
  * Vacuum magnetic permeability \mu_0 in Vs/Am.
@@ -44,21 +46,21 @@ static constexpr double kMagneticFieldBlendingFactor = 0.05;
  * Files: magnetic_field_provider_lib.cc, external_magnetic_field.cc
  * Traditional definition: \mu_0 = 4\pi \times 10^{-7} Vs/Am
  */
-static constexpr double kVacuumPermeability = 4.0e-7 * M_PI;
+static constexpr real_t kVacuumPermeability = 4.0e-7L * M_PI;
 
 /**
  * Ion Larmor radius calculation coefficient.
  * Used in: output_quantities.cc for plasma parameter calculations
  * Context: Relates ion gyroradius to plasma parameters
  */
-static constexpr double kIonLarmorRadiusCoefficient = 3.2e-3;
+static constexpr real_t kIonLarmorRadiusCoefficient = 3.2e-3L;
 
 /**
  * Eigenvalue avoidance factor for numerical stability.
  * Used in: ideal_mhd_model.cc to avoid singular matrix systems
  * Context: Prevents division by zero in eigenvalue computations
  */
-static constexpr double kEigenvalueAvoidanceFactor = -1.0e-10;
+static constexpr real_t kEigenvalueAvoidanceFactor = -1.0e-10L;
 
 // ========== Mathematical Constants ==========
 
@@ -67,21 +69,21 @@ static constexpr double kEigenvalueAvoidanceFactor = -1.0e-10;
  * Used throughout for: volume integrals, flux surface calculations
  * Appears 40+ times across the codebase for torus geometry
  */
-static constexpr double kToroidalNormalizationFactor = 2.0 * M_PI;
+static constexpr real_t kToroidalNormalizationFactor = 2.0L * M_PI;
 
 /**
  * Toroidal volume factor: (2\pi)^2
  * Used in: volume calculations requiring full torus integration
  * Context: Volume = \iiint d\rho d\theta d\zeta over torus
  */
-static constexpr double kToroidalVolumeFactor = 4.0 * M_PI * M_PI;
+static constexpr real_t kToroidalVolumeFactor = 4.0L * M_PI * M_PI;
 
 /**
  * Constraint scaling factor: 1/\sqrt{2}
  * Used in: DFT normalization and constraint scaling
  * Context: Preserves orthogonality in Fourier transformations
  */
-static constexpr double kConstraintScalingFactor = 1.0 / std::numbers::sqrt2;
+static constexpr real_t kConstraintScalingFactor = 1.0L / std::numbers::sqrt2;
 
 // ========== Convergence and Tolerance Constants ==========
 
@@ -90,42 +92,42 @@ static constexpr double kConstraintScalingFactor = 1.0 / std::numbers::sqrt2;
  * Used in: vmec_indata.h as kFTolDefault
  * Context: ||F|| < kDefaultForceTolerance indicates equilibrium
  */
-static constexpr double kDefaultForceTolerance = 1.0e-10;
+static constexpr real_t kDefaultForceTolerance = 1.0e-10L;
 
 /**
  * Fast convergence detection threshold.
  * Used in: ideal_mhd_model.cc for convergence acceleration
  * Context: When ||F|| < threshold, apply special techniques
  */
-static constexpr double kFastConvergenceThreshold = 1.0e-6;
+static constexpr real_t kFastConvergenceThreshold = 1.0e-6L;
 
 /**
  * Vacuum pressure activation threshold.
  * Used in: ideal_mhd_model.cc for free-boundary calculations
  * Context: Gradual activation of vacuum pressure forces
  */
-static constexpr double kVacuumPressureThreshold = 1.0e-3;
+static constexpr real_t kVacuumPressureThreshold = 1.0e-3L;
 
 /**
  * Current density scaling factor.
  * Used in: ideal_mhd_model.cc for current profile normalization
  * Context: J \cdot B force balance computations
  */
-static constexpr double kCurrentScalingFactor = 1.0e-6;
+static constexpr real_t kCurrentScalingFactor = 1.0e-6L;
 
 /**
  * Force residual threshold for iteration decisions.
  * Used in: vmec.cc for determining when to continue iterations
  * Context: ||F_residual|| < threshold \rightarrow good convergence
  */
-static constexpr double kForceResidualThreshold = 1.0e-2;
+static constexpr real_t kForceResidualThreshold = 1.0e-2L;
 
 /**
  * Tangential epsilon for numerical stability in surface integrals.
  * Used in: regularized_integrals.cc for singular integral regularization
  * Context: Prevents division by zero in surface-surface interactions
  */
-static constexpr double kTangentialEpsilon = 1.0e-15;
+static constexpr real_t kTangentialEpsilon = 1.0e-15L;
 
 // ========== Iteration Control Constants ==========
 
@@ -208,38 +210,38 @@ static constexpr int kStringBufferSize = 30;
  * Used in: constraint reduction, parameter adjustments
  * Context: Conservative scaling to maintain numerical stability
  */
-static constexpr double kGeneralScalingFactor = 0.9;
+static constexpr real_t kGeneralScalingFactor = 0.9L;
 
 /**
  * Jacobian scaling factors for specific iteration ranges.
  * Used in: vmec.cc for adaptive scaling based on iteration count
  * Context: Scale factors applied at iterations 25 and 50
  */
-static constexpr double kJacobianScaling25 = 0.98;
-static constexpr double kJacobianScaling50 = 0.96;
+static constexpr real_t kJacobianScaling25 = 0.98L;
+static constexpr real_t kJacobianScaling50 = 0.96L;
 
 /**
  * Edge pedestal factor for boundary layer physics.
  * Used in: ideal_mhd_model.cc for edge physics modeling
  * Context: Controls edge gradient steepness in H-mode-like profiles
  */
-static constexpr double kEdgePedestalFactor = 0.05;
+static constexpr real_t kEdgePedestalFactor = 0.05L;
 
 /**
  * Mode damping parameters for numerical stability.
  * Used in: ideal_mhd_model.cc for suppressing unstable modes
  * Context: Prevents numerical instabilities in Fourier space
  */
-static constexpr double kModeDampingLarge = 16.0 * 16.0;
-static constexpr double kModeDampingSmall = 8.0;
+static constexpr real_t kModeDampingLarge = 16.0L * 16.0L;
+static constexpr real_t kModeDampingSmall = 8.0L;
 
 /**
  * Vacuum frequency adjustment factors.
  * Used in: ideal_mhd_model.cc for free-boundary force balance
  * Context: Balances plasma and vacuum contributions
  */
-static constexpr double kVacuumFrequencyLow = 0.1;
-static constexpr double kVacuumFrequencyHigh = 1.0e11;
+static constexpr real_t kVacuumFrequencyLow = 0.1L;
+static constexpr real_t kVacuumFrequencyHigh = 1.0e11L;
 
 // ========== Symmetry and Parity Constants ==========
 
@@ -265,7 +267,7 @@ static constexpr int kOddParity = 1;
  * Context: High-accuracy integration of radial pressure profiles
  * Mathematical basis: \int_{-1}^1 f(x)dx \approx \sum_i w_i f(x_i)
  */
-static constexpr std::array<double, 10> kGaussLegendreWeights10 = {
+static constexpr std::array<real_t, 10> kGaussLegendreWeights10 = {
     0.0666713443086881, 0.1494513491505806, 0.2190863625159820,
     0.2692667193099963, 0.2955242247147529, 0.2955242247147529,
     0.2692667193099963, 0.2190863625159820, 0.1494513491505806,
@@ -276,7 +278,7 @@ static constexpr std::array<double, 10> kGaussLegendreWeights10 = {
  * Used in: radial_profiles.cc for accurate pressure integration
  * Context: Optimal sampling points for polynomial integration
  */
-static constexpr std::array<double, 10> kGaussLegendreAbscissae10 = {
+static constexpr std::array<real_t, 10> kGaussLegendreAbscissae10 = {
     -0.9739065285171717, -0.8650633666889845, -0.6794095682990244,
     -0.4333953941292472, -0.1488743389816312, 0.1488743389816312,
     0.4333953941292472,  0.6794095682990244,  0.8650633666889845,


### PR DESCRIPTION
No distinguishable difference between regular and long double precision (80bit on my platform) in the force residual evolution.
Relative difference is 1e-4.

![image.png](https://app.graphite.com/user-attachments/assets/e1a8ad7e-43ff-4640-9689-a562db217352.png)

