### PR TITLE
Complete the Eigen3 port of the free-boundary code

### DIFF
--- a/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.cc
@@ -122,8 +122,7 @@ void ExternalMagneticField::AddAxisCurrentFieldAbscab(
   // since ABSCAB only adds to whatever is in there.
   // If we don't do this, the axis current contributions effectively pile up,
   // iteration after iteration (don't ask how I know about this...).
-  const int numLocal = tp_.ztMax - tp_.ztMin;
-  absl::c_fill_n(bCoilsXYZ, 3 * numLocal, 0);
+  bCoilsXYZ.setZero();
 
   // compute magnetic field due to line current along magnetic axis
   int numProcessors = 1;  // Nestor itself is already parallelized via OpenMP
@@ -203,8 +202,7 @@ void ExternalMagneticField::AddAxisCurrentFieldSimple(
   // Initialize target storage for axis-current magnetic field to zero.
   // If we don't do this, the axis current contributions effectively pile up,
   // iteration after iteration (don't ask how I know about this...).
-  const int numLocal = tp_.ztMax - tp_.ztMin;
-  absl::c_fill_n(bCoilsXYZ, 3 * numLocal, 0);
+  bCoilsXYZ.setZero();
 
   // 1.0e-7 == mu0/4 pi
   // NOTE: The factor of 2 comes from the Hanson-Hirshman Biot-Savart formula,

--- a/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.h
@@ -5,8 +5,8 @@
 #ifndef VMECPP_FREE_BOUNDARY_EXTERNAL_MAGNETIC_FIELD_EXTERNAL_MAGNETIC_FIELD_H_
 #define VMECPP_FREE_BOUNDARY_EXTERNAL_MAGNETIC_FIELD_EXTERNAL_MAGNETIC_FIELD_H_
 
+#include <Eigen/Dense>
 #include <span>
-#include <vector>
 
 #include "vmecpp/common/sizes/sizes.h"
 #include "vmecpp/common/util/util.h"
@@ -25,25 +25,25 @@ class ExternalMagneticField {
               const std::span<const double> zAxis, double netToroidalCurrent);
 
   // axis geometry around whole machine
-  std::vector<double> axisXYZ;
-  std::vector<double> surfaceXYZ;
-  std::vector<double> bCoilsXYZ;
+  Eigen::VectorXd axisXYZ;
+  Eigen::VectorXd surfaceXYZ;
+  Eigen::VectorXd bCoilsXYZ;
 
   // interpolated magnetic field from mgrid
-  std::vector<double> interpBr;
-  std::vector<double> interpBp;
-  std::vector<double> interpBz;
+  Eigen::VectorXd interpBr;
+  Eigen::VectorXd interpBp;
+  Eigen::VectorXd interpBz;
 
   // interpolated magnetic field from mgrid
   double axis_current;
-  std::vector<double> curtorBr;
-  std::vector<double> curtorBp;
-  std::vector<double> curtorBz;
+  Eigen::VectorXd curtorBr;
+  Eigen::VectorXd curtorBp;
+  Eigen::VectorXd curtorBz;
 
   // outputs to Nestor
-  std::vector<double> bSubU;
-  std::vector<double> bSubV;
-  std::vector<double> bDotN;
+  Eigen::VectorXd bSubU;
+  Eigen::VectorXd bSubV;
+  Eigen::VectorXd bDotN;
 
  private:
   // We /can/ use ABSCAB to compute the magnetic field due to the axis current,

--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.cc
@@ -98,7 +98,7 @@ LaplaceSolver::LaplaceSolver(const Sizes* s, const FourierBasisFastToroidal* fb,
 
 // fourp()-equivalent
 void LaplaceSolver::TransformGreensFunctionDerivative(
-    const std::vector<double>& greenp) {
+    const Eigen::VectorXd& greenp) {
   grpmn_sin.setZero();
   if (s_.lasym) {
     grpmn_cos.setZero();
@@ -181,7 +181,7 @@ void LaplaceSolver::TransformGreensFunctionDerivative(
   }  // kl'
 }  // TransformGreensFunctionDerivative
 
-void LaplaceSolver::SymmetriseSourceTerm(const std::vector<double>& gstore) {
+void LaplaceSolver::SymmetriseSourceTerm(const Eigen::VectorXd& gstore) {
   for (int l = 0; l < s_.nThetaReduced; ++l) {
     const int lRev = (s_.nThetaEven - l) % s_.nThetaEven;
     for (int k = 0; k < s_.nZeta; ++k) {
@@ -197,8 +197,8 @@ void LaplaceSolver::SymmetriseSourceTerm(const std::vector<double>& gstore) {
 }  // SymmetriseSourceTerm
 
 void LaplaceSolver::AccumulateFullGrpmn(
-    const std::vector<double>& grpmn_sin_singular,
-    const std::vector<double>& grpmn_cos_singular) {
+    const Eigen::VectorXd& grpmn_sin_singular,
+    const Eigen::VectorXd& grpmn_cos_singular) {
   const int mnpd = (mf + 1) * (2 * nf + 1);
   const double inv_nfp = 1.0 / s_.nfp;
 
@@ -434,7 +434,7 @@ void LaplaceSolver::DecomposeMatrix() {
 }  // DecomposeMatrix
 
 void LaplaceSolver::SolveForPotential(
-    const std::vector<double>& bvec_sin_singular) {
+    const Eigen::VectorXd& bvec_sin_singular) {
   int mnpd = (mf + 1) * (2 * nf + 1);
   const double inv_nfp = 1.0 / s_.nfp;
 

--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.h
@@ -22,16 +22,16 @@ class LaplaceSolver {
                 std::span<double> matrixShare, std::span<int> iPiv,
                 std::span<double> bvecShare);
 
-  void TransformGreensFunctionDerivative(const std::vector<double>& greenp);
-  void SymmetriseSourceTerm(const std::vector<double>& gstore);
-  void AccumulateFullGrpmn(const std::vector<double>& grpmn_sin_singular,
-                           const std::vector<double>& grpmn_cos_singular);
+  void TransformGreensFunctionDerivative(const Eigen::VectorXd& greenp);
+  void SymmetriseSourceTerm(const Eigen::VectorXd& gstore);
+  void AccumulateFullGrpmn(const Eigen::VectorXd& grpmn_sin_singular,
+                           const Eigen::VectorXd& grpmn_cos_singular);
   void PerformToroidalFourierTransforms();
   void PerformPoloidalFourierTransforms();
 
   void BuildMatrix();
   void DecomposeMatrix();
-  void SolveForPotential(const std::vector<double>& bvec_sin_singular);
+  void SolveForPotential(const Eigen::VectorXd& bvec_sin_singular);
 
   // Green's function derivative Fourier transform, non-singular part,
   // stellarator-symmetric.

--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver_test.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver_test.cc
@@ -77,7 +77,7 @@ TEST_P(TransformGreensFunctionDerivativeTest, SingleModeRoundTrip) {
   const int nThetaEven = s.nThetaEven;
   const int nZeta = s.nZeta;
 
-  std::vector<double> greenp(numLocal * nThetaEven * nZeta, 0.0);
+  Eigen::VectorXd greenp = Eigen::VectorXd::Zero(numLocal * nThetaEven * nZeta);
 
   for (int klpRel = 0; klpRel < numLocal; ++klpRel) {
     for (int l = 0; l < nThetaEven; ++l) {
@@ -226,15 +226,16 @@ TEST(LaplaceSolverTest, ZeroKernelSolveGivesHalfInverse) {
                    std::span<int>(iPiv), std::span<double>(bvecShare));
 
   // Zero greenp: no double-layer kernel contribution.
-  std::vector<double> greenp(numLocal * s.nThetaEven * s.nZeta, 0.0);
+  Eigen::VectorXd greenp =
+      Eigen::VectorXd::Zero(numLocal * s.nThetaEven * s.nZeta);
   ls.TransformGreensFunctionDerivative(greenp);
 
-  std::vector<double> grpmn_sin_singular(mnpd * numLocal, 0.0);
-  std::vector<double> grpmn_cos_singular(mnpd * numLocal, 0.0);
+  Eigen::VectorXd grpmn_sin_singular = Eigen::VectorXd::Zero(mnpd * numLocal);
+  Eigen::VectorXd grpmn_cos_singular = Eigen::VectorXd::Zero(mnpd * numLocal);
   ls.AccumulateFullGrpmn(grpmn_sin_singular, grpmn_cos_singular);
 
   // Zero gstore: no source term from regularized integrals.
-  std::vector<double> gstore(s.nThetaEven * s.nZeta, 0.0);
+  Eigen::VectorXd gstore = Eigen::VectorXd::Zero(s.nThetaEven * s.nZeta);
   ls.SymmetriseSourceTerm(gstore);
   ls.PerformToroidalFourierTransforms();
   ls.PerformPoloidalFourierTransforms();
@@ -245,7 +246,7 @@ TEST(LaplaceSolverTest, ZeroKernelSolveGivesHalfInverse) {
   const int m0 = 2;
   const int n0 = 1;
   const int idx_posn = (nf + n0) * (mf + 1) + m0;
-  std::vector<double> bvec_sin_singular(mnpd, 0.0);
+  Eigen::VectorXd bvec_sin_singular = Eigen::VectorXd::Zero(mnpd);
   bvec_sin_singular[idx_posn] = 1.0;
 
   ls.SolveForPotential(bvec_sin_singular);

--- a/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
@@ -100,9 +100,9 @@ absl::Status MGridProvider::LoadFile(const std::filesystem::path& filename,
 
   // Resize and make sure that the accumulation arrays are reset to zeros
   // if they contained previous contents from an earlier call to this routine.
-  bR.resize(numPhi * numZ * numR, 0.0);
-  bP.resize(numPhi * numZ * numR, 0.0);
-  bZ.resize(numPhi * numZ * numR, 0.0);
+  bR.setZero(numPhi * numZ * numR);
+  bP.setZero(numPhi * numZ * numR);
+  bZ.setZero(numPhi * numZ * numR);
 
   // combine coil contributions, weighted by coil currents
   for (int i = 0; i < nextcur; ++i) {
@@ -184,9 +184,9 @@ absl::Status MGridProvider::LoadFields(
 
   // TODO(eguiraud): factor out this part that is duplicated
   const int num_grid_points = numPhi * numZ * numR;
-  bR.resize(num_grid_points, 0.0);
-  bP.resize(num_grid_points, 0.0);
-  bZ.resize(num_grid_points, 0.0);
+  bR.setZero(num_grid_points);
+  bP.setZero(num_grid_points);
+  bZ.setZero(num_grid_points);
 
   // combine coil contributions, weighted by coil currents
   for (int i = 0; i < nextcur; ++i) {
@@ -206,9 +206,9 @@ absl::Status MGridProvider::LoadFields(
   return absl::OkStatus();
 }
 
-void MGridProvider::SetFixedMagneticField(const std::vector<double>& fixed_br,
-                                          const std::vector<double>& fixed_bp,
-                                          const std::vector<double>& fixed_bz) {
+void MGridProvider::SetFixedMagneticField(const Eigen::VectorXd& fixed_br,
+                                          const Eigen::VectorXd& fixed_bp,
+                                          const Eigen::VectorXd& fixed_bz) {
   // copy into local storage
   fixed_br_ = fixed_br;
   fixed_bp_ = fixed_bp;
@@ -220,11 +220,11 @@ void MGridProvider::SetFixedMagneticField(const std::vector<double>& fixed_br,
 
 // interpolate mgrid file at current flux surface
 void MGridProvider::interpolate(int ztMin, int ztMax, int nZeta,
-                                const std::vector<double>& rLCFS,
-                                const std::vector<double>& zLCFS,
-                                std::vector<double>& m_interpBr,
-                                std::vector<double>& m_interpBp,
-                                std::vector<double>& m_interpBz) const {
+                                const Eigen::VectorXd& rLCFS,
+                                const Eigen::VectorXd& zLCFS,
+                                Eigen::VectorXd& m_interpBr,
+                                Eigen::VectorXd& m_interpBp,
+                                Eigen::VectorXd& m_interpBz) const {
   CHECK(has_mgrid_loaded_) << "no mgrid loaded";
 
   if (has_fixed_field_) {

--- a/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.h
@@ -30,9 +30,8 @@ class MGridProvider {
                              const Eigen::VectorXd& fixed_bp,
                              const Eigen::VectorXd& fixed_bz);
 
-  void interpolate(int ztMin, int ztMax, int nZeta,
-                   const Eigen::VectorXd& r, const Eigen::VectorXd& z,
-                   Eigen::VectorXd& m_interpBr,
+  void interpolate(int ztMin, int ztMax, int nZeta, const Eigen::VectorXd& r,
+                   const Eigen::VectorXd& z, Eigen::VectorXd& m_interpBr,
                    Eigen::VectorXd& m_interpBp,
                    Eigen::VectorXd& m_interpBz) const;
 

--- a/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.h
@@ -5,8 +5,8 @@
 #ifndef VMECPP_FREE_BOUNDARY_MGRID_PROVIDER_MGRID_PROVIDER_H_
 #define VMECPP_FREE_BOUNDARY_MGRID_PROVIDER_MGRID_PROVIDER_H_
 
+#include <Eigen/Dense>
 #include <filesystem>
-#include <vector>
 
 #include "vmecpp/common/makegrid_lib/makegrid_lib.h"
 #include "vmecpp/common/sizes/sizes.h"
@@ -26,21 +26,21 @@ class MGridProvider {
       const makegrid::MagneticFieldResponseTable& magnetic_response_table,
       const Eigen::VectorXd& coil_currents);
 
-  void SetFixedMagneticField(const std::vector<double>& fixed_br,
-                             const std::vector<double>& fixed_bp,
-                             const std::vector<double>& fixed_bz);
+  void SetFixedMagneticField(const Eigen::VectorXd& fixed_br,
+                             const Eigen::VectorXd& fixed_bp,
+                             const Eigen::VectorXd& fixed_bz);
 
   void interpolate(int ztMin, int ztMax, int nZeta,
-                   const std::vector<double>& r, const std::vector<double>& z,
-                   std::vector<double>& m_interpBr,
-                   std::vector<double>& m_interpBp,
-                   std::vector<double>& m_interpBz) const;
+                   const Eigen::VectorXd& r, const Eigen::VectorXd& z,
+                   Eigen::VectorXd& m_interpBr,
+                   Eigen::VectorXd& m_interpBp,
+                   Eigen::VectorXd& m_interpBz) const;
 
   // mgrid internals below
 
-  std::vector<double> bR;
-  std::vector<double> bP;
-  std::vector<double> bZ;
+  Eigen::VectorXd bR;
+  Eigen::VectorXd bP;
+  Eigen::VectorXd bZ;
 
   int nfp;
 
@@ -66,9 +66,9 @@ class MGridProvider {
   bool has_mgrid_loaded_;
   bool has_fixed_field_;
 
-  std::vector<double> fixed_br_;
-  std::vector<double> fixed_bp_;
-  std::vector<double> fixed_bz_;
+  Eigen::VectorXd fixed_br_;
+  Eigen::VectorXd fixed_bp_;
+  Eigen::VectorXd fixed_bz_;
 };
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/free_boundary/regularized_integrals/regularized_integrals.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/regularized_integrals/regularized_integrals.cc
@@ -58,14 +58,13 @@ void RegularizedIntegrals::computeConstants() {
   }  // k
 }
 
-void RegularizedIntegrals::update(const std::vector<double>& bDotN) {
+void RegularizedIntegrals::update(const Eigen::VectorXd& bDotN) {
   // thread-local tangential grid point range
-  const int numLocal = tp_.ztMax - tp_.ztMin;
   const int theta_by_nzeta = s_.nThetaEven * s_.nZeta;
   const double twopidivnfp = 2.0 * M_PI / s_.nfp;
 
-  absl::c_fill_n(greenp, numLocal * theta_by_nzeta, 0);
-  absl::c_fill_n(gstore, theta_by_nzeta, 0);
+  greenp.setZero();
+  gstore.setZero();
 
   // storage for intermediate results
   std::vector<double> ga1_buf(s_.nZeta);

--- a/src/vmecpp/cpp/vmecpp/free_boundary/regularized_integrals/regularized_integrals.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/regularized_integrals/regularized_integrals.h
@@ -5,7 +5,7 @@
 #ifndef VMECPP_FREE_BOUNDARY_REGULARIZED_INTEGRALS_REGULARIZED_INTEGRALS_H_
 #define VMECPP_FREE_BOUNDARY_REGULARIZED_INTEGRALS_REGULARIZED_INTEGRALS_H_
 
-#include <vector>
+#include <Eigen/Dense>
 
 #include "vmecpp/common/fourier_basis_fast_toroidal/fourier_basis_fast_toroidal.h"
 #include "vmecpp/common/sizes/sizes.h"
@@ -20,16 +20,16 @@ class RegularizedIntegrals {
   RegularizedIntegrals(const Sizes* s, const TangentialPartitioning* tp,
                        const SurfaceGeometry* sg);
 
-  void update(const std::vector<double>& bDotN);
+  void update(const Eigen::VectorXd& bDotN);
 
-  std::vector<double> gsave;
-  std::vector<double> dsave;
+  Eigen::VectorXd gsave;
+  Eigen::VectorXd dsave;
 
-  std::vector<double> tanu;
-  std::vector<double> tanv;
+  Eigen::VectorXd tanu;
+  Eigen::VectorXd tanv;
 
-  std::vector<double> greenp;
-  std::vector<double> gstore;
+  Eigen::VectorXd greenp;
+  Eigen::VectorXd gstore;
 
  private:
   const Sizes& s_;

--- a/src/vmecpp/cpp/vmecpp/free_boundary/singular_integrals/singular_integrals.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/singular_integrals/singular_integrals.cc
@@ -10,8 +10,6 @@
 #include <cstring>
 #include <vector>
 
-#include "absl/algorithm/container.h"
-
 namespace vmecpp {
 
 SingularIntegrals::SingularIntegrals(const Sizes* s,
@@ -69,11 +67,11 @@ SingularIntegrals::SingularIntegrals(const Sizes* s,
   }
 
   const int mnfull = (2 * nf + 1) * (mf + 1);
-  bvec_sin.resize(mnfull, 0.0);
-  grpmn_sin.resize(mnfull * numLocal, 0.0);
+  bvec_sin.setZero(mnfull);
+  grpmn_sin.setZero(mnfull * numLocal);
   if (s->lasym) {
-    bvec_cos.resize(mnfull, 0.0);
-    grpmn_cos.resize(mnfull * numLocal, 0.0);
+    bvec_cos.setZero(mnfull);
+    grpmn_cos.setZero(mnfull * numLocal);
   }
 
   // -------------
@@ -84,7 +82,7 @@ SingularIntegrals::SingularIntegrals(const Sizes* s,
 void SingularIntegrals::computeCoefficients() {
   // below loop sets only parts of cmn,
   // so initialize all entries to zero once here
-  absl::c_fill_n(cmn, (1 + mf + nf) * (nf + 1) * (mf + 1), 0);
+  cmn.setZero();
 
   // cmn from scratch: Algorithm 1 in TNOV
   for (int n = 0; n < nf + 1; ++n) {
@@ -156,8 +154,7 @@ void SingularIntegrals::computeCoefficients() {
   }  // n
 }  // computeCoefficients
 
-void SingularIntegrals::update(const std::vector<double>& bDotN,
-                               bool fullUpdate) {
+void SingularIntegrals::update(const Eigen::VectorXd& bDotN, bool fullUpdate) {
 #ifdef _OPENMP
 #pragma omp barrier
 #endif  // _OPENMP
@@ -176,13 +173,10 @@ void SingularIntegrals::update(const std::vector<double>& bDotN,
 #endif  // _OPENMP
 }  // update
 
-void SingularIntegrals::prepareUpdate(const std::vector<double>& a,
-                                      const std::vector<double>& b2,
-                                      const std::vector<double>& c,
-                                      const std::vector<double>& A,
-                                      const std::vector<double>& B2,
-                                      const std::vector<double>& C,
-                                      bool fullUpdate) {
+void SingularIntegrals::prepareUpdate(
+    const Eigen::VectorXd& a, const Eigen::VectorXd& b2,
+    const Eigen::VectorXd& c, const Eigen::VectorXd& A,
+    const Eigen::VectorXd& B2, const Eigen::VectorXd& C, bool fullUpdate) {
   int numLocal = tp_.ztMax - tp_.ztMin;
   for (int kl = 0; kl < numLocal; ++kl) {
     // initialize constants (along expansion in l)
@@ -340,26 +334,25 @@ void SingularIntegrals::prepareUpdate(const std::vector<double>& a,
   }  // kl
 }  // prepareUpdate
 
-void SingularIntegrals::performUpdate(const std::vector<double>& bDotN,
+void SingularIntegrals::performUpdate(const Eigen::VectorXd& bDotN,
                                       bool fullUpdate) {
   const int numLocal = tp_.ztMax - tp_.ztMin;
 
-  const int mnfull = (2 * nf + 1) * (mf + 1);
-  absl::c_fill_n(bvec_sin, mnfull, 0.0);
+  bvec_sin.setZero();
   if (s_.lasym) {
-    absl::c_fill_n(bvec_cos, mnfull, 0.0);
+    bvec_cos.setZero();
   }
 
   if (fullUpdate) {
-    absl::c_fill_n(grpmn_sin, mnfull * numLocal, 0.0);
+    grpmn_sin.setZero();
     if (s_.lasym) {
-      absl::c_fill_n(grpmn_cos, mnfull * numLocal, 0.0);
+      grpmn_cos.setZero();
     }
   }
 
   // Tl1p/Tl1m hold T^{\pm}_{fl-1} for the Slp/Slm formula; T^{\pm}_{-1} = 0.
-  absl::c_fill(Tl1p, 0.0);
-  absl::c_fill(Tl1m, 0.0);
+  Tl1p.setZero();
+  Tl1m.setZero();
 
   int sgn = 1;
   for (int fl = 0; fl < 1 + nf + mf; ++fl) {

--- a/src/vmecpp/cpp/vmecpp/free_boundary/singular_integrals/singular_integrals.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/singular_integrals/singular_integrals.h
@@ -5,6 +5,7 @@
 #ifndef VMECPP_FREE_BOUNDARY_SINGULAR_INTEGRALS_SINGULAR_INTEGRALS_H_
 #define VMECPP_FREE_BOUNDARY_SINGULAR_INTEGRALS_SINGULAR_INTEGRALS_H_
 
+#include <Eigen/Dense>
 #include <vector>
 
 #include "vmecpp/common/fourier_basis_fast_toroidal/fourier_basis_fast_toroidal.h"
@@ -21,68 +22,67 @@ class SingularIntegrals {
                     const TangentialPartitioning* tp, const SurfaceGeometry* sg,
                     int nf, int mf);
 
-  void update(const std::vector<double>& bDotN, bool fullUpdate);
+  void update(const Eigen::VectorXd& bDotN, bool fullUpdate);
 
   int numSC;
   int numCS;
   int nzLen;  // non-zero length
 
-  std::vector<double> cmn;
-  std::vector<double> cmns;
+  Eigen::VectorXd cmn;
+  Eigen::VectorXd cmns;
 
-  std::vector<double> ap;
-  std::vector<double> am;
-  std::vector<double> d;
-  std::vector<double> sqrtc2;
-  std::vector<double> sqrta2;
-  std::vector<double> delta4;
+  Eigen::VectorXd ap;
+  Eigen::VectorXd am;
+  Eigen::VectorXd d;
+  Eigen::VectorXd sqrtc2;
+  Eigen::VectorXd sqrta2;
+  Eigen::VectorXd delta4;
 
-  std::vector<double> Ap;
-  std::vector<double> Am;
-  std::vector<double> D;
+  Eigen::VectorXd Ap;
+  Eigen::VectorXd Am;
+  Eigen::VectorXd D;
 
-  std::vector<double> R1p;
-  std::vector<double> R1m;
-  std::vector<double> R0p;
-  std::vector<double> R0m;
-  std::vector<double> Ra1p;
-  std::vector<double> Ra1m;
+  Eigen::VectorXd R1p;
+  Eigen::VectorXd R1m;
+  Eigen::VectorXd R0p;
+  Eigen::VectorXd R0m;
+  Eigen::VectorXd Ra1p;
+  Eigen::VectorXd Ra1m;
 
   // l-2
-  std::vector<double> Tl2p;
+  Eigen::VectorXd Tl2p;
   // l-2
-  std::vector<double> Tl2m;
+  Eigen::VectorXd Tl2m;
   // l-1
-  std::vector<double> Tl1p;
+  Eigen::VectorXd Tl1p;
   // l-1
-  std::vector<double> Tl1m;
+  Eigen::VectorXd Tl1m;
   // l
-  std::vector<std::vector<double> > Tlp;
+  std::vector<Eigen::VectorXd> Tlp;
   // l
-  std::vector<std::vector<double> > Tlm;
+  std::vector<Eigen::VectorXd> Tlm;
 
   // l
-  std::vector<std::vector<double> > Slp;
+  std::vector<Eigen::VectorXd> Slp;
   // l
-  std::vector<std::vector<double> > Slm;
+  std::vector<Eigen::VectorXd> Slm;
 
   // sum_kl { Tlm * sin(mu + nv), Tlp * sin(mu - nv) }
-  std::vector<double> bvec_sin;
+  Eigen::VectorXd bvec_sin;
 
   // sum_kl { Tlm * cos(mu + nv), Tlp * cos(mu - nv) }
-  std::vector<double> bvec_cos;
+  Eigen::VectorXd bvec_cos;
 
   // Slm * sin(mu + nv), Slp * sin(mu - nv)
-  std::vector<double> grpmn_sin;
+  Eigen::VectorXd grpmn_sin;
 
   // Slm * cos(mu + nv), Slp * cos(mu - nv)
-  std::vector<double> grpmn_cos;
+  Eigen::VectorXd grpmn_cos;
 
-  void prepareUpdate(const std::vector<double>& a,
-                     const std::vector<double>& b2,
-                     const std::vector<double>& c, const std::vector<double>& A,
-                     const std::vector<double>& B2,
-                     const std::vector<double>& C, bool fullUpdate);
+  void prepareUpdate(const Eigen::VectorXd& a, const Eigen::VectorXd& b2,
+                     const Eigen::VectorXd& c, const Eigen::VectorXd& A,
+                     const Eigen::VectorXd& B2, const Eigen::VectorXd& C,
+                     bool fullUpdate);
 
  private:
   const Sizes& s_;
@@ -92,7 +92,7 @@ class SingularIntegrals {
 
   void computeCoefficients();
 
-  void performUpdate(const std::vector<double>& bDotN, bool fullUpdate);
+  void performUpdate(const Eigen::VectorXd& bDotN, bool fullUpdate);
 
   int nf;
   int mf;

--- a/src/vmecpp/cpp/vmecpp/free_boundary/singular_integrals/singular_integrals_test.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/singular_integrals/singular_integrals_test.cc
@@ -218,12 +218,12 @@ TEST_P(TlpTlmAccuracyTest, MatchesQuadrature) {
   ASSERT_LT(d * d, ap * am) << "test setup: need smooth integrand on [-1,1]";
 
   const int numLocal = tp.ztMax - tp.ztMin;
-  std::vector<double> a(numLocal, a_val);
-  std::vector<double> b2(numLocal, b2_val);
-  std::vector<double> c(numLocal, c_val);
-  std::vector<double> A(numLocal, 0.0);
-  std::vector<double> B2(numLocal, 0.0);
-  std::vector<double> C(numLocal, 0.0);
+  Eigen::VectorXd a = Eigen::VectorXd::Constant(numLocal, a_val);
+  Eigen::VectorXd b2 = Eigen::VectorXd::Constant(numLocal, b2_val);
+  Eigen::VectorXd c = Eigen::VectorXd::Constant(numLocal, c_val);
+  Eigen::VectorXd A = Eigen::VectorXd::Zero(numLocal);
+  Eigen::VectorXd B2 = Eigen::VectorXd::Zero(numLocal);
+  Eigen::VectorXd C = Eigen::VectorXd::Zero(numLocal);
 
   si.prepareUpdate(a, b2, c, A, B2, C, /*fullUpdate=*/false);
 

--- a/src/vmecpp/cpp/vmecpp/free_boundary/surface_geometry/surface_geometry.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/surface_geometry/surface_geometry.cc
@@ -4,8 +4,6 @@
 // SPDX-License-Identifier: MIT
 #include "vmecpp/free_boundary/surface_geometry/surface_geometry.h"
 
-#include "absl/algorithm/container.h"  // c_fill_n
-
 namespace vmecpp {
 
 SurfaceGeometry::SurfaceGeometry(const Sizes* s,
@@ -119,24 +117,23 @@ void SurfaceGeometry::inverseDFT(
 
   // ----------------
 
-  absl::c_fill_n(r1b, s_.nThetaEven * s_.nZeta, 0);
-  absl::c_fill_n(z1b, s_.nThetaEven * s_.nZeta, 0);
+  r1b.setZero();
+  z1b.setZero();
 
   // ----------------
-  int numLocal = tp_.ztMax - tp_.ztMin;
 
-  absl::c_fill_n(rub, numLocal, 0);
-  absl::c_fill_n(rvb, numLocal, 0);
-  absl::c_fill_n(zub, numLocal, 0);
-  absl::c_fill_n(zvb, numLocal, 0);
+  rub.setZero();
+  rvb.setZero();
+  zub.setZero();
+  zvb.setZero();
 
   if (fullUpdate) {
-    absl::c_fill_n(ruu, numLocal, 0);
-    absl::c_fill_n(ruv, numLocal, 0);
-    absl::c_fill_n(rvv, numLocal, 0);
-    absl::c_fill_n(zuu, numLocal, 0);
-    absl::c_fill_n(zuv, numLocal, 0);
-    absl::c_fill_n(zvv, numLocal, 0);
+    ruu.setZero();
+    ruv.setZero();
+    rvv.setZero();
+    zuu.setZero();
+    zuv.setZero();
+    zvv.setZero();
   }
 
   for (int n = 0; n < s_.ntor + 1; ++n) {

--- a/src/vmecpp/cpp/vmecpp/free_boundary/surface_geometry/surface_geometry.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/surface_geometry/surface_geometry.h
@@ -5,8 +5,8 @@
 #ifndef VMECPP_FREE_BOUNDARY_SURFACE_GEOMETRY_SURFACE_GEOMETRY_H_
 #define VMECPP_FREE_BOUNDARY_SURFACE_GEOMETRY_SURFACE_GEOMETRY_H_
 
+#include <Eigen/Dense>
 #include <span>
-#include <vector>
 
 #include "vmecpp/common/fourier_basis_fast_toroidal/fourier_basis_fast_toroidal.h"
 #include "vmecpp/common/sizes/sizes.h"
@@ -28,126 +28,126 @@ class SurfaceGeometry {
       int signOfJacobian, bool fullUpdate);
 
   // [nfp] cos(2 pi / nfp * p)
-  std::vector<double> cos_per;
+  Eigen::VectorXd cos_per;
 
   // [nfp] sin(2 pi / nfp * p)
-  std::vector<double> sin_per;
+  Eigen::VectorXd sin_per;
 
   // [nZeta] cos(phi)
-  std::vector<double> cos_phi;
+  Eigen::VectorXd cos_phi;
 
   // [nZeta] sin(phi)
-  std::vector<double> sin_phi;
+  Eigen::VectorXd sin_phi;
 
   // -----------------
 
   // R
   // full surface
-  std::vector<double> r1b;
+  Eigen::VectorXd r1b;
 
   // dR/dTheta
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> rub;
+  Eigen::VectorXd rub;
 
   // dR/dPhi
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> rvb;
+  Eigen::VectorXd rvb;
 
   // Z
   // full surface
-  std::vector<double> z1b;
+  Eigen::VectorXd z1b;
 
   // dZ/dTheta
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> zub;
+  Eigen::VectorXd zub;
 
   // dZ/dPhi
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> zvb;
+  Eigen::VectorXd zvb;
 
   // d^2R/dTheta^2
   // thread-local effective poloidal range (tp->numZT)
   // only needed within SurfaceGeometry() but public for testing
-  std::vector<double> ruu;
+  Eigen::VectorXd ruu;
 
   // d^2R/(dTheta dPhi)
   // thread-local effective poloidal range (tp->numZT)
   // only needed within SurfaceGeometry() but public for testing
-  std::vector<double> ruv;
+  Eigen::VectorXd ruv;
 
   // d^2R/dPhi^2
   // thread-local effective poloidal range (tp->numZT)
   // only needed within SurfaceGeometry() but public for testing
-  std::vector<double> rvv;
+  Eigen::VectorXd rvv;
 
   // d^2Z/dTheta^2
   // thread-local effective poloidal range (tp->numZT)
   // only needed within SurfaceGeometry() but public for testing
-  std::vector<double> zuu;
+  Eigen::VectorXd zuu;
 
   // d^2Z/(dTheta dPhi)
   // thread-local effective poloidal range (tp->numZT)
   // only needed within SurfaceGeometry() but public for testing
-  std::vector<double> zuv;
+  Eigen::VectorXd zuv;
 
   // d^2Z/dPhi^2
   // thread-local effective poloidal range (tp->numZT)
   // only needed within SurfaceGeometry() but public for testing
-  std::vector<double> zvv;
+  Eigen::VectorXd zvv;
 
   // N^r * signOfJacobian
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> snr;
+  Eigen::VectorXd snr;
 
   // N^phi * signOfJacobian
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> snv;
+  Eigen::VectorXd snv;
 
   // N^z * signOfJacobian
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> snz;
+  Eigen::VectorXd snz;
 
   // g_{theta,theta}
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> guu;
+  Eigen::VectorXd guu;
 
   // 2 * g_{theta,zeta} = 2/nfp * g_{theta,phi}
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> guv;
+  Eigen::VectorXd guv;
 
   // g_{zeta,zeta} = 1/(nfp*nfp) g_{phi,phi}
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> gvv;
+  Eigen::VectorXd gvv;
 
   // 1/2 d^2X/dTheta^2 dot N
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> auu;
+  Eigen::VectorXd auu;
 
   // d^2X/(dTheta dZeta) dot N
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> auv;
+  Eigen::VectorXd auv;
 
   // 1/2 d^2X/dZeta^2 dot N
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> avv;
+  Eigen::VectorXd avv;
 
   // - (R N^R + Z N^Z)
   // needed for dsave --> (X - X') dot N'
   // thread-local effective poloidal range (tp->numZT)
-  std::vector<double> drv;
+  Eigen::VectorXd drv;
 
   // R^2 + Z^2
   // needed for gsave --> |X - X'|^2
   // full surface
-  std::vector<double> rzb2;
+  Eigen::VectorXd rzb2;
 
   // x
   // full surface
-  std::vector<double> rcosuv;
+  Eigen::VectorXd rcosuv;
 
   // y
   // full surface
-  std::vector<double> rsinuv;
+  Eigen::VectorXd rsinuv;
 
  private:
   const Sizes& s_;
@@ -167,8 +167,8 @@ class SurfaceGeometry {
 
   void derivedSurfaceQuantities(int signOfJacobian, bool fullUpdate);
 
-  std::vector<double> r1b_asym;
-  std::vector<double> z1b_asym;
+  Eigen::VectorXd r1b_asym;
+  Eigen::VectorXd z1b_asym;
 };
 
 }  // namespace vmecpp


### PR DESCRIPTION
## Goal

Migrate the free-boundary (NESTOR) modules from `std::vector<double>` storage to Eigen (`Eigen::VectorXd`), matching the style already used by `laplace_solver`, so the whole free-boundary stack uses a single array type and inter-module data flows as Eigen vectors without copies.

## What changed

All free-boundary modules now use Eigen storage and Eigen inter-module interfaces:

| Module | Change |
|--------|--------|
| `surface_geometry` | members → `Eigen::VectorXd` |
| `external_magnetic_field` | members → `Eigen::VectorXd` |
| `mgrid_provider` | members → `Eigen::VectorXd`; `SetFixedMagneticField` / `interpolate` → Eigen |
| `regularized_integrals` | members + `update` input → Eigen |
| `singular_integrals` | members → `Eigen::VectorXd`; the 2D `Tlp` / `Tlm` / `Slp` / `Slm` → `std::vector<Eigen::VectorXd>`; `update` / `prepareUpdate` / `performUpdate` inputs → Eigen |
| `laplace_solver` | method inputs (`TransformGreensFunctionDerivative`, `SymmetriseSourceTerm`, `AccumulateFullGrpmn`, `SolveForPotential`) → Eigen (storage was already Eigen) |

Conventions:

- `std::vector<double>` members become `Eigen::VectorXd`; logically-2D `std::vector<std::vector<double>>` become `std::vector<Eigen::VectorXd>`, which keeps `x[i][j]` element access intact.
- Inter-module method parameters move from `const std::vector<double>&` to `const Eigen::VectorXd&`, so a module's Eigen members feed the next module directly. `Nestor::update` passes these members straight through, so its body is unchanged.
- External entry points stay `std::span<const double>` (`SurfaceGeometry::update`, `Nestor::update`), and the NetCDF 3D read temporaries in `mgrid_provider` stay nested `std::vector` (to match `NetcdfReadArray3D`).
- Zero-initialization that the old `std::vector` code relied on (`resize(n, 0.0)`, `absl::c_fill*`) becomes `setZero()` / `setZero(n)`; a plain `resize(n)` followed by a full assignment is left as `resize(n)`. The now-unused `absl/algorithm/container.h` includes are dropped.

## Validation

This is a storage-type migration only; the numerics are bit-for-bit identical.

- All `//vmecpp/free_boundary/...` targets compile.
- `singular_integrals_test` and `laplace_solver_test` pass: the Tlp/Tlm recurrence still matches the independent Gauss-Legendre references, and the Laplace method-of-manufactured-solutions and solve checks still hold.
- The free-boundary equilibrium golden tests (`output_quantities_test`, including `cth_like_free_bdy`) pass unchanged, confirming the full free-boundary chain is bit-for-bit unchanged end to end.
