### PR TITLE
Cache TSAN Docker image in GHCR

### DIFF
--- a/.github/workflows/build_tsan_image.yaml
+++ b/.github/workflows/build_tsan_image.yaml
@@ -1,0 +1,41 @@
+name: Build TSAN Docker image
+
+# Builds the ThreadSanitizer-enabled clang/libomp Docker image and pushes it to
+# GHCR. This image takes ~1h to build (it compiles LLVM/clang 18 from source),
+# so we cache it in the registry and only rebuild when the docker/tsan/ sources
+# change. The C++ TSAN test workflow (test_bazel_tsan.yaml) then just pulls the
+# prebuilt image instead of rebuilding it on every run.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/vmecpp/cpp/docker/tsan/**"
+      - ".github/workflows/build_tsan_image.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    name: Build and push TSAN image to GHCR
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: |
+          IMAGE=ghcr.io/${{ github.repository_owner }}/vmecpp-tsan:latest
+          docker build -t "${IMAGE,,}" src/vmecpp/cpp/docker/tsan
+          docker push "${IMAGE,,}"

--- a/.github/workflows/test_bazel_tsan.yaml
+++ b/.github/workflows/test_bazel_tsan.yaml
@@ -17,12 +17,28 @@ jobs:
   tsan:
     name: Build and run tsan tests
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@v4
         with:
           lfs: true  # for the mgrid test data
-      - name: Build TSAN Docker image
-        run: docker build -t proximafusion/tsan src/vmecpp/cpp/docker/tsan
+      # The TSAN image (clang/libomp with ThreadSanitizer support) takes ~1h to
+      # build, so it is prebuilt and pushed to GHCR by build_tsan_image.yaml and
+      # only rebuilt when src/vmecpp/cpp/docker/tsan/ changes. Here we just pull
+      # the cached image.
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pull TSAN Docker image
+        run: |
+          IMAGE=ghcr.io/${{ github.repository_owner }}/vmecpp-tsan:latest
+          docker pull "${IMAGE,,}"
+          docker tag "${IMAGE,,}" proximafusion/tsan
       - uses: actions/checkout@v4
         with:
           repository: proximafusion/vmecpp_large_cpp_tests


### PR DESCRIPTION
## Problem

The C++ TSAN CI job takes ~80 min, of which **~61 min is rebuilding the TSAN Docker image** on every run (it compiles LLVM/clang 18 + runtimes from source). See https://github.com/proximafusion/vmecpp/actions/runs/26652081830/job/78552836168 — the "Build TSAN Docker image" step alone runs 17:29 -> 18:30.

The image content only depends on `src/vmecpp/cpp/docker/tsan/`, which rarely changes.

## Change

- **New `build_tsan_image.yaml`**: builds the image and pushes it to GHCR (`ghcr.io/<owner>/vmecpp-tsan:latest`). Triggers only on pushes to `main` touching `src/vmecpp/cpp/docker/tsan/**`, or manually via `workflow_dispatch`.
- **`test_bazel_tsan.yaml`**: replaces the `docker build` step with a GHCR login + `docker pull`, re-tagged `proximafusion/tsan` so the rest of the job is unchanged.

Cuts the TSAN job from ~80 min to ~20 min on every PR.

## Note for reviewers

After merge, run **"Build TSAN Docker image"** once (Actions -> Run workflow, or `gh workflow run build_tsan_image.yaml`) to populate GHCR before the next TSAN test run can pull it.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)