### PR TITLE
iteration: fix post-reguess lambda scaling divergence, add Python multigrid driver

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -30,6 +30,7 @@ from vmecpp._iteration import (
     RestartReason,
     iterate,
     solve_equilibrium,
+    solve_multigrid,
 )
 from vmecpp._pydantic_numpy import BaseModelWithNumpy
 from vmecpp.cpp import _vmecpp  # type: ignore # bindings to the C++ core
@@ -2422,6 +2423,7 @@ __all__ = [  # noqa: RUF022
     "set_profile",
     "iterate",
     "solve_equilibrium",
+    "solve_multigrid",
     "IterationResult",
     "IterationState",
 ]

--- a/src/vmecpp/_iteration.py
+++ b/src/vmecpp/_iteration.py
@@ -299,7 +299,16 @@ def solve_equilibrium(
                 trace_l.append(fsql)
                 trace_rr.append(int(rr))
 
-                otav = inv_tau.sum() / _NDAMP
+                # Sequential left-to-right sum, matching Eigen's scalar
+                # VectorXd::sum() bit for bit. numpy's pairwise summation
+                # associates differently; the last-bit difference in the
+                # damping average amplifies through the early force
+                # transient on cold-start cases and shifts the convergence
+                # iteration against the C++ loop.
+                otav = 0.0
+                for _v in inv_tau:
+                    otav += float(_v)
+                otav /= _NDAMP
                 dtau = delt0r * otav / 2.0
                 model.perform_time_step(1.0 / (1.0 + dtau), 1.0 - dtau, delt0r)
 
@@ -506,6 +515,72 @@ def solve_equilibrium(
         force_residual_lambda=trace_l,
         restart_reasons=trace_rr,
     )
+
+
+def solve_multigrid(
+    vmec_input,
+    *,
+    iteration_style: str | None = None,
+    verbose: bool = False,
+    callback: Callable[[IterationState], None] | None = None,
+):
+    """Drive the full coarse-to-fine multi-grid ramp of ``vmec_input`` from
+    Python, mirroring the multi-grid loop of the C++ ``Vmec::run``.
+
+    Walks ``ns_array`` in order: entries coarser than the finest resolution
+    solved so far are skipped (the C++ ``ns_min`` rule), each remaining stage
+    is solved to its ``ftol_array`` / ``niter_array`` tolerance with
+    :func:`solve_equilibrium`, and the converged geometry is interpolated onto
+    the next stage's radial grid with ``VmecModel.refine_to`` (the C++
+    ``InterpolateToNextMultigridStep``). A stage that exhausts its iteration
+    budget without converging proceeds to the next stage, exactly as the C++
+    run does; a stage that hard-fails (unrecoverable bad Jacobian, the
+    ijacob >= 75 give-up) stops the ramp.
+
+    ``ftol_array`` / ``niter_array`` entries are matched to ``ns_array``
+    entries by ns value (``VmecModel.create`` / ``refine_to`` semantics);
+    repeated ns values in ``ns_array`` are not supported because the model
+    only refines to strictly finer grids.
+
+    Returns ``(model, results)``: the model holds the final stage's geometry
+    and ``results`` is the per-stage list of :class:`IterationResult`.
+    """
+    cpp_indata = vmec_input._to_cpp_vmecindata()
+    if iteration_style in (_VMEC_8_52, _PARVMEC):
+        cpp_indata.iteration_style = getattr(
+            _vmecpp.IterationStyle, iteration_style.upper()
+        )
+
+    ns_array = [int(ns) for ns in np.asarray(cpp_indata.ns_array)]
+    if len(set(ns_array)) != len(ns_array):
+        msg = (
+            "solve_multigrid: repeated ns values in ns_array are not "
+            f"supported (got {ns_array})"
+        )
+        raise ValueError(msg)
+
+    model = None
+    results: list[IterationResult] = []
+    ns_min = 3  # FlowControl::ns_min -- no refinement downward
+    for ns in ns_array:
+        if ns < ns_min:
+            # mirror the C++ run: skip entries coarser than already solved
+            continue
+        ns_min = ns
+        if model is None:
+            model = _vmecpp.VmecModel.create(cpp_indata, ns)
+        else:
+            model.refine_to(ns)
+        result = solve_equilibrium(
+            model, style=iteration_style, verbose=verbose, callback=callback
+        )
+        results.append(result)
+        if result.failed:
+            break
+    if model is None:
+        msg = f"solve_multigrid: no usable ns_array entries (got {ns_array})"
+        raise ValueError(msg)
+    return model, results
 
 
 def iterate(

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -293,6 +293,12 @@ class VmecModel {
     vmec_->b_.RecomputeMagneticAxisToFixJacobianSign(
         vmec_->fc_.nsval, vmecpp::Vmec::kSignOfJacobian);
     double delt0 = vmec_->indata_.delt;
+    // Vmec::run resets the accumulated constants before every
+    // InitializeRadial (the rmsPhiP -> lamscale accumulation in
+    // evalRadialProfiles is additive); without this reset a second
+    // InitializeRadial doubles rmsPhiP and rescales the entire lambda
+    // sector by sqrt(2).
+    vmec_->constants_.reset();
     vmec_->InitializeRadial(vmecpp::VmecCheckpoint::NONE, INT_MAX,
                             vmec_->fc_.nsval, /*ns_old=*/0, delt0,
                             std::nullopt);
@@ -346,6 +352,9 @@ class VmecModel {
     v.fc_.nsval = new_ns;
 
     double delt0 = v.indata_.delt;
+    // Same per-multi-grid-step constants reset Vmec::run performs before
+    // InitializeRadial (rmsPhiP accumulates in evalRadialProfiles).
+    v.constants_.reset();
     v.InitializeRadial(vmecpp::VmecCheckpoint::NONE, INT_MAX, new_ns, ns_old,
                        delt0, std::nullopt);
     last_preconditioner_update_ = 0;

--- a/tests/test_iteration.py
+++ b/tests/test_iteration.py
@@ -242,7 +242,7 @@ def test_callback_records_iteration_state():
 
 
 def test_reinitialize_preserves_lambda_scaling():
-    """reinitialize() must leave the lambda scaling (lamscale) unchanged.
+    """Reinitialize() must leave the lambda scaling (lamscale) unchanged.
 
     InitializeRadial accumulates rmsPhiP across calls (Vmec::run resets the
     constants before each call); without the matching reset in reinitialize(),
@@ -289,9 +289,9 @@ def test_python_multigrid_matches_cpp_run():
     assert model.ns == vmec_input.ns_array[-1]
 
     py_r = np.concatenate([np.asarray(r.force_residual_r) for r in results])
-    py_rr = np.concatenate(
-        [np.asarray(r.restart_reasons) for r in results]
-    ).astype(np.int64)
+    py_rr = np.concatenate([np.asarray(r.restart_reasons) for r in results]).astype(
+        np.int64
+    )
 
     assert len(py_rr) == len(cpp_rr)
     np.testing.assert_array_equal(py_rr, cpp_rr)

--- a/tests/test_iteration.py
+++ b/tests/test_iteration.py
@@ -132,6 +132,10 @@ def test_styles_agree_when_no_restart():
         ("cma", 72, 200, {RestartReason.HUGE_INITIAL_FORCES}),
         # W7-X drives a descent with mid-run bad-Jacobian time-step reverts
         ("w7x", 15, 300, {RestartReason.BAD_JACOBIAN}),
+        # li383's cold guess also needs the axis reguess; the descent itself is
+        # clean, which makes it a sharp probe of the post-reguess state (the
+        # lambda scaling after reinitialize).
+        ("li383_low_res", 31, 250, set()),
     ],
 )
 def test_python_iteration_matches_cpp_restart_path(
@@ -170,13 +174,13 @@ def test_python_iteration_matches_cpp_restart_path(
     # restart reason or a dropped reguess would change which reasons appear).
     assert reasons.issubset(set(py_rr.tolist()))
 
-    # The residual traces track to a tight tolerance until floating-point noise in
-    # the damping average compounds; assert the early steps match bit-for-bit and
-    # the whole trace stays close.
+    # The residual traces track tightly; the only non-bit-exact operation left
+    # is the order of additions in the damping average, whose last-bit noise
+    # can grow through long chaotic transients.
     cpp_r = np.asarray(reference.force_residual_r)
     py_r = np.asarray(result.force_residual_r)
-    np.testing.assert_allclose(py_r[:5], cpp_r[:5], rtol=1.0e-9, atol=1e-15)
-    np.testing.assert_allclose(py_r, cpp_r, rtol=0.5, atol=1e-15)
+    np.testing.assert_allclose(py_r[:50], cpp_r[:50], rtol=1.0e-9, atol=1e-15)
+    np.testing.assert_allclose(py_r, cpp_r, rtol=1.0e-3, atol=1e-15)
 
 
 def test_alternative_styles_converge_cma():
@@ -235,6 +239,64 @@ def test_callback_records_iteration_state():
     # cma's cold guess has a bad Jacobian, so the axis reguess fires (ijacob >= 1).
     assert states[-1].ijacob >= 1
     assert result.axis_reguesses >= 1
+
+
+def test_reinitialize_preserves_lambda_scaling():
+    """reinitialize() must leave the lambda scaling (lamscale) unchanged.
+
+    InitializeRadial accumulates rmsPhiP across calls (Vmec::run resets the
+    constants before each call); without the matching reset in reinitialize(),
+    a second initialization doubles rmsPhiP, rescales lamscale by sqrt(2), and
+    the whole lambda sector (preconditioned residual fsql1 above all) silently
+    diverges from the C++ on every post-reguess trajectory.
+    """
+    cpp_indata = _single_resolution_indata("solovev", 15, 1.0e-12, 3000)
+
+    once = _vmecpp.VmecModel.create(cpp_indata, 15)
+    once.reinitialize()
+    once.evaluate(1, 1)
+
+    twice = _vmecpp.VmecModel.create(cpp_indata, 15)
+    twice.reinitialize()
+    twice.reinitialize()
+    twice.evaluate(1, 1)
+
+    assert once.fsqr == twice.fsqr
+    assert once.fsql == pytest.approx(twice.fsql, rel=1e-14)
+    # fsql1 has no normalization that cancels a lamscale change; before the
+    # constants reset the second reinitialize shifted it by a factor 1.5.
+    assert once.fsql1 == pytest.approx(twice.fsql1, rel=1e-14)
+
+
+def test_python_multigrid_matches_cpp_run():
+    """solve_multigrid reproduces the C++ Vmec::run multi-grid ramp.
+
+    cma's own input is a two-stage ramp (ns_array [25, 51]) whose coarse stage
+    needs the cold-start axis reguess. The C++ reference is the full
+    vmecpp.run; its wout records the force-residual and restart-reason traces
+    concatenated across stages, which must match the concatenation of the
+    Python per-stage traces step for step.
+    """
+    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA / "cma.json")
+
+    reference = vmecpp.run(vmec_input, max_threads=1, verbose=False)
+    cpp_r = np.asarray(reference.wout.force_residual_r)
+    cpp_rr = np.asarray(reference.wout.restart_reason_timetrace)
+
+    model, results = vmecpp.solve_multigrid(vmec_input)
+    assert len(results) == 2
+    assert all(r.converged for r in results)
+    assert model.ns == vmec_input.ns_array[-1]
+
+    py_r = np.concatenate([np.asarray(r.force_residual_r) for r in results])
+    py_rr = np.concatenate(
+        [np.asarray(r.restart_reasons) for r in results]
+    ).astype(np.int64)
+
+    assert len(py_rr) == len(cpp_rr)
+    np.testing.assert_array_equal(py_rr, cpp_rr)
+    np.testing.assert_allclose(py_r[:50], cpp_r[:50], rtol=1.0e-9, atol=1e-15)
+    np.testing.assert_allclose(py_r, cpp_r, rtol=1.0e-3, atol=1e-15)
 
 
 def test_refine_to_multigrid_ramp_converges():


### PR DESCRIPTION
Fixes #555.

## Root cause of the Python/C++ divergence

`VmecConstants::rmsPhiP` is accumulated by `RadialProfiles::evalRadialProfiles`, and `Vmec::run` calls `constants_.reset()` before every `InitializeRadial` (vmec.cc:302). The `VmecModel` bindings `Reinitialize()` (the axis-reguess path) and `RefineTo()` (the multigrid step) re-ran `InitializeRadial` without that reset, so each re-initialization doubled `rmsPhiP` and rescaled `lamscale` by sqrt(2).

That rescales the entire lambda sector. The preconditioned residual `fsql1` carries the factor directly (it has no normalization that cancels a `lamscale` change), while the invariant `fsql` stays unchanged, so the damping average sees a different `fsq1` and the post-reguess trajectory splits from the C++ inner solve from the second step onward. The converged physics is unaffected (`lamscale` is an internal scaling), which is why this never showed in convergence tests, only in step-for-step traces. On `li383_low_res` at ns=31 the signature is clean: bit-identical `fsqr`/`fsqr1`/`fsqz1` with `fsql1` off by exactly 2.0 at the first post-reguess evaluation.

A secondary, much smaller divergence channel was the damping average itself: numpy's pairwise summation associates differently from Eigen's sequential `VectorXd::sum()`, and the last-bit difference grows through long chaotic transients. The Python loop now sums the ring buffer left to right, matching Eigen bit for bit.

## Changes

- `pybind_vmec.cc`: `constants_.reset()` before `InitializeRadial` in `Reinitialize()` and `RefineTo()`, matching `Vmec::run`.
- `_iteration.py`: sequential left-to-right damping-average sum.
- `_iteration.py` / `__init__.py`: `solve_multigrid()` — drives the full coarse-to-fine `ns_array` ramp from Python, mirroring the `Vmec::run` multi-grid loop (skip-coarser `ns_min` rule, per-stage ftol/niter, `refine_to` interpolation between stages, C++ failure semantics). This covers the "multigrid logic isn't implemented yet" part of the issue.
- `tests/test_iteration.py`:
  - regression test for the lambda scaling under repeated `reinitialize()`,
  - multigrid parity test: `solve_multigrid` on cma's own two-stage input (ns_array `[25, 51]`) against the full `vmecpp.run`, comparing the concatenated force-residual and restart-reason traces step for step,
  - `li383_low_res` added to the restart-path matrix (cold-start reguess with a clean descent — a sharp probe of the post-reguess state),
  - whole-trace residual tolerance tightened from `rtol=0.5` to `rtol=1e-3`, with the first 50 iterations at `rtol=1e-9`.

## Validation

Full-length (to convergence) Python-vs-C++ parity sweep, comparing iteration counts, restart-reason traces, and residual traces:

| case | ns | before | after |
|---|---|---|---|
| cma | 72 | 1729 vs 1728 iters, residuals split at it 5 | 1729 vs 1729, traces match |
| cma | 15 | 1539 vs 1540 | 1539 vs 1539, traces match |
| cma | 31 | 1655 vs 1649 | 1655 vs 1655, traces match |
| li383_low_res | 31 | 476 vs 511, residuals split at it 2 | 476 vs 476, traces match |
| solovev 15, cth_like 25, circular_tokamak 25, w7x 15/25 | | already matching | still matching |

Restart-reason traces are identical in every case; residual traces are tight for the whole run (the only remaining non-bit-exact effect is last-bit noise through the longest chaotic transients, staying below 1e-3 relative).

`tests/test_iteration.py`: 12 passed. Full Python suite: 144 passed, 4 skipped (the `cth_like_free_bdy` wout-reference failure pre-exists at `main` in this environment and is unrelated).
