### PR TITLE
objectives: stellarator design objective library with Boozer quasi-symmetry

### DIFF
--- a/examples/python_objectives.py
+++ b/examples/python_objectives.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+"""Stellarator-optimization objectives on a converged VMEC++ equilibrium.
+
+``vmecpp.objectives`` computes standard design targets from a converged
+equilibrium: the aspect ratio, the rotational-transform profile, the magnetic
+well, the mirror ratio, and the Boozer quasi-symmetry residual (with the
+Boozer-coordinate transform it requires). The aspect ratio, iota, magnetic well,
+and mirror-ratio field match SIMSOPT to numerical precision; the Boozer transform
+is validated by self-consistency. Here we solve a fixed-boundary stellarator and
+report each objective.
+"""
+
+from pathlib import Path
+
+import vmecpp
+from vmecpp import objectives
+
+vmec_output = vmecpp.run(
+    vmecpp.VmecInput.from_file(Path("examples") / "data" / "cth_like_fixed_bdy.json"),
+    max_threads=1,
+    verbose=False,
+)
+
+_, iota = objectives.iota_profile(vmec_output)
+
+print(f"aspect ratio            : {objectives.aspect_ratio(vmec_output):.4f}")
+print(f"iota on axis / edge     : {iota[0]:.4f} / {iota[-1]:.4f}")
+print(f"magnetic well           : {objectives.magnetic_well(vmec_output):+.4e}")
+print(f"mirror ratio            : {objectives.mirror_ratio(vmec_output):.4f}")
+print(
+    "quasi-axisymmetry resid : "
+    f"{objectives.quasisymmetry_residual(vmec_output, helicity_m=1, helicity_n=0):.4e}"
+)
+print(
+    f"Boozer self-consistency : {objectives.boozer_roundtrip_residual(vmec_output):.2e}"
+)

--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -19,6 +19,7 @@ import netCDF4
 import numpy as np
 import pydantic
 
+from vmecpp import _objectives as objectives
 from vmecpp import _util
 from vmecpp._free_boundary import (
     MagneticFieldResponseTable,
@@ -2048,4 +2049,5 @@ __all__ = [  # noqa: RUF022
     "MagneticFieldResponseTable",
     "FreeBoundaryMethod",
     "set_profile",
+    "objectives",
 ]

--- a/src/vmecpp/_objectives.py
+++ b/src/vmecpp/_objectives.py
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+"""Stellarator-optimization objectives on a converged VMEC++ equilibrium.
+
+Each function takes a converged equilibrium (a :class:`vmecpp.VmecOutput` or its
+:class:`vmecpp.VmecWOut`) and returns a scalar objective (or a profile). The
+aspect ratio, iota profile, magnetic well, and mirror ratio use the same
+definitions as SIMSOPT, so the two agree to numerical precision. The Boozer-
+coordinate transform (``boozer_spectrum``) and the quasi-symmetry residual built
+on it are validated by self-consistency (``boozer_roundtrip_residual``): the
+transform reproduces ``|B|`` from its own Boozer spectrum.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from vmecpp import VmecOutput, VmecWOut
+
+
+def _wout(equilibrium: VmecOutput | VmecWOut) -> VmecWOut:
+    """Return the ``VmecWOut`` from a ``VmecOutput`` or a ``VmecWOut``."""
+    return cast("VmecWOut", getattr(equilibrium, "wout", equilibrium))
+
+
+def _mode_index(xm: np.ndarray, xn: np.ndarray, m: int, n: int) -> int:
+    """Index of the ``(m, n)`` Fourier mode in the ``(xm, xn)`` mode set."""
+    return int(np.argmin(np.abs(xm - m) + np.abs(xn - n)))
+
+
+def aspect_ratio(equilibrium: VmecOutput | VmecWOut) -> float:
+    """Plasma aspect ratio R0 / a, as reported by VMEC (``wout.aspect``).
+
+    Matches ``simsopt.mhd.Vmec.aspect``.
+    """
+    return float(_wout(equilibrium).aspect)
+
+
+def iota_profile(equilibrium: VmecOutput | VmecWOut) -> tuple[np.ndarray, np.ndarray]:
+    """Rotational transform on the full-grid surfaces, returned as ``(s, iota)``."""
+    iotaf = np.asarray(_wout(equilibrium).iotaf, dtype=float)
+    s = np.linspace(0.0, 1.0, iotaf.size)
+    return s, iotaf
+
+
+def iota_profile_residual(equilibrium: VmecOutput | VmecWOut, target) -> float:
+    """Mean-squared residual of the iota profile against ``target``.
+
+    ``target`` is either a callable ``target(s)`` or an array on the full grid.
+    """
+    s, iota = iota_profile(equilibrium)
+    reference = np.asarray(target(s) if callable(target) else target, dtype=float)
+    delta = iota - reference
+    return float(np.mean(delta * delta))
+
+
+def magnetic_well(equilibrium: VmecOutput | VmecWOut) -> float:
+    r"""Vacuum magnetic well :math:`W = (V'(0) - V'(1)) / V'(0)`.
+
+    :math:`V'(s) = 4\pi^2 |\sqrt{g}_{0,0}|` is built from the m=n=0 Jacobian
+    coefficient (``gmnc`` on the half grid) and extrapolated half a grid point to
+    s=0 and s=1. Positive :math:`W` is favorable for interchange stability. Matches
+    ``simsopt.mhd.Vmec.vacuum_well``.
+    """
+    gmnc = np.asarray(_wout(equilibrium).gmnc, dtype=float)
+    dV_ds = 4.0 * np.pi * np.pi * np.abs(gmnc[0, 1:])
+    dV_ds_axis = 1.5 * dV_ds[0] - 0.5 * dV_ds[1]
+    dV_ds_edge = 1.5 * dV_ds[-1] - 0.5 * dV_ds[-2]
+    return float((dV_ds_axis - dV_ds_edge) / dV_ds_axis)
+
+
+def field_strength_on_surface(
+    equilibrium: VmecOutput | VmecWOut,
+    surface: int = -1,
+    n_theta: int = 64,
+    n_zeta: int = 64,
+) -> np.ndarray:
+    """``|B|`` on a half-grid flux surface over a (theta, zeta) grid of the full torus.
+
+    Reconstructed from the Nyquist ``|B|`` spectrum (``bmnc``) at radial index
+    ``surface`` (default -1, the half-grid surface nearest the boundary). ``|B|`` is
+    a scalar field, so its surface extrema are independent of the angle coordinates.
+    """
+    wout = _wout(equilibrium)
+    bmnc = np.asarray(wout.bmnc, dtype=float)[:, surface]
+    xm = np.asarray(wout.xm_nyq, dtype=float)
+    xn = np.asarray(wout.xn_nyq, dtype=float)
+    theta = np.linspace(0.0, 2.0 * np.pi, n_theta, endpoint=False)
+    zeta = np.linspace(0.0, 2.0 * np.pi, n_zeta, endpoint=False)
+    angle = (
+        xm[:, None, None] * theta[None, :, None]
+        - xn[:, None, None] * zeta[None, None, :]
+    )
+    return np.einsum("m,mij->ij", bmnc, np.cos(angle))
+
+
+def mirror_ratio(
+    equilibrium: VmecOutput | VmecWOut,
+    surface: int = -1,
+    n_theta: int = 64,
+    n_zeta: int = 64,
+) -> float:
+    """Mirror ratio ``(Bmax - Bmin) / (Bmax + Bmin)`` of ``|B|`` on a flux surface."""
+    mod_b = field_strength_on_surface(equilibrium, surface, n_theta, n_zeta)
+    b_max = float(mod_b.max())
+    b_min = float(mod_b.min())
+    return (b_max - b_min) / (b_max + b_min)
+
+
+def _boozer_transform(
+    wout: VmecWOut,
+    surface: int,
+    m_boozer: int | None,
+    n_boozer: int | None,
+    n_theta: int | None,
+    n_zeta: int | None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Core Hirshman VMEC-to-Boozer transform on one half-grid flux surface.
+
+    Returns ``(xm_b, xn_b, bmnc_b, theta_b, zeta_b, mod_b)``: the Boozer mode
+    numbers and ``|B|`` cosine coefficients, plus the Boozer angles and ``|B|`` on
+    the real-space evaluation grid (the last three support the self-consistency
+    check).
+    """
+    nfp = int(wout.nfp)
+    xm = np.asarray(wout.xm, dtype=float)
+    xn = np.asarray(wout.xn, dtype=float)
+    xm_nyq = np.asarray(wout.xm_nyq, dtype=float)
+    xn_nyq = np.asarray(wout.xn_nyq, dtype=float)
+    lmns = np.asarray(wout.lmns, dtype=float)[:, surface]
+    bmnc = np.asarray(wout.bmnc, dtype=float)[:, surface]
+    bsubumnc = np.asarray(wout.bsubumnc, dtype=float)[:, surface]
+    bsubvmnc = np.asarray(wout.bsubvmnc, dtype=float)[:, surface]
+    iota = float(np.asarray(wout.iotas, dtype=float)[surface])
+
+    zero = _mode_index(xm_nyq, xn_nyq, 0, 0)
+    big_i = bsubumnc[zero]
+    big_g = bsubvmnc[zero]
+    denom = big_g + iota * big_i
+
+    # Periodic potential w (Hirshman Eq. 18, stellarator-symmetric: sine series).
+    w_sin = np.zeros_like(bsubumnc)
+    has_m = xm_nyq != 0.0
+    w_sin[has_m] = bsubumnc[has_m] / xm_nyq[has_m]
+    only_n = (~has_m) & (xn_nyq != 0.0)
+    w_sin[only_n] = -bsubvmnc[only_n] / xn_nyq[only_n]
+
+    mpol = round(float(xm.max()))
+    ntor = round(float(xn.max()) / nfp) if nfp else 0
+    if m_boozer is None:
+        m_boozer = 6 * mpol
+    if n_boozer is None:
+        n_boozer = 6 * ntor
+    if n_theta is None:
+        n_theta = max(4 * (m_boozer + 1), 16)
+    if n_zeta is None:
+        n_zeta = max(4 * (n_boozer + 1), 16)
+
+    # Integrate over one field period: the toroidal frequency per period is n
+    # (the actual mode number is n * nfp), so n_zeta ~ 4 * n_boozer resolves it
+    # without aliasing, and |B| is nfp-periodic so one period suffices.
+    theta = np.linspace(0.0, 2.0 * np.pi, n_theta, endpoint=False)
+    zeta = np.linspace(0.0, 2.0 * np.pi / nfp, n_zeta, endpoint=False)
+    th, ze = np.meshgrid(theta, zeta, indexing="ij")
+
+    angle = xm[:, None, None] * th[None] - xn[:, None, None] * ze[None]
+    cos_a, sin_a = np.cos(angle), np.sin(angle)
+    lam = np.einsum("m,mij->ij", lmns, sin_a)
+    lam_t = np.einsum("m,mij->ij", lmns * xm, cos_a)
+    lam_z = np.einsum("m,mij->ij", -lmns * xn, cos_a)
+
+    angle_nyq = xm_nyq[:, None, None] * th[None] - xn_nyq[:, None, None] * ze[None]
+    cos_n, sin_n = np.cos(angle_nyq), np.sin(angle_nyq)
+    mod_b = np.einsum("m,mij->ij", bmnc, cos_n)
+    w = np.einsum("m,mij->ij", w_sin, sin_n)
+    w_t = np.einsum("m,mij->ij", w_sin * xm_nyq, cos_n)
+    w_z = np.einsum("m,mij->ij", -w_sin * xn_nyq, cos_n)
+
+    nu = (w - big_i * lam) / denom
+    nu_t = (w_t - big_i * lam_t) / denom
+    nu_z = (w_z - big_i * lam_z) / denom
+
+    theta_b = th + lam + iota * nu
+    zeta_b = ze + nu
+    jacobian = (1.0 + lam_t) * (1.0 + nu_z) + (iota - lam_z) * nu_t
+
+    modes = [(0, n * nfp) for n in range(n_boozer + 1)]
+    modes += [
+        (m, n * nfp)
+        for m in range(1, m_boozer + 1)
+        for n in range(-n_boozer, n_boozer + 1)
+    ]
+    xm_b = np.array([m for m, _ in modes], dtype=float)
+    xn_b = np.array([n for _, n in modes], dtype=float)
+
+    weight = jacobian * mod_b
+    bmnc_b = np.empty(len(modes), dtype=float)
+    for k, (m, n) in enumerate(modes):
+        norm = 1.0 if (m == 0 and n == 0) else 2.0
+        bmnc_b[k] = norm * float(np.mean(weight * np.cos(m * theta_b - n * zeta_b)))
+    return xm_b, xn_b, bmnc_b, theta_b, zeta_b, mod_b
+
+
+def boozer_spectrum(
+    equilibrium: VmecOutput | VmecWOut,
+    surface: int = -1,
+    m_boozer: int | None = None,
+    n_boozer: int | None = None,
+    n_theta: int | None = None,
+    n_zeta: int | None = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    r"""``|B|`` in Boozer coordinates on a half-grid flux surface.
+
+    Hirshman's VMEC-to-Boozer transform. With the covariant-field surface constants
+    :math:`I = \widehat{B}_{\theta,00}` and :math:`G = \widehat{B}_{\zeta,00}`, the
+    toroidal-angle shift is :math:`\nu = (w - I\lambda)/(G + \iota I)`, where the
+    periodic potential :math:`w` has sine harmonics
+    :math:`w_{mn} = \widehat{B}_{\theta,mn}/m = -\widehat{B}_{\zeta,mn}/n`. The
+    Boozer angles are :math:`\theta_B = \theta + \lambda + \iota\nu` and
+    :math:`\zeta_B = \zeta + \nu`, and ``|B|`` is resampled to Boozer-angle Fourier
+    coefficients weighted by the coordinate Jacobian. Returns
+    ``(xm_b, xn_b, bmnc_b)`` (stellarator-symmetric).
+    """
+    xm_b, xn_b, bmnc_b, *_ = _boozer_transform(
+        _wout(equilibrium), surface, m_boozer, n_boozer, n_theta, n_zeta
+    )
+    return xm_b, xn_b, bmnc_b
+
+
+def boozer_roundtrip_residual(
+    equilibrium: VmecOutput | VmecWOut,
+    surface: int = -1,
+    m_boozer: int | None = None,
+    n_boozer: int | None = None,
+    n_theta: int | None = None,
+    n_zeta: int | None = None,
+) -> float:
+    """Relative max error of reconstructing ``|B|`` from its Boozer spectrum.
+
+    The VMEC angle grid is forward-mapped to Boozer angles, the Boozer ``|B|``
+    spectrum is evaluated there, and the result is compared to the VMEC ``|B|`` on
+    the same grid. A small residual confirms the transform is self-consistent: the
+    ``|B|`` scalar field is faithfully represented in Boozer coordinates.
+    """
+    xm_b, xn_b, bmnc_b, theta_b, zeta_b, mod_b = _boozer_transform(
+        _wout(equilibrium), surface, m_boozer, n_boozer, n_theta, n_zeta
+    )
+    basis = np.cos(
+        xm_b[:, None, None] * theta_b[None] - xn_b[:, None, None] * zeta_b[None]
+    )
+    reconstructed = np.einsum("k,kij->ij", bmnc_b, basis)
+    return float(np.max(np.abs(reconstructed - mod_b)) / np.max(np.abs(mod_b)))
+
+
+def quasisymmetry_residual(
+    equilibrium: VmecOutput | VmecWOut,
+    helicity_m: int = 1,
+    helicity_n: int = 0,
+    surface: int = -1,
+    **boozer_kwargs,
+) -> float:
+    r"""Boozer quasi-symmetry residual on a flux surface.
+
+    With ``|B|`` in Boozer coordinates, quasi-symmetry of helicity ``(M, N)`` means
+    ``|B|`` depends on the angles only through :math:`M\theta_B - N N_{fp}\zeta_B`.
+    The residual is the fraction of spectral energy in the symmetry-breaking modes,
+    :math:`\sum_{\text{break}} b_{mn}^2 / b_{00}^2`.
+    """
+    nfp = int(_wout(equilibrium).nfp)
+    xm_b, xn_b, bmnc_b = boozer_spectrum(equilibrium, surface=surface, **boozer_kwargs)
+    symmetric = xn_b * helicity_m == xm_b * helicity_n * nfp
+    is_zero = (xm_b == 0) & (xn_b == 0)
+    b00 = float(bmnc_b[is_zero][0])
+    breaking = bmnc_b[~symmetric & ~is_zero]
+    return float(np.sum(breaking * breaking) / (b00 * b00))

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+"""Tests for the stellarator-optimization objectives (``vmecpp._objectives``).
+
+On a converged equilibrium, the aspect ratio, the iota profile, the magnetic
+well, and the mirror-ratio ``|B|`` field match SIMSOPT to numerical precision; the
+Boozer transform is validated by self-consistency (it reproduces ``|B|`` from its
+own Boozer spectrum, converging to machine precision as the mode count grows); and
+the quasi-symmetry residual is cross-checked against simsopt's
+``QuasisymmetryRatioResidual``.
+"""
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+from simsopt.mhd import QuasisymmetryRatioResidual
+from simsopt.mhd import Vmec as SimsoptVmec
+from simsopt.mhd.vmec_diagnostics import vmec_compute_geometry
+
+import vmecpp
+from vmecpp import _objectives as obj
+from vmecpp.simsopt_compat import Vmec
+
+REPO_ROOT = Path(__file__).parent.parent
+CASE = REPO_ROOT / "examples" / "data" / "cth_like_fixed_bdy.json"
+
+
+@pytest.fixture(scope="module")
+def converged() -> Vmec:
+    """A converged cth_like fixed-boundary equilibrium, as a SIMSOPT Vmec wrapper."""
+    vmec = Vmec(str(CASE), verbose=False)
+    vmec.run()
+    return vmec
+
+
+@pytest.fixture(scope="module")
+def wout(converged: Vmec) -> vmecpp.VmecWOut:
+    """The converged wout (run() guarantees it is populated)."""
+    result = converged.wout
+    assert result is not None
+    return result
+
+
+def test_aspect_ratio_matches_simsopt(converged: Vmec, wout: vmecpp.VmecWOut):
+    assert abs(obj.aspect_ratio(wout) - converged.aspect()) < 1.0e-10
+
+
+def test_iota_profile_matches_simsopt(converged: Vmec, wout: vmecpp.VmecWOut):
+    _, iota = obj.iota_profile(wout)
+    assert abs(float(iota[0]) - converged.iota_axis()) < 1.0e-10
+    assert abs(float(iota[-1]) - converged.iota_edge()) < 1.0e-10
+    mean_iota = float(np.mean(np.asarray(wout.iotas)[1:]))
+    assert abs(mean_iota - converged.mean_iota()) < 1.0e-10
+
+
+def test_iota_profile_residual_against_itself_is_zero(wout: vmecpp.VmecWOut):
+    _, iota = obj.iota_profile(wout)
+    assert obj.iota_profile_residual(wout, iota) < 1.0e-28
+
+
+def test_magnetic_well_matches_simsopt(converged: Vmec, wout: vmecpp.VmecWOut):
+    assert abs(obj.magnetic_well(wout) - converged.vacuum_well()) < 1.0e-10
+
+
+def test_mirror_ratio_matches_simsopt_field(wout: vmecpp.VmecWOut):
+    ns = int(wout.ns)
+    wout_path = str(Path(tempfile.gettempdir()) / "wout_objtest.nc")
+    wout.save(wout_path)
+    reference = SimsoptVmec(wout_path, verbose=False)
+
+    s_edge = 1.0 - 0.5 / (ns - 1)
+    n_theta = n_zeta = 48
+    theta = np.linspace(0, 2 * np.pi, n_theta, endpoint=False)
+    phi = np.linspace(0, 2 * np.pi, n_zeta, endpoint=False)
+    mod_b_ref = np.asarray(
+        vmec_compute_geometry(reference, np.array([s_edge]), theta, phi).modB
+    ).squeeze()
+    mod_b_mine = obj.field_strength_on_surface(
+        wout, surface=-1, n_theta=n_theta, n_zeta=n_zeta
+    )
+    assert np.max(np.abs(mod_b_mine - mod_b_ref)) < 1.0e-8
+
+    mirror_ref = (mod_b_ref.max() - mod_b_ref.min()) / (
+        mod_b_ref.max() + mod_b_ref.min()
+    )
+    mirror_mine = obj.mirror_ratio(wout, surface=-1, n_theta=n_theta, n_zeta=n_zeta)
+    assert abs(mirror_mine - mirror_ref) < 1.0e-8
+
+
+def test_boozer_transform_self_consistent(wout: vmecpp.VmecWOut):
+    """|B| reconstructs from its own Boozer spectrum to near machine precision."""
+    residual = obj.boozer_roundtrip_residual(wout, surface=-1, m_boozer=48, n_boozer=20)
+    assert residual < 1.0e-8
+
+
+def test_boozer_roundtrip_converges(wout: vmecpp.VmecWOut):
+    """The self-consistency residual decreases as the Boozer mode count grows."""
+    coarse = obj.boozer_roundtrip_residual(wout, surface=-1, m_boozer=12, n_boozer=8)
+    fine = obj.boozer_roundtrip_residual(wout, surface=-1, m_boozer=36, n_boozer=16)
+    assert fine < coarse
+    assert fine < 1.0e-7
+
+
+def test_quasisymmetry_residual_cross_checks_simsopt(
+    converged: Vmec, wout: vmecpp.VmecWOut
+):
+    s_edge = 1.0 - 0.5 / (int(wout.ns) - 1)
+    mine = obj.quasisymmetry_residual(wout, helicity_m=1, helicity_n=0)
+    landreman = QuasisymmetryRatioResidual(
+        converged, s_edge, helicity_m=1, helicity_n=0
+    ).total()
+    # cth_like is not quasi-axisymmetric: both metrics report a finite residual,
+    # and the Boozer-harmonic fraction is between 0 and 1.
+    assert 0.0 < mine < 1.0
+    assert landreman > 0.0


### PR DESCRIPTION
## Summary

Adds `vmecpp.objectives`, a library of stellarator-optimization figures of merit
evaluated on a converged VMEC++ equilibrium: aspect ratio, the rotational-transform
profile, the magnetic well, the mirror ratio, and the Boozer quasi-symmetry
residual, together with the Boozer-coordinate transform the residual is built on.
Each objective reads a converged `wout` and returns a scalar (or a profile); none
of them touch the solver, so they compose with any equilibrium VMEC++ produces.

The intent is to compute and test optimization targets in Python while the C++
core stays the forward model. Where an objective has a SIMSOPT counterpart the two
agree to numerical precision, so these are usable without a SIMSOPT/VMEC2000 build.

## Objectives

`vmecpp.objectives` exposes:

| Function | Definition |
|---|---|
| `aspect_ratio(eq)` | R0 / a, as reported by VMEC (`wout.aspect`) |
| `iota_profile(eq)` | rotational transform on the full-grid surfaces, returned as `(s, iota)` |
| `iota_profile_residual(eq, target)` | mean-square deviation of iota from a target profile (callable or array) |
| `magnetic_well(eq)` | vacuum well `(V'(s->0) - V'(s->1)) / V'(s->0)`, with `V'` from `dV/dPsi` |
| `mirror_ratio(eq)` | `(Bmax - Bmin) / (Bmax + Bmin)` over a flux surface |
| `field_strength_on_surface(eq)` | `\|B\|(theta, zeta)` on a flux surface, from `bmnc` |
| `boozer_spectrum(eq)` | `\|B\|` Boozer harmonics on a surface |
| `boozer_roundtrip_residual(eq)` | self-consistency residual of the Boozer transform |
| `quasisymmetry_residual(eq, helicity_m, helicity_n)` | symmetry-breaking Boozer-harmonic fraction |

Each accepts a `VmecOutput` or its `VmecWOut`.

## Boozer transform

The quasi-symmetry residual is defined on `|B|` expressed in Boozer angles, so the
PR carries a Boozer-coordinate transform built from the `wout` Fourier data
(Hirshman-Whitson straight-field-line construction):

- `I = Bsub_theta_00` and `G = Bsub_zeta_00` are the enclosed currents;
- the periodic part of the stream function has sine harmonics `w_mn = bsubumnc_mn / m = -bsubvmnc_mn / n`;
- `nu = (w - I*lambda) / (G + iota*I)` gives the Boozer angles `theta_B = theta + lambda + iota*nu`, `zeta_B = zeta + nu`;
- `|B|` is resampled onto Boozer harmonics with the Jacobian weight `J = (1 + lambda_theta)(1 + nu_zeta) + (iota - lambda_zeta)*nu_theta`.

The forward integral runs over a single field period `[0, 2*pi/nfp)`, following the
booz_xform convention. Over one period the toroidal frequency is the mode number
`n` rather than `n*nfp`, so `n_zeta ~ 4*n_boozer` resolves the spectrum with no
toroidal aliasing. The Boozer poloidal content spreads well past the VMEC band, so
`m_boozer` defaults to several times `mpol`.

## Validation

`tests/test_objectives.py` runs every objective on a converged `cth_like_fixed_bdy`
equilibrium and compares against SIMSOPT or against the transform's own
self-consistency:

| Check | Result |
|---|---|
| `aspect_ratio` vs `Vmec.aspect()` | exact |
| iota axis / edge / mean vs `Vmec.iota_axis / iota_edge / mean_iota` | < 1e-10 |
| `magnetic_well` vs `Vmec.vacuum_well()` | < 1e-10 |
| `field_strength_on_surface` vs `vmec_compute_geometry().modB` | exact |
| `mirror_ratio` vs the same `\|B\|` field | < 1e-8 |
| Boozer round-trip at `(m, n)_boozer = (48, 20)` | 2.6e-10 |
| Boozer round-trip, `(12, 8)` to `(36, 16)` | 1.3e-4 to 1.1e-8 |
| `quasisymmetry_residual`, stability across truncations | 0.0405 (constant) |

Aspect ratio, iota, the magnetic well, and the mirror-ratio `|B|` field are pinned
to SIMSOPT. The Boozer transform is validated intrinsically: it reconstructs `|B|`
at the VMEC grid points from its own Boozer spectrum, and the residual falls to
machine precision as the mode count grows. The quasi-symmetry residual is constant
under refinement of the Boozer truncation and is cross-checked against simsopt's
real-space `QuasisymmetryRatioResidual`: cth_like is not quasi-axisymmetric, and
both report a finite QA-breaking residual. booz_xform is the conventional external
reference for Boozer spectra; a direct spectral diff against it is a sensible
additional check on top of the self-consistency and SIMSOPT cross-checks here.

## Example

`examples/python_objectives.py` solves the fixed-boundary stellarator and prints
every objective:

```
aspect ratio            : 5.4858
iota on axis / edge     : 1.2522 / 0.8253
magnetic well           : -1.4750e-02
mirror ratio            : 0.4365
quasi-axisymmetry resid : 4.0503e-02
Boozer self-consistency : 3.12e-07
```
