### PR TITLE
Handle jaxtyping anonymous-dimension API drift in wout serialization

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -1064,31 +1064,31 @@ class VmecWOut(BaseModelWithNumpy):
     piota_type: ProfileType
     """Parametrization of iota profile (copied from input)."""
 
-    am: jt.Float[np.ndarray, "preset"]
+    am: jt.Float[np.ndarray, "_preset"]
     """Mass/pressure profile coefficients (copied from input)."""
 
-    ac: jt.Float[np.ndarray, "preset"]
+    ac: jt.Float[np.ndarray, "_preset"]
     """Enclosed toroidal current profile coefficients (copied from input)."""
 
-    ai: jt.Float[np.ndarray, "preset"]
+    ai: jt.Float[np.ndarray, "_preset"]
     """Iota profile coefficients (copied from input)."""
 
-    am_aux_s: AuxSType[jt.Float[np.ndarray, "ndfmax"]]
+    am_aux_s: AuxSType[jt.Float[np.ndarray, "_ndfmax"]]
     """Spline mass/pressure profile: knot locations in ``s`` (copied from input)."""
 
-    am_aux_f: AuxFType[jt.Float[np.ndarray, "ndfmax"]]
+    am_aux_f: AuxFType[jt.Float[np.ndarray, "_ndfmax"]]
     """Spline mass/pressure profile: values at knots (copied from input)."""
 
-    ac_aux_s: AuxSType[jt.Float[np.ndarray, "ndfmax"]]
+    ac_aux_s: AuxSType[jt.Float[np.ndarray, "_ndfmax"]]
     """Spline toroidal current profile: knot locations in ``s`` (copied from input)."""
 
-    ac_aux_f: AuxFType[jt.Float[np.ndarray, "ndfmax"]]
+    ac_aux_f: AuxFType[jt.Float[np.ndarray, "_ndfmax"]]
     """Spline toroidal current profile: values at knots (copied from input)."""
 
-    ai_aux_s: AuxSType[jt.Float[np.ndarray, "ndfmax"]]
+    ai_aux_s: AuxSType[jt.Float[np.ndarray, "_ndfmax"]]
     """Spline iota profile: knot locations in ``s`` (copied from input)."""
 
-    ai_aux_f: AuxFType[jt.Float[np.ndarray, "ndfmax"]]
+    ai_aux_f: AuxFType[jt.Float[np.ndarray, "_ndfmax"]]
     """Spline iota profile: values at knots (copied from input)."""
 
     gamma: float

--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -1352,18 +1352,26 @@ class VmecWOut(BaseModelWithNumpy):
                         )
                     ):
                         # Extract the dimension names used for NetCDF wout when available
-                        shape_string = tuple(
-                            [
-                                map_dimension_names.get(dim.name, str(dim.name))
-                                if isinstance(dim, jt._array_types._NamedDim)
+                        annotation_dim_names = field_info.annotation.dim_str.split()
+                        inferred_shape: list[str] = []
+                        for dim, dim_default_name, annotation_dim_name in zip(
+                            field_info.annotation.dims,
+                            shape_string,
+                            annotation_dim_names,
+                            strict=True,
+                        ):
+                            dim_name: str | None = None
+                            if isinstance(dim, jt._array_types._NamedDim):
+                                dim_name = str(dim.name).lstrip("_")
+                            elif isinstance(dim, jt._array_types._AnonymousDim):
+                                if annotation_dim_name.startswith("_"):
+                                    dim_name = annotation_dim_name.lstrip("_")
+                            inferred_shape.append(
+                                map_dimension_names.get(dim_name, dim_name)
+                                if dim_name is not None
                                 else dim_default_name
-                                for dim, dim_default_name in zip(
-                                    field_info.annotation.dims,
-                                    shape_string,
-                                    strict=True,
-                                )
-                            ]
-                        )
+                            )
+                        shape_string = tuple(inferred_shape)
 
                     for dim_name, dim_size in zip(
                         shape_string, value_array.shape, strict=True

--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -1296,6 +1296,24 @@ class VmecWOut(BaseModelWithNumpy):
                 ): field_info
                 for field, field_info in VmecWOut.model_fields.items()
             }
+            # jaxtyping does not expose a stable public API for dimension marker
+            # types. Older versions expose `_AnonymousDim`, while newer versions
+            # expose `_anonymous_dim` (instance). Resolve both for compatibility.
+            array_types = getattr(jt, "_array_types", None)
+            named_dim_type = (
+                getattr(array_types, "_NamedDim", None)
+                if array_types is not None
+                else None
+            )
+            anonymous_dim_type = (
+                getattr(array_types, "_AnonymousDim", None)
+                if array_types is not None
+                else None
+            )
+            if anonymous_dim_type is None and array_types is not None:
+                anonymous_dim_instance = getattr(array_types, "_anonymous_dim", None)
+                if anonymous_dim_instance is not None:
+                    anonymous_dim_type = type(anonymous_dim_instance)
 
             # Operates under the assumption that the order of the fields in
             # model_fields and model_dump are the same.
@@ -1361,11 +1379,15 @@ class VmecWOut(BaseModelWithNumpy):
                             strict=True,
                         ):
                             dim_name: str | None = None
-                            if isinstance(dim, jt._array_types._NamedDim):
+                            if named_dim_type is not None and isinstance(
+                                dim, named_dim_type
+                            ):
                                 dim_name = str(dim.name).lstrip("_")
-                            elif isinstance(
-                                dim, jt._array_types._AnonymousDim
-                            ) and annotation_dim_name.startswith("_"):
+                            elif (
+                                anonymous_dim_type is not None
+                                and isinstance(dim, anonymous_dim_type)
+                                and annotation_dim_name.startswith("_")
+                            ):
                                 dim_name = annotation_dim_name.lstrip("_")
                             inferred_shape.append(
                                 map_dimension_names.get(dim_name, dim_name)

--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -1363,9 +1363,10 @@ class VmecWOut(BaseModelWithNumpy):
                             dim_name: str | None = None
                             if isinstance(dim, jt._array_types._NamedDim):
                                 dim_name = str(dim.name).lstrip("_")
-                            elif isinstance(dim, jt._array_types._AnonymousDim):
-                                if annotation_dim_name.startswith("_"):
-                                    dim_name = annotation_dim_name.lstrip("_")
+                            elif isinstance(
+                                dim, jt._array_types._AnonymousDim
+                            ) and annotation_dim_name.startswith("_"):
+                                dim_name = annotation_dim_name.lstrip("_")
                             inferred_shape.append(
                                 map_dimension_names.get(dim_name, dim_name)
                                 if dim_name is not None


### PR DESCRIPTION
`VmecWOut` NetCDF serialization assumed `jaxtyping._array_types._AnonymousDim` exists. With newer jaxtyping releases, that symbol may be absent (replaced by `_anonymous_dim`), causing runtime `AttributeError` in `test_init` wout IO/reference paths.

- **Compatibility fix: dim marker resolution**
  - Resolve jaxtyping dimension marker types via guarded lookup on `jt._array_types`:
    - named: `_NamedDim`
    - anonymous: `_AnonymousDim` **or** fallback to `type(_anonymous_dim)` when only the instance-style API is present.
- **Runtime behavior: robust dimension-name inference**
  - Keep existing inference behavior, but branch on resolved types instead of hard-coding a single private symbol.
  - If a marker type is unavailable, logic degrades safely to existing default dimension naming.
- **Code organization**
  - Compute marker-type resolution once before field iteration, then reuse in per-field shape inference.

```python
array_types = getattr(jt, "_array_types", None)
named_dim_type = getattr(array_types, "_NamedDim", None) if array_types is not None else None
anonymous_dim_type = getattr(array_types, "_AnonymousDim", None) if array_types is not None else None
if anonymous_dim_type is None and array_types is not None:
    anonymous_dim_instance = getattr(array_types, "_anonymous_dim", None)
    if anonymous_dim_instance is not None:
        anonymous_dim_type = type(anonymous_dim_instance)
```