### PR TITLE
Expose the full threed1 output quantities in the Python interface

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -1580,6 +1580,344 @@ class Threed1Volumetrics(BaseModelWithNumpy):
         return threed1volumetrics
 
 
+class Threed1FirstTable(BaseModelWithNumpy):
+    """Python equivalent of the first table in VMEC's "threed1" file.
+
+    Radial profiles on the full grid: flux-surface label, radial force balance,
+    currents, pressure, and parallel-current diagnostics.
+    """
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    s: jt.Float[np.ndarray, "num_full"]
+    """Normalized toroidal flux `s` on the full grid."""
+
+    radial_force: jt.Float[np.ndarray, "num_full"]
+    """Radial force-balance residual on the full grid."""
+
+    toroidal_flux: jt.Float[np.ndarray, "num_full"]
+    """Toroidal flux profile on the full grid."""
+
+    iota: jt.Float[np.ndarray, "num_full"]
+    """Rotational transform profile on the full grid."""
+
+    avg_jsupu: jt.Float[np.ndarray, "num_full"]
+    """Surface-averaged poloidal current density `<JSUPU>` on the full grid."""
+
+    avg_jsupv: jt.Float[np.ndarray, "num_full"]
+    """Surface-averaged toroidal current density `<JSUPV>` on the full grid."""
+
+    d_volume_d_phi: jt.Float[np.ndarray, "num_full"]
+    """Differential volume `d(VOL)/d(PHI)` on the full grid."""
+
+    d_pressure_d_phi: jt.Float[np.ndarray, "num_full"]
+    """Radial derivative of pressure `d(PRES)/d(PHI)` on the full grid."""
+
+    spectral_width: jt.Float[np.ndarray, "num_full"]
+    """Surface-averaged spectral width `<M>` on the full grid."""
+
+    pressure: jt.Float[np.ndarray, "num_full"]
+    """Pressure `PRESF` on the full grid in Pa (without mu_0)."""
+
+    buco_full: jt.Float[np.ndarray, "num_full"]
+    """Enclosed toroidal current `<BSUBU>` on the full grid."""
+
+    bvco_full: jt.Float[np.ndarray, "num_full"]
+    """Enclosed poloidal current `<BSUBV>` on the full grid."""
+
+    j_dot_b: jt.Float[np.ndarray, "num_full"]
+    """Parallel current density `<J.B>` on the full grid."""
+
+    b_dot_b: jt.Float[np.ndarray, "num_full"]
+    """`<|B|^2>` on the full grid."""
+
+    @staticmethod
+    def _from_cpp_threed1_first_table(
+        cpp_threed1_first_table: _vmecpp.Threed1FirstTable,
+    ) -> Threed1FirstTable:
+        return Threed1FirstTable(
+            **{
+                attr: getattr(cpp_threed1_first_table, attr)
+                for attr in Threed1FirstTable.model_fields
+            }
+        )
+
+
+class Threed1GeometricAndMagneticQuantities(BaseModelWithNumpy):
+    """Python equivalent of the geometric and magnetic quantities in VMEC's "threed1"
+    file.
+
+    Global geometry, magnetic-field limits, aspect ratio, beta values, currents, and
+    radial geometric profiles.
+    """
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    toroidal_flux: float
+    """Total enclosed toroidal flux."""
+
+    circum_p: float
+    """Poloidal circumference of the boundary cross-section."""
+
+    surf_area_p: float
+    """Plasma surface area."""
+
+    cross_area_p: float
+    """Plasma cross-sectional area."""
+
+    volume_p: float
+    """Plasma volume."""
+
+    Rmajor_p: float
+    """Major radius."""
+
+    Aminor_p: float
+    """Minor radius."""
+
+    aspect: float
+    """Aspect ratio."""
+
+    kappa_p: float
+    """Elongation."""
+
+    rcen: float
+    """Geometric center major radius."""
+
+    aminr1: float
+    """Volume-averaged minor radius."""
+
+    pavg: float
+    """Volume-averaged pressure."""
+
+    factor: float
+    """Normalization factor used in the threed1 computation."""
+
+    b0: float
+    """Magnetic field magnitude on the magnetic axis."""
+
+    rmax_surf: float
+    """Maximum major radius on the boundary."""
+
+    rmin_surf: float
+    """Minimum major radius on the boundary."""
+
+    zmax_surf: float
+    """Maximum height on the boundary."""
+
+    bmin: jt.Float[np.ndarray, "num_half nThetaReduced"]
+    """Minimum `|B|` per half-grid surface and poloidal angle."""
+
+    bmax: jt.Float[np.ndarray, "num_half nThetaReduced"]
+    """Maximum `|B|` per half-grid surface and poloidal angle."""
+
+    waist: jt.Float[np.ndarray, "n_symmetry_planes"]
+    """Plasma waist thickness in the phi = 0, pi symmetry planes."""
+
+    height: jt.Float[np.ndarray, "n_symmetry_planes"]
+    """Plasma height in the phi = 0, pi symmetry planes."""
+
+    betapol: float
+    """Poloidal beta."""
+
+    betatot: float
+    """Total beta."""
+
+    betator: float
+    """Toroidal beta."""
+
+    VolAvgB: float
+    """Volume-averaged magnetic field magnitude."""
+
+    IonLarmor: float
+    """Ion Larmor radius estimate."""
+
+    jpar_perp: float
+    """Volume-integrated ratio of parallel to perpendicular current."""
+
+    jparPS_perp: float
+    """Volume-integrated Pfirsch-Schlueter parallel/perpendicular current ratio."""
+
+    toroidal_current: float
+    """Net toroidal current in A."""
+
+    rbtor: float
+    """`R * Btor` at the boundary."""
+
+    rbtor0: float
+    """`R * Btor` on the magnetic axis."""
+
+    psi: jt.Float[np.ndarray, "num_full"]
+    """Poloidal magnetic flux on the full grid."""
+
+    ygeo: jt.Float[np.ndarray, "num_full"]
+    """Geometric minor radius profile."""
+
+    yinden: jt.Float[np.ndarray, "num_full"]
+    """Geometric indentation profile."""
+
+    yellip: jt.Float[np.ndarray, "num_full"]
+    """Geometric ellipticity profile."""
+
+    ytrian: jt.Float[np.ndarray, "num_full"]
+    """Geometric triangularity profile."""
+
+    yshift: jt.Float[np.ndarray, "num_full"]
+    """Geometric shift measured from the magnetic axis."""
+
+    loc_jpar_perp: jt.Float[np.ndarray, "num_full"]
+    """Local parallel/perpendicular current ratio profile."""
+
+    loc_jparPS_perp: jt.Float[np.ndarray, "num_full"]
+    """Local Pfirsch-Schlueter parallel/perpendicular current ratio profile."""
+
+    @staticmethod
+    def _from_cpp_threed1_geometric_and_magnetic_quantities(
+        cpp_threed1_geometric_and_magnetic: _vmecpp.Threed1GeometricAndMagneticQuantities,
+    ) -> Threed1GeometricAndMagneticQuantities:
+        return Threed1GeometricAndMagneticQuantities(
+            **{
+                attr: getattr(cpp_threed1_geometric_and_magnetic, attr)
+                for attr in Threed1GeometricAndMagneticQuantities.model_fields
+            }
+        )
+
+
+class Threed1AxisGeometry(BaseModelWithNumpy):
+    """Python equivalent of the magnetic-axis geometry in VMEC's "threed1" file:
+    Fourier coefficients of the converged magnetic axis.
+    """
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    raxis_symm: jt.Float[np.ndarray, "ntor_plus_1"]
+    """Stellarator-symmetric axis coefficients `R * cos(n * zeta)`."""
+
+    zaxis_symm: jt.Float[np.ndarray, "ntor_plus_1"]
+    """Stellarator-symmetric axis coefficients `Z * sin(n * zeta)`."""
+
+    raxis_asym: jt.Float[np.ndarray, "ntor_plus_1"]
+    """Non-stellarator-symmetric axis coefficients `R * sin(n * zeta)`."""
+
+    zaxis_asym: jt.Float[np.ndarray, "ntor_plus_1"]
+    """Non-stellarator-symmetric axis coefficients `Z * cos(n * zeta)`."""
+
+    @staticmethod
+    def _from_cpp_threed1_axis_geometry(
+        cpp_threed1_axis: _vmecpp.Threed1AxisGeometry,
+    ) -> Threed1AxisGeometry:
+        return Threed1AxisGeometry(
+            **{
+                attr: getattr(cpp_threed1_axis, attr)
+                for attr in Threed1AxisGeometry.model_fields
+            }
+        )
+
+
+class Threed1Betas(BaseModelWithNumpy):
+    """Python equivalent of the beta values in VMEC's "threed1" file."""
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    betatot: float
+    """Total beta."""
+
+    betapol: float
+    """Poloidal beta."""
+
+    betator: float
+    """Toroidal beta."""
+
+    rbtor: float
+    """`R * Btor` (vacuum)."""
+
+    betaxis: float
+    """Peak beta on the magnetic axis."""
+
+    betstr: float
+    """Beta-star."""
+
+    @staticmethod
+    def _from_cpp_threed1_betas(
+        cpp_threed1_betas: _vmecpp.Threed1Betas,
+    ) -> Threed1Betas:
+        return Threed1Betas(
+            **{
+                attr: getattr(cpp_threed1_betas, attr)
+                for attr in Threed1Betas.model_fields
+            }
+        )
+
+
+class Threed1ShafranovIntegrals(BaseModelWithNumpy):
+    """Python equivalent of the Shafranov surface integrals in VMEC's "threed1" file.
+
+    Ref: S. P. Hirshman, Phys. Fluids B, 5, (1993) 3119.
+    """
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    scaling_ratio: float
+    """Scaling ratio applied to the surface integrals."""
+
+    r_lao: float
+    """Lao major radius."""
+
+    f_lao: float
+    """Lao form factor."""
+
+    f_geo: float
+    """Geometric form factor."""
+
+    smaleli: float
+    """Normalized internal inductance `li`."""
+
+    betai: float
+    """Internal beta."""
+
+    musubi: float
+    """Ratio of volume poloidal-field energy to the surface-integral estimate."""
+
+    # `lambda` is a Python keyword, so the field is named `lambda_`; it maps to
+    # the C++ `lambda` member in `_from_cpp_threed1_shafranov_integrals`.
+    lambda_: float
+    """Shafranov lambda parameter."""
+
+    s11: float
+    """Shafranov surface integral S1/2 (Hirshman definition)."""
+
+    s12: float
+    """Shafranov surface integral S2/2 (Hirshman definition)."""
+
+    s13: float
+    """Shafranov surface integral S3/2 (Lao definition)."""
+
+    s2: float
+    """Shafranov integral s2."""
+
+    s3: float
+    """Shafranov integral s3."""
+
+    delta1: float
+    """Shafranov shift parameter delta1."""
+
+    delta2: float
+    """Shafranov shift parameter delta2."""
+
+    delta3: float
+    """Shafranov shift parameter delta3."""
+
+    @staticmethod
+    def _from_cpp_threed1_shafranov_integrals(
+        cpp_threed1_shafranov_integrals: _vmecpp.Threed1ShafranovIntegrals,
+    ) -> Threed1ShafranovIntegrals:
+        # `lambda_` maps to the C++ member `lambda` (a Python keyword).
+        values = {}
+        for field_name in Threed1ShafranovIntegrals.model_fields:
+            cpp_name = "lambda" if field_name == "lambda_" else field_name
+            values[field_name] = getattr(cpp_threed1_shafranov_integrals, cpp_name)
+        return Threed1ShafranovIntegrals(**values)
+
+
 class Mercier(BaseModelWithNumpy):
     model_config = pydantic.ConfigDict(extra="forbid")
 
@@ -1762,6 +2100,23 @@ class VmecOutput(BaseModelWithNumpy):
     integrals. Useful for postprocessing and global equilibrium characterization.
     """
 
+    threed1_first_table: Threed1FirstTable
+    """Python equivalent of the first table in VMEC's "threed1" file: radial
+    profiles of s, iota, currents, pressure, and force balance."""
+
+    threed1_geometric_magnetic: Threed1GeometricAndMagneticQuantities
+    """Python equivalent of the geometric and magnetic quantities in VMEC's
+    "threed1" file: global geometry, beta values, currents, and geometric profiles."""
+
+    threed1_axis: Threed1AxisGeometry
+    """Python equivalent of the magnetic-axis geometry in VMEC's "threed1" file."""
+
+    threed1_betas: Threed1Betas
+    """Python equivalent of the beta values in VMEC's "threed1" file."""
+
+    threed1_shafranov_integrals: Threed1ShafranovIntegrals
+    """Python equivalent of the Shafranov surface integrals in VMEC's "threed1" file."""
+
     wout: VmecWOut
     """Python equivalent of VMEC's "wout" file."""
 
@@ -1868,12 +2223,34 @@ def run(
     threed1_volumetrics = Threed1Volumetrics._from_cpp_threed1volumetrics(
         cpp_output_quantities.threed1_volumetrics
     )
+    threed1_first_table = Threed1FirstTable._from_cpp_threed1_first_table(
+        cpp_output_quantities.threed1_first_table
+    )
+    threed1_geometric_magnetic = Threed1GeometricAndMagneticQuantities._from_cpp_threed1_geometric_and_magnetic_quantities(
+        cpp_output_quantities.threed1_geometric_magnetic
+    )
+    threed1_axis = Threed1AxisGeometry._from_cpp_threed1_axis_geometry(
+        cpp_output_quantities.threed1_axis
+    )
+    threed1_betas = Threed1Betas._from_cpp_threed1_betas(
+        cpp_output_quantities.threed1_betas
+    )
+    threed1_shafranov_integrals = (
+        Threed1ShafranovIntegrals._from_cpp_threed1_shafranov_integrals(
+            cpp_output_quantities.threed1_shafranov_integrals
+        )
+    )
     return VmecOutput(
         input=input,
         wout=wout,
         jxbout=jxbout,
         mercier=mercier,
         threed1_volumetrics=threed1_volumetrics,
+        threed1_first_table=threed1_first_table,
+        threed1_geometric_magnetic=threed1_geometric_magnetic,
+        threed1_axis=threed1_axis,
+        threed1_betas=threed1_betas,
+        threed1_shafranov_integrals=threed1_shafranov_integrals,
     )
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -440,6 +440,110 @@ def test_threed1volumetrics_bindings(cma_output: vmecpp.VmecOutput):
         assert isinstance(getattr(cma_output.threed1_volumetrics, varname), float)
 
 
+def test_threed1_first_table_bindings(cma_output: vmecpp.VmecOutput):
+    for varname in [
+        "s",
+        "radial_force",
+        "toroidal_flux",
+        "iota",
+        "avg_jsupu",
+        "avg_jsupv",
+        "d_volume_d_phi",
+        "d_pressure_d_phi",
+        "spectral_width",
+        "pressure",
+        "buco_full",
+        "bvco_full",
+        "j_dot_b",
+        "b_dot_b",
+    ]:
+        assert len(getattr(cma_output.threed1_first_table, varname).shape) == 1
+
+
+def test_threed1_geometric_magnetic_bindings(cma_output: vmecpp.VmecOutput):
+    for varname in [
+        "toroidal_flux",
+        "circum_p",
+        "surf_area_p",
+        "cross_area_p",
+        "volume_p",
+        "Rmajor_p",
+        "Aminor_p",
+        "aspect",
+        "kappa_p",
+        "rcen",
+        "aminr1",
+        "pavg",
+        "factor",
+        "b0",
+        "rmax_surf",
+        "rmin_surf",
+        "zmax_surf",
+        "betapol",
+        "betatot",
+        "betator",
+        "VolAvgB",
+        "IonLarmor",
+        "jpar_perp",
+        "jparPS_perp",
+        "toroidal_current",
+        "rbtor",
+        "rbtor0",
+    ]:
+        assert isinstance(
+            getattr(cma_output.threed1_geometric_magnetic, varname), float
+        )
+    for varname in [
+        "bmin",
+        "bmax",
+        "waist",
+        "height",
+        "psi",
+        "ygeo",
+        "yinden",
+        "yellip",
+        "ytrian",
+        "yshift",
+        "loc_jpar_perp",
+        "loc_jparPS_perp",
+    ]:
+        assert len(getattr(cma_output.threed1_geometric_magnetic, varname).shape) >= 1
+
+
+def test_threed1_axis_bindings(cma_output: vmecpp.VmecOutput):
+    for varname in ["raxis_symm", "zaxis_symm", "raxis_asym", "zaxis_asym"]:
+        assert len(getattr(cma_output.threed1_axis, varname).shape) == 1
+
+
+def test_threed1_betas_bindings(cma_output: vmecpp.VmecOutput):
+    for varname in ["betatot", "betapol", "betator", "rbtor", "betaxis", "betstr"]:
+        assert isinstance(getattr(cma_output.threed1_betas, varname), float)
+
+
+def test_threed1_shafranov_integrals_bindings(cma_output: vmecpp.VmecOutput):
+    for varname in [
+        "scaling_ratio",
+        "r_lao",
+        "f_lao",
+        "f_geo",
+        "smaleli",
+        "betai",
+        "musubi",
+        "lambda_",
+        "s11",
+        "s12",
+        "s13",
+        "s2",
+        "s3",
+        "delta1",
+        "delta2",
+        "delta3",
+    ]:
+        assert isinstance(
+            getattr(cma_output.threed1_shafranov_integrals, varname), float
+        )
+
+
 def test_is_vmec2000_input():
     vmec2000_input_file = TEST_DATA_DIR / "input.cma"
     vmecpp_input_file = TEST_DATA_DIR / "cma.json"


### PR DESCRIPTION
## Summary

Exposes the full threed1 file contents in the public Python `VmecOutput`. Previously only `threed1_volumetrics` was surfaced; the rest of the threed1 quantities were already bound in pybind but not reachable from `vmecpp.run(...)`.

## Change

Python only (`src/vmecpp/__init__.py`). Adds pydantic wrappers, mirroring the existing `Threed1Volumetrics` / `Mercier` pattern, for the remaining threed1 output structs, and surfaces them as fields on `VmecOutput`:

- `Threed1FirstTable` — radial profiles on the full grid (s, iota, currents, pressure, radial force balance, `<J.B>`, `<B.B>`).
- `Threed1GeometricAndMagneticQuantities` — global geometry, magnetic-field limits, aspect ratio, beta values, currents, and geometric profiles.
- `Threed1AxisGeometry` — Fourier coefficients of the converged magnetic axis.
- `Threed1Betas` — beta values.
- `Threed1ShafranovIntegrals` — Shafranov surface integrals.

The C++ `OutputQuantities` and the pybind bindings already expose all of these; this completes the Python-side wrapper and the `run()` population. No C++ changes.

`Threed1ShafranovIntegrals.lambda` is surfaced as `lambda_` because `lambda` is a Python keyword.

With this, `VmecOutput` surfaces every `OutputQuantities` member that the pybind layer binds (the output-file contents: wout, jxbout, mercier, and the full threed1 set). A handful of `OutputQuantities` members are not bound in pybind at all and so aren't reachable from Python today: `vmec_internal_results`, `remaining_metric`, `b_cylindrical`, `bsubs_half`, `bsubs_full`, `covariant_b_derivatives`, and the `*_intermediate` scratch structs. Exposing those is a larger change (new C++ pybind bindings in addition to the Python wrappers). Happy to include them here as well if that's wanted, and some of them (e.g. `b_cylindrical`, `bsubs_half/full`) are genuine physics outputs that are likely worth surfacing regardless.

## Tests

`tests/test_init.py` adds a binding test per new struct, mirroring `test_threed1volumetrics_bindings`: each runs the cma case and asserts every field of the struct is reachable with the expected type.
