### PR TITLE
Make the lambda Fourier resolution independent of the geometry

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -175,6 +175,20 @@ class VmecInput(BaseModelWithNumpy):
     """Number of toroidal Fourier harmonics; n = -ntor, -ntor+1, ..., -1, 0, 1, ...,
     ntor-1, ntor."""
 
+    mpol_geometry: int = -1
+    """Optional reduced poloidal resolution for the geometry (R, Z).
+
+    If in [1, mpol), R/Z modes with m >= mpol_geometry are held fixed while lambda keeps
+    the full mpol. < 0 (default) means geometry uses mpol.
+    """
+
+    ntor_geometry: int = -1
+    """Optional reduced toroidal resolution for the geometry (R, Z).
+
+    If in [0, ntor), R/Z modes with n > ntor_geometry are held fixed while lambda keeps
+    the full ntor. < 0 (default) means geometry uses ntor.
+    """
+
     ntheta: int = 0
     """Number of poloidal grid points (ntheta >= 0).
 

--- a/src/vmecpp/cpp/vmecpp/common/sizes/sizes.cc
+++ b/src/vmecpp/cpp/vmecpp/common/sizes/sizes.cc
@@ -14,13 +14,19 @@
 namespace vmecpp {
 
 Sizes::Sizes(const VmecINDATA& id)
-    : Sizes(id.lasym, id.nfp, id.mpol, id.ntor, id.ntheta, id.nzeta) {}
+    : Sizes(id.lasym, id.nfp, id.mpol, id.ntor, id.ntheta, id.nzeta,
+            id.mpol_geometry, id.ntor_geometry) {}
 
-Sizes::Sizes(bool lasym, int nfp, int mpol, int ntor, int ntheta, int nzeta)
+Sizes::Sizes(bool lasym, int nfp, int mpol, int ntor, int ntheta, int nzeta,
+             int mpol_geometry, int ntor_geometry)
     : lasym(lasym),
       nfp(nfp),
       mpol(mpol),
       ntor(ntor),
+      mpolGeometry((mpol_geometry < 1 || mpol_geometry > mpol) ? mpol
+                                                               : mpol_geometry),
+      ntorGeometry((ntor_geometry < 0 || ntor_geometry > ntor) ? ntor
+                                                               : ntor_geometry),
       ntheta(ntheta),
       nZeta(nzeta) {
   computeDerivedSizes();

--- a/src/vmecpp/cpp/vmecpp/common/sizes/sizes.h
+++ b/src/vmecpp/cpp/vmecpp/common/sizes/sizes.h
@@ -19,7 +19,8 @@ class Sizes {
   // object.
   explicit Sizes(const VmecINDATA& id);
 
-  Sizes(bool lasym, int nfp, int mpol, int ntor, int ntheta, int nzeta);
+  Sizes(bool lasym, int nfp, int mpol, int ntor, int ntheta, int nzeta,
+        int mpol_geometry = -1, int ntor_geometry = -1);
 
   // inputs from INDATA
 
@@ -34,6 +35,12 @@ class Sizes {
 
   // number of toroidal Fourier harmoncis
   int ntor;
+
+  // geometry-only resolution: R and Z modes with m >= mpolGeometry or
+  // n > ntorGeometry are frozen, while lambda keeps the full mpol/ntor.
+  // Equal to mpol/ntor unless a reduced geometry resolution was requested.
+  int mpolGeometry;
+  int ntorGeometry;
 
   // number of poloidal grid points
   int ntheta;

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -111,6 +111,8 @@ VmecINDATA::VmecINDATA() {
   nfp = 1;
   mpol = 6;
   ntor = 0;
+  mpol_geometry = -1;
+  ntor_geometry = -1;
   ntheta = 0;
   nzeta = 0;
 
@@ -250,6 +252,8 @@ absl::Status VmecINDATA::WriteTo(H5::H5File& file) const {
   WriteH5Dataset(nfp, "/indata/nfp", file);
   WriteH5Dataset(mpol, "/indata/mpol", file);
   WriteH5Dataset(ntor, "/indata/ntor", file);
+  WriteH5Dataset(mpol_geometry, "/indata/mpol_geometry", file);
+  WriteH5Dataset(ntor_geometry, "/indata/ntor_geometry", file);
   WriteH5Dataset(ntheta, "/indata/ntheta", file);
   WriteH5Dataset(nzeta, "/indata/nzeta", file);
   WriteH5Dataset(phiedge, "/indata/phiedge", file);
@@ -323,6 +327,14 @@ absl::Status VmecINDATA::LoadInto(VmecINDATA& m_indata, H5::H5File& from_file) {
   ReadH5Dataset(m_indata.nfp, "/indata/nfp", from_file);
   ReadH5Dataset(m_indata.mpol, "/indata/mpol", from_file);
   ReadH5Dataset(m_indata.ntor, "/indata/ntor", from_file);
+  // Added after the initial wout schema; read only when present so that files
+  // written before this field load with the defaults from the constructor.
+  if (from_file.nameExists("/indata/mpol_geometry")) {
+    ReadH5Dataset(m_indata.mpol_geometry, "/indata/mpol_geometry", from_file);
+  }
+  if (from_file.nameExists("/indata/ntor_geometry")) {
+    ReadH5Dataset(m_indata.ntor_geometry, "/indata/ntor_geometry", from_file);
+  }
   ReadH5Dataset(m_indata.ntheta, "/indata/ntheta", from_file);
   ReadH5Dataset(m_indata.nzeta, "/indata/nzeta", from_file);
   ReadH5Dataset(m_indata.phiedge, "/indata/phiedge", from_file);
@@ -505,6 +517,22 @@ absl::StatusOr<VmecINDATA> VmecINDATA::FromJson(
   }
   if (maybe_ntor->has_value()) {
     vmec_indata.ntor = maybe_ntor->value();
+  }
+
+  auto maybe_mpol_geometry = JsonReadInt(j, "mpol_geometry");
+  if (!maybe_mpol_geometry.ok()) {
+    return maybe_mpol_geometry.status();
+  }
+  if (maybe_mpol_geometry->has_value()) {
+    vmec_indata.mpol_geometry = maybe_mpol_geometry->value();
+  }
+
+  auto maybe_ntor_geometry = JsonReadInt(j, "ntor_geometry");
+  if (!maybe_ntor_geometry.ok()) {
+    return maybe_ntor_geometry.status();
+  }
+  if (maybe_ntor_geometry->has_value()) {
+    vmec_indata.ntor_geometry = maybe_ntor_geometry->value();
   }
 
   auto maybe_ntheta = JsonReadInt(j, "ntheta");
@@ -1083,6 +1111,8 @@ absl::StatusOr<std::string> VmecINDATA::ToJson() const {
   output["nfp"] = nfp;
   output["mpol"] = mpol;
   output["ntor"] = ntor;
+  output["mpol_geometry"] = mpol_geometry;
+  output["ntor_geometry"] = ntor_geometry;
   output["ntheta"] = ntheta;
   output["nzeta"] = nzeta;
 

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
@@ -79,6 +79,13 @@ class VmecINDATA {
   // ..., ntor-1, ntor
   int ntor;
 
+  // Optional reduced resolution for the geometry (R, Z). When in [1, mpol) /
+  // [0, ntor), R and Z modes above it are held fixed while lambda keeps the
+  // full mpol/ntor resolution. < 0 (or >= mpol/ntor) means "use mpol/ntor",
+  // i.e. geometry and lambda share resolution as before.
+  int mpol_geometry;
+  int ntor_geometry;
+
   // number of poloidal grid points; if odd: is rounded to next smaller even
   // number
   int ntheta;

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.cc
@@ -198,6 +198,42 @@ void FourierCoeffs::m1Constraint(double scalingFactor,
   }  // j
 }
 
+void FourierCoeffs::maskGeometryAbove(int mpolGeom, int ntorGeom) {
+  // Same surface range as decomposeInto (owned slab plus boundary).
+  int jMaxIncludingBoundary = nsMax_;
+  if (r_.nsMaxF1 == ns) {
+    jMaxIncludingBoundary = ns;
+  }
+
+  for (int jF = nsMin_; jF < jMaxIncludingBoundary; ++jF) {
+    for (int m = 0; m < s_.mpol; ++m) {
+      for (int n = 0; n < s_.ntor + 1; ++n) {
+        if (m < mpolGeom && n <= ntorGeom) {
+          continue;
+        }
+
+        int idx_fc = ((jF - nsMin_) * s_.mpol + m) * (s_.ntor + 1) + n;
+
+        rcc[idx_fc] = 0.0;
+        zsc[idx_fc] = 0.0;
+        if (s_.lthreed) {
+          rss[idx_fc] = 0.0;
+          zcs[idx_fc] = 0.0;
+        }
+        if (s_.lasym) {
+          rsc[idx_fc] = 0.0;
+          zcc[idx_fc] = 0.0;
+          if (s_.lthreed) {
+            rcs[idx_fc] = 0.0;
+            zss[idx_fc] = 0.0;
+          }
+        }
+        // lambda left untouched
+      }  // n
+    }  // m
+  }  // j
+}
+
 double FourierCoeffs::rzNorm(bool include_offset, int nsMinHere,
                              int nsMaxHere) const {
   // accumulator for local thread

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.h
@@ -31,6 +31,11 @@ class FourierCoeffs {
   void m1Constraint(double scalingFactor,
                     std::optional<int> jMax = std::nullopt);
 
+  // Zero R and Z coefficients with m >= mpolGeom or n > ntorGeom; lambda is
+  // left untouched. On the force, this holds geometry at mpolGeom/ntorGeom
+  // while lambda keeps the full mpol/ntor resolution.
+  void maskGeometryAbove(int mpolGeom, int ntorGeom);
+
   // Get the sum of squared coefficients for R and Z.
   // If includeOffset is false, the (0,0)-coefficients for cos(mu)*cos(nv) are
   // left out. The range of flux surface to count in is specified as [nsMinHere,

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -414,6 +414,12 @@ absl::StatusOr<bool> IdealMhdModel::update(
     int& m_last_full_update_nestor, FlowControl& m_fc, const int iter1,
     const int iter2, const VmecCheckpoint& checkpoint,
     const int iterations_before_checkpointing, bool verbose) {
+  // An axis re-guess after a bad Jacobian can repopulate high geometry modes
+  // directly, bypassing the force mask; clear them on the state each iteration.
+  if (s_.mpolGeometry < s_.mpol || s_.ntorGeometry < s_.ntor) {
+    m_decomposed_x.maskGeometryAbove(s_.mpolGeometry, s_.ntorGeometry);
+  }
+
   // preprocess Fourier coefficients of geometry
   m_decomposed_x.decomposeInto(m_physical_x, m_p_.scalxc);
   if (checkpoint == VmecCheckpoint::FOURIER_GEOMETRY_TO_START_WITH &&
@@ -807,6 +813,13 @@ absl::StatusOr<bool> IdealMhdModel::update(
     m_decomposed_f.zeroZForceForM1();
   }
 
+  // Freeze geometry above the reduced resolution before the invariant
+  // residuals (so frozen modes stay out of the convergence test) and before
+  // preconditioning (so they get no update).
+  if (s_.mpolGeometry < s_.mpol || s_.ntorGeometry < s_.ntor) {
+    m_decomposed_f.maskGeometryAbove(s_.mpolGeometry, s_.ntorGeometry);
+  }
+
   if (checkpoint == VmecCheckpoint::PHYSICAL_FORCES &&
       iter2 >= iterations_before_checkpointing) {
     return true;
@@ -866,6 +879,13 @@ absl::StatusOr<bool> IdealMhdModel::update(
   if (checkpoint == VmecCheckpoint::APPLY_RADIAL_PRECONDITIONER &&
       iter2 >= iterations_before_checkpointing) {
     return true;
+  }
+
+  // Re-freeze after preconditioning. The radial preconditioner is per-mode so
+  // it cannot reintroduce frozen modes; this keeps the preconditioned residual
+  // and the state update clean.
+  if (s_.mpolGeometry < s_.mpol || s_.ntorGeometry < s_.ntor) {
+    m_decomposed_f.maskGeometryAbove(s_.mpolGeometry, s_.ntorGeometry);
   }
 
   Eigen::Vector3d localFResPrecd;

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -475,22 +475,25 @@ PYBIND11_MODULE(_vmecpp, m) {
   // play well with OpenMP: only use it with max_thread=1 or OMP_NUM_THREADS=1!
   py::add_ostream_redirect(m, "ostream_redirect");
 
-  auto pyindata = py::class_<VmecINDATA>(m, "VmecINDATA")
-                      .def(py::init<>())
-                      .def("_set_mpol_ntor", &VmecINDATA::SetMpolNtor,
-                           py::arg("new_mpol"), py::arg("new_ntor"))
-                      .def("from_file", &VmecINDATA::FromFile)
-                      .def("from_json", &VmecINDATA::FromJson)
-                      .def("to_json", &VmecINDATA::ToJsonOrException)
-                      .def("copy", &VmecINDATA::Copy)
+  auto pyindata =
+      py::class_<VmecINDATA>(m, "VmecINDATA")
+          .def(py::init<>())
+          .def("_set_mpol_ntor", &VmecINDATA::SetMpolNtor, py::arg("new_mpol"),
+               py::arg("new_ntor"))
+          .def("from_file", &VmecINDATA::FromFile)
+          .def("from_json", &VmecINDATA::FromJson)
+          .def("to_json", &VmecINDATA::ToJsonOrException)
+          .def("copy", &VmecINDATA::Copy)
 
-                      // numerical resolution, symmetry assumption
-                      .def_readwrite("lasym", &VmecINDATA::lasym)
-                      .def_readwrite("nfp", &VmecINDATA::nfp)
-                      .def_readonly("mpol", &VmecINDATA::mpol)  // readonly!
-                      .def_readonly("ntor", &VmecINDATA::ntor)  // readonly!
-                      .def_readwrite("ntheta", &VmecINDATA::ntheta)
-                      .def_readwrite("nzeta", &VmecINDATA::nzeta);
+          // numerical resolution, symmetry assumption
+          .def_readwrite("lasym", &VmecINDATA::lasym)
+          .def_readwrite("nfp", &VmecINDATA::nfp)
+          .def_readonly("mpol", &VmecINDATA::mpol)  // readonly!
+          .def_readonly("ntor", &VmecINDATA::ntor)  // readonly!
+          .def_readwrite("ntheta", &VmecINDATA::ntheta)
+          .def_readwrite("nzeta", &VmecINDATA::nzeta)
+          .def_readwrite("mpol_geometry", &VmecINDATA::mpol_geometry)
+          .def_readwrite("ntor_geometry", &VmecINDATA::ntor_geometry);
 
   // multi-grid steps
   DefEigenProperty(pyindata, "ns_array", &VmecINDATA::ns_array);

--- a/tests/test_lambda_resolution.py
+++ b/tests/test_lambda_resolution.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+"""Tests for an independent lambda Fourier resolution.
+
+``mpol_geometry`` / ``ntor_geometry`` cap the geometry (R, Z) resolution below
+the working ``mpol`` / ``ntor`` while lambda keeps the full resolution. The
+tests drive cma with the geometry capped below its resolution and check that the
+capped modes are frozen at zero, that lambda is still resolved above the cap, and
+that a cap equal to the working resolution is a no-op.
+"""
+
+from pathlib import Path
+
+import numpy as np
+
+import vmecpp
+
+REPO_ROOT = Path(__file__).parent.parent
+TEST_DATA_DIR = REPO_ROOT / "src" / "vmecpp" / "cpp" / "vmecpp" / "test_data"
+
+
+def _modes_first(array: np.ndarray, mnmax: int) -> np.ndarray:
+    """Return ``array`` with the Fourier-mode axis (length ``mnmax``) first."""
+    a = np.asarray(array, dtype=float)
+    return a if a.shape[0] == mnmax else a.T
+
+
+def _cma(mpol_geometry: int = -1, ntor_geometry: int = -1) -> vmecpp.VmecInput:
+    """Cma capped at (mpol_geometry, ntor_geometry), run for a few iterations."""
+    return vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cma.json").model_copy(
+        update={
+            "mpol_geometry": mpol_geometry,
+            "ntor_geometry": ntor_geometry,
+            "ns_array": np.array([25], dtype=np.int64),
+            "ftol_array": np.array([1e-12]),
+            "niter_array": np.array([80], dtype=np.int64),
+            "return_outputs_even_if_not_converged": True,
+        }
+    )
+
+
+def test_geometry_cap_at_full_resolution_is_a_noop():
+    """A geometry cap equal to the working resolution must not change the run."""
+    baseline = vmecpp.run(_cma(), max_threads=1).wout  # mpol_geometry unset (-1)
+    full = _cma()
+    capped = vmecpp.run(
+        _cma(mpol_geometry=full.mpol, ntor_geometry=full.ntor), max_threads=1
+    ).wout
+
+    for name in ("rmnc", "zmns", "lmns"):
+        np.testing.assert_array_equal(
+            np.asarray(getattr(capped, name)), np.asarray(getattr(baseline, name))
+        )
+    assert capped.niter == baseline.niter
+
+
+def test_geometry_frozen_while_lambda_is_resolved():
+    """Above the geometry cap, R/Z stay at zero while lambda keeps content."""
+    mpol_geometry, ntor_geometry = 3, 4
+    inp = _cma(mpol_geometry=mpol_geometry, ntor_geometry=ntor_geometry)
+    wout = vmecpp.run(inp, max_threads=1).wout
+
+    xm = np.asarray(wout.xm)
+    xn = np.asarray(wout.xn)
+    mnmax = len(xm)
+    # Modes above the geometry cap: poloidal m >= cap or toroidal |n| > cap.
+    above_cap = (xm >= mpol_geometry) | (np.abs(xn) // inp.nfp > ntor_geometry)
+    assert above_cap.any()
+
+    rmnc = _modes_first(wout.rmnc, mnmax)[above_cap]
+    zmns = _modes_first(wout.zmns, mnmax)[above_cap]
+    lmns = _modes_first(wout.lmns, mnmax)[above_cap]
+
+    # Geometry above the cap is held at exactly zero.
+    assert np.max(np.abs(rmnc)) == 0.0
+    assert np.max(np.abs(zmns)) == 0.0
+    # Lambda above the cap is resolved and carries non-trivial content.
+    assert np.max(np.abs(lmns)) > 1e-10


### PR DESCRIPTION
Closes #524.

## Motivation

Lambda can carry higher spectral content than the boundary geometry needs. Today the only way to give lambda that resolution is to raise `mpol`/`ntor` for the whole state, which over-resolves R and Z as well. This adds two optional inputs, `mpol_geometry` and `ntor_geometry`, that cap the geometry resolution below the working `mpol`/`ntor` while lambda keeps the full `mpol`/`ntor`. Unset (the default), or set equal to `mpol`/`ntor`, they change nothing.

## Approach

The working resolution stays `mpol`/`ntor`, so every array, transform, and the lambda spectrum are unchanged; only the geometry (R, Z) is constrained. The boundary is zero-padded to `mpol`/`ntor` on input, so the geometry modes above the cap start at zero, and two masks hold them there:

- the R/Z spectral force above the cap is zeroed every iteration, before the invariant residual (so the frozen modes stay out of the convergence criterion) and before preconditioning (so they receive no update);
- the geometry state above the cap is zeroed at the top of each iteration, so a bad-Jacobian axis re-guess, which writes geometry modes directly, cannot reintroduce them.

Lambda's coefficients are never touched, so it is resolved at the full `mpol`/`ntor`.

## Changes

- `vmec_indata`: `mpol_geometry` / `ntor_geometry` inputs (default `-1` = use `mpol`/`ntor`), with JSON and HDF5 read/write.
- `sizes`: derive `mpolGeometry` / `ntorGeometry`, clamped so an unset or out-of-range value equals `mpol`/`ntor`.
- `fourier_coefficients`: `maskGeometryAbove(mpolGeom, ntorGeom)` zeros R/Z coefficients with `m >= mpolGeom` or `n > ntorGeom`, leaving lambda.
- `ideal_mhd_model`: mask the R/Z force after it is formed and again after preconditioning, and mask the geometry state at the top of `update`.
- `pybind_vmec.cc` / `__init__.py`: expose the two inputs.

## Validation

Unset, or set equal to `mpol`/`ntor`, the caps reproduce the un-capped `wout` array-for-array (the committed no-op test).

With the geometry capped below the working resolution, the R/Z coefficients above the cap are held at exactly zero while lambda is resolved above it. On an nfp=5 boundary run at `mpol=8`, capping the geometry at 6 converges in 926 iterations (`fsqr` 1e-11) with every R/Z mode above m=6 exactly zero and all 22 lambda modes above m=6 populated; reaching the same lambda resolution the old way, `mpol=8` throughout, takes 1037 iterations with the geometry over-resolved.

The geometry-state mask is what makes the cap hold through a bad-Jacobian axis re-guess; on clean runs it is a no-op, and a capped run is bit-identical with and without it. `test_init.py` is unchanged (the same pre-existing source-run failures with and without this change).

## Test

`tests/test_lambda_resolution.py` drives cma with the geometry capped below its resolution:
- a cap equal to the working resolution reproduces the un-capped `wout` array-for-array (`mpol_geometry`/`ntor_geometry` are a no-op at full resolution);
- below the cap, every R and Z coefficient is exactly zero while lambda carries non-trivial content, confirming the geometry is frozen and lambda is resolved independently.
