### PR TITLE
Restore external optimizer behavioral tests

### DIFF
--- a/tests/test_external_optimizers.py
+++ b/tests/test_external_optimizers.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+# <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+"""External optimizers reach force balance on axisymmetric and 3D cases.
+
+The Solov'ev equilibrium has a reproducible internal state, so the 2D test compares the
+full state vector with the native solver. In 3D, the poloidal parameterization is not
+unique and spectral condensation only regularizes that coordinate freedom. The 3D test
+therefore compares the residual and energy instead of coordinate-dependent Fourier
+coefficients.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "examples"))
+from external_optimizers import (  # type: ignore
+    make_model,
+    reference_equilibrium,
+    residual,
+    solve_newton_hvp,
+    solve_newton_krylov,
+    solve_newton_krylov_preconditioned,
+    solve_preconditioned_descent,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+SOLOVEV = ROOT / "examples" / "data" / "solovev.json"
+CTH_LIKE = ROOT / "examples" / "data" / "cth_like_fixed_bdy.json"
+CMA = ROOT / "src" / "vmecpp" / "cpp" / "vmecpp" / "test_data" / "cma.json"
+
+SOLVERS = (
+    solve_preconditioned_descent,
+    solve_newton_krylov,
+    solve_newton_krylov_preconditioned,
+    solve_newton_hvp,
+)
+
+
+def _solve_all(input_path):
+    return {solver.__name__: solver(input_path, ns=11) for solver in SOLVERS}
+
+
+@pytest.fixture(scope="module")
+def reference_2d():
+    return reference_equilibrium(SOLOVEV, ns=11)
+
+
+@pytest.fixture(scope="module")
+def reference_3d():
+    return reference_equilibrium(CTH_LIKE, ns=11)
+
+
+@pytest.fixture(scope="module")
+def solutions_2d():
+    return _solve_all(SOLOVEV)
+
+
+@pytest.fixture(scope="module")
+def solutions_3d():
+    return _solve_all(CTH_LIKE)
+
+
+def test_optimizers_reach_2d_equilibrium(reference_2d, solutions_2d):
+    x_star, w_star = reference_2d
+    for name, (x, result) in solutions_2d.items():
+        assert result.residual_norm < 1e-7, name
+        assert abs(result.energy - w_star) < 1e-8, name
+        assert np.linalg.norm(x - x_star) < 1e-5, name
+
+
+def test_optimizers_reach_3d_force_balance(reference_3d, solutions_3d):
+    _, w_star = reference_3d
+    for name, (_, result) in solutions_3d.items():
+        assert result.residual_norm < 1e-7, name
+        assert np.isclose(result.energy, w_star, rtol=1e-4, atol=0.0), name
+
+
+def test_preconditioner_reduces_newton_krylov_force_evaluations(solutions_3d):
+    plain = solutions_3d[solve_newton_krylov.__name__][1]
+    preconditioned = solutions_3d[solve_newton_krylov_preconditioned.__name__][1]
+    assert preconditioned.force_evals < plain.force_evals
+
+
+def test_hvp_newton_uses_fewer_outer_iterations_than_descent(solutions_3d):
+    newton = solutions_3d[solve_newton_hvp.__name__][1]
+    descent = solutions_3d[solve_preconditioned_descent.__name__][1]
+    assert newton.outer_iters < 20
+    assert newton.outer_iters < descent.outer_iters
+
+
+def test_cma_cold_start_exercises_non_axisymmetric_paths():
+    model = make_model(CMA, ns=25)
+    x0 = np.asarray(model.get_state(), float)
+    f0 = residual(model)(x0)
+    assert np.all(np.isfinite(f0))
+    assert np.linalg.norm(f0) > 0.0
+
+    rng = np.random.default_rng(0)
+    v = rng.standard_normal(x0.size)
+    hv = np.asarray(model.hessian_vector_product(np.ascontiguousarray(v)), float)
+    assert np.all(np.isfinite(hv))
+    assert np.linalg.norm(hv) > 0.0


### PR DESCRIPTION
## Problem

#618 changed the example's shared default input from the 2D Solov'ev case to the 3D CTH-like case. The optimizer test inherited that default and kept a strict internal-state comparison. All four solver cases then failed. #622 restored CI by deleting the entire test module, including force-balance, energy, preconditioner, HVP, and non-axisymmetric cold-start coverage.

The failed state-vector assertion is not a valid 3D oracle. The poloidal parameterization of a flux surface is nonunique; spectral condensation selects a parameterization, but the tested solvers reach weakly separated internal states dominated by the lambda sector. The reported states are nearby stationary points, not proven exact gauge copies. The Solov'ev state comparison remains useful because it is empirically reproducible across these solvers.

## Change

- Restore the deleted behavioral tests.
- Pass the Solov'ev and CTH-like input paths explicitly; tests do not inherit `DEFAULT_INPUT`.
- Run every solver once per case and reuse the module-scoped results.
- Keep strict residual, energy, and state checks on Solov'ev.
- Check raw force balance and relative energy agreement for all four solvers on the CTH-like case.
- Retain the preconditioner evaluation-count, HVP iteration-count, and CMA non-axisymmetric path checks.

There are no optional assertions, unavailable branch APIs, or repeated-evaluation workarounds. The separate `VmecModel.evaluate()` history defect is fixed in #626.

Closes the test-coverage part of #620.

## Verification

### Test fails on main

Main contains no optimizer test after #622:

```text
$ git show upstream/main:tests/test_external_optimizers.py
fatal: path 'tests/test_external_optimizers.py' exists on disk, but not in 'upstream/main'
```

Immediately before that deletion, the 3D default produced:

```text
$ pytest tests/test_external_optimizers.py::test_optimizer_reaches_equilibrium -q
>       assert np.linalg.norm(x - x_star) < 1e-5
E       AssertionError: assert np.float64(0.012047202036774236) < 1e-05
FAILED ...[solve_preconditioned_descent]
FAILED ...[solve_newton_krylov]
FAILED ...[solve_newton_krylov_preconditioned]
FAILED ...[solve_newton_hvp]
4 failed in 53.98s
```

### Test passes after fix

```text
$ uv run pytest tests/test_external_optimizers.py -q
.....                                                                    [100%]
5 passed in 65.25s
```

Pre-commit passes on the restored test module.
