### PR TITLE
Make raw VMEC forces history independent

### DIFF
--- a/src/vmecpp/_iteration.py
+++ b/src/vmecpp/_iteration.py
@@ -259,7 +259,7 @@ def solve_equilibrium(
             iter2 = force_iteration - bad_resets
 
             # Evolve: forward model, then convergence / damping / time step.
-            model.evaluate(iter1, iter2, precondition=True, legacy_m1_constraint=True)
+            model.evaluate(iter1, iter2, precondition=True, always_fix_m1_gauge=False)
             fsqr, fsqz, fsql = model.fsqr, model.fsqz, model.fsql
             rr = model.restart_reason
             finite = math.isfinite(fsqr) and math.isfinite(fsqz) and math.isfinite(fsql)

--- a/src/vmecpp/_iteration.py
+++ b/src/vmecpp/_iteration.py
@@ -259,7 +259,7 @@ def solve_equilibrium(
             iter2 = force_iteration - bad_resets
 
             # Evolve: forward model, then convergence / damping / time step.
-            model.evaluate(iter1, iter2)
+            model.evaluate(iter1, iter2, precondition=True, legacy_m1_constraint=True)
             fsqr, fsqz, fsql = model.fsqr, model.fsqz, model.fsql
             rr = model.restart_reason
             finite = math.isfinite(fsqr) and math.isfinite(fsqz) and math.isfinite(fsql)

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -422,7 +422,7 @@ absl::StatusOr<bool> IdealMhdModel::update(
     int& m_last_full_update_nestor, FlowControl& m_fc, const int iter1,
     const int iter2, const VmecCheckpoint& checkpoint,
     const int iterations_before_checkpointing, bool verbose,
-    M1ConstraintMode m1_constraint_mode) {
+    bool always_fix_m1_gauge) {
   // An axis re-guess after a bad Jacobian can repopulate high geometry modes
   // directly, bypassing the force mask; clear them on the state each iteration.
   if (s_.mpolGeometry < s_.mpol || s_.ntorGeometry < s_.ntor) {
@@ -814,8 +814,9 @@ absl::StatusOr<bool> IdealMhdModel::update(
   m_decomposed_f.m1Constraint(1.0 / std::numbers::sqrt2);
 
   // v8.50: ADD iter2<2 so reset=<WOUT_FILE> works
-  if (m1_constraint_mode == M1ConstraintMode::kEnforce || m_fc.fsqz < 1.0e-6 ||
-      iter2 < 2) {
+  const bool fix_m1_gauge =
+      always_fix_m1_gauge || m_fc.fsqz < 1.0e-6 || iter2 < 2;
+  if (fix_m1_gauge) {
     // ensure that the m=1 constraint is satisfied exactly
     // --> the corresponding m=1 coeffs of R,Z are constrained to be zero
     //     and thus must not be "forced" (by the time evol using gc) away from

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -421,7 +421,8 @@ absl::StatusOr<bool> IdealMhdModel::update(
     bool& m_need_restart, int& m_last_preconditioner_update,
     int& m_last_full_update_nestor, FlowControl& m_fc, const int iter1,
     const int iter2, const VmecCheckpoint& checkpoint,
-    const int iterations_before_checkpointing, bool verbose) {
+    const int iterations_before_checkpointing, bool verbose,
+    M1ConstraintMode m1_constraint_mode) {
   // An axis re-guess after a bad Jacobian can repopulate high geometry modes
   // directly, bypassing the force mask; clear them on the state each iteration.
   if (s_.mpolGeometry < s_.mpol || s_.ntorGeometry < s_.ntor) {
@@ -813,7 +814,8 @@ absl::StatusOr<bool> IdealMhdModel::update(
   m_decomposed_f.m1Constraint(1.0 / std::numbers::sqrt2);
 
   // v8.50: ADD iter2<2 so reset=<WOUT_FILE> works
-  if (m_fc.fsqz < 1.0e-6 || iter2 < 2) {
+  if (m1_constraint_mode == M1ConstraintMode::kEnforce || m_fc.fsqz < 1.0e-6 ||
+      iter2 < 2) {
     // ensure that the m=1 constraint is satisfied exactly
     // --> the corresponding m=1 coeffs of R,Z are constrained to be zero
     //     and thus must not be "forced" (by the time evol using gc) away from

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
@@ -7,6 +7,7 @@
 
 #include <Eigen/Dense>
 #include <climits>
+#include <cstdint>
 #include <span>
 
 #ifdef _OPENMP
@@ -34,7 +35,7 @@
 
 namespace vmecpp {
 
-enum class M1ConstraintMode { kLegacy, kEnforce };
+enum class M1ConstraintMode : std::uint8_t { kLegacy, kEnforce };
 
 // Implemented as a free function for easier testing and benchmarking.
 void deAliasConstraintForce(const RadialPartitioning& rp,

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
@@ -7,7 +7,6 @@
 
 #include <Eigen/Dense>
 #include <climits>
-#include <cstdint>
 #include <span>
 
 #ifdef _OPENMP
@@ -34,8 +33,6 @@
 #include "vmecpp/vmec/vmec_constants/vmec_constants.h"
 
 namespace vmecpp {
-
-enum class M1ConstraintMode : std::uint8_t { kLegacy, kEnforce };
 
 // Implemented as a free function for easier testing and benchmarking.
 void deAliasConstraintForce(const RadialPartitioning& rp,
@@ -74,7 +71,7 @@ class IdealMhdModel {
       int& m_last_full_update_nestor, FlowControl& m_fc, const int iter1,
       const int iter2, const VmecCheckpoint& checkpoint = VmecCheckpoint::NONE,
       const int iterations_before_checkpointing = INT_MAX, bool verbose = true,
-      M1ConstraintMode m1_constraint_mode = M1ConstraintMode::kLegacy);
+      bool always_fix_m1_gauge = false);
 
   // Coordinates which inverse-DFT routine to call for computing
   // the flux surface geometry and lambda on it from the provided Fourier

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
@@ -34,6 +34,8 @@
 
 namespace vmecpp {
 
+enum class M1ConstraintMode { kLegacy, kEnforce };
+
 // Implemented as a free function for easier testing and benchmarking.
 void deAliasConstraintForce(const RadialPartitioning& rp,
                             const FourierBasisFastPoloidal& fb, const Sizes& s_,
@@ -70,7 +72,8 @@ class IdealMhdModel {
       bool& m_need_restart, int& m_last_preconditioner_update,
       int& m_last_full_update_nestor, FlowControl& m_fc, const int iter1,
       const int iter2, const VmecCheckpoint& checkpoint = VmecCheckpoint::NONE,
-      const int iterations_before_checkpointing = INT_MAX, bool verbose = true);
+      const int iterations_before_checkpointing = INT_MAX, bool verbose = true,
+      M1ConstraintMode m1_constraint_mode = M1ConstraintMode::kLegacy);
 
   // Coordinates which inverse-DFT routine to call for computing
   // the flux surface geometry and lambda on it from the provided Fourier

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -226,11 +226,11 @@ class VmecModel {
   // lambda-constraint components. That raw gradient is what gradient-based
   // optimizers minimizing the MHD energy functional need; mhd_energy is already
   // set earlier in update(), so it is valid at the checkpoint too.
-  // The native iteration delays the exact m=1 projection based on the previous
-  // Z residual. External evaluations enforce it immediately so F(x) does not
-  // depend on the previously evaluated state.
+  // The native iteration leaves the m=1 gauge free until the previous Z
+  // residual crosses its threshold. External evaluations fix it immediately so
+  // F(x) does not depend on the previously evaluated state.
   void Evaluate(int iter1, int iter2, bool precondition = true,
-                bool legacy_m1_constraint = false) {
+                bool always_fix_m1_gauge = true) {
     ++force_eval_count_;
     bool need_restart = false;
     std::string error_message;
@@ -259,9 +259,7 @@ class VmecModel {
           *vmec_->decomposed_f_[0], *vmec_->physical_f_[0], need_restart,
           last_preconditioner_update_, last_full_update_nestor_, vmec_->fc_,
           iter1, iter2, checkpoint, checkpoint_after,
-          /*verbose=*/false,
-          legacy_m1_constraint ? vmecpp::M1ConstraintMode::kLegacy
-                               : vmecpp::M1ConstraintMode::kEnforce);
+          /*verbose=*/false, always_fix_m1_gauge);
       if (!s.ok()) {
         error_message = std::string(s.status().message());
       }
@@ -1267,7 +1265,7 @@ PYBIND11_MODULE(_vmecpp, m) {
                   py::arg("ns"), py::arg("initial_state") = std::nullopt)
       .def("evaluate", &VmecModel::Evaluate, py::arg("iter1"), py::arg("iter2"),
            py::arg("precondition") = true,
-           py::arg("legacy_m1_constraint") = false)
+           py::arg("always_fix_m1_gauge") = true)
       .def_property_readonly("need_restart", &VmecModel::need_restart)
       .def("perform_time_step", &VmecModel::PerformTimeStep,
            py::arg("velocity_scale"), py::arg("conjugation_parameter"),

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -226,7 +226,11 @@ class VmecModel {
   // lambda-constraint components. That raw gradient is what gradient-based
   // optimizers minimizing the MHD energy functional need; mhd_energy is already
   // set earlier in update(), so it is valid at the checkpoint too.
-  void Evaluate(int iter1, int iter2, bool precondition = true) {
+  // The native iteration delays the exact m=1 projection based on the previous
+  // Z residual. External evaluations enforce it immediately so F(x) does not
+  // depend on the previously evaluated state.
+  void Evaluate(int iter1, int iter2, bool precondition = true,
+                bool legacy_m1_constraint = false) {
     ++force_eval_count_;
     bool need_restart = false;
     std::string error_message;
@@ -255,7 +259,9 @@ class VmecModel {
           *vmec_->decomposed_f_[0], *vmec_->physical_f_[0], need_restart,
           last_preconditioner_update_, last_full_update_nestor_, vmec_->fc_,
           iter1, iter2, checkpoint, checkpoint_after,
-          /*verbose=*/false);
+          /*verbose=*/false,
+          legacy_m1_constraint ? vmecpp::M1ConstraintMode::kLegacy
+                               : vmecpp::M1ConstraintMode::kEnforce);
       if (!s.ok()) {
         error_message = std::string(s.status().message());
       }
@@ -1260,7 +1266,8 @@ PYBIND11_MODULE(_vmecpp, m) {
       .def_static("create", &VmecModel::Create, py::arg("indata"),
                   py::arg("ns"), py::arg("initial_state") = std::nullopt)
       .def("evaluate", &VmecModel::Evaluate, py::arg("iter1"), py::arg("iter2"),
-           py::arg("precondition") = true)
+           py::arg("precondition") = true,
+           py::arg("legacy_m1_constraint") = false)
       .def_property_readonly("need_restart", &VmecModel::need_restart)
       .def("perform_time_step", &VmecModel::PerformTimeStep,
            py::arg("velocity_scale"), py::arg("conjugation_parameter"),

--- a/tests/test_internal_gradient.py
+++ b/tests/test_internal_gradient.py
@@ -17,10 +17,17 @@ points in a different direction; both vanish at the converged equilibrium.
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from vmecpp.cpp import _vmecpp  # type: ignore
 
 SOLOVEV = Path(__file__).resolve().parents[1] / "examples" / "data" / "solovev.json"
+CTH_LIKE = (
+    Path(__file__).resolve().parents[1]
+    / "examples"
+    / "data"
+    / "cth_like_fixed_bdy.json"
+)
 
 
 def _model(ns: int = 11):
@@ -63,3 +70,38 @@ def test_cold_start_is_excluded():
     m = _model()
     m.evaluate(2, 2, False)
     assert np.all(np.isfinite(np.asarray(m.get_forces(), float)))
+
+
+@pytest.fixture(scope="module")
+def force_histories():
+    indata = _vmecpp.VmecINDATA.from_file(str(CTH_LIKE))
+    reference = _vmecpp.VmecModel.create(indata, 11)
+    reference.solve()
+    low_residual_state = np.asarray(reference.get_state(), float).copy()
+
+    model = _vmecpp.VmecModel.create(indata, 11)
+    high_residual_state = np.asarray(model.get_state(), float).copy()
+    model.evaluate(2, 2, False)
+    high_after_high = np.asarray(model.get_forces(), float).copy()
+
+    model.set_state(np.ascontiguousarray(low_residual_state))
+    model.evaluate(2, 2, False)
+    low_after_high = np.asarray(model.get_forces(), float).copy()
+    model.evaluate(2, 2, False)
+    low_after_low = np.asarray(model.get_forces(), float).copy()
+
+    model.set_state(np.ascontiguousarray(high_residual_state))
+    model.evaluate(2, 2, False)
+    high_after_low = np.asarray(model.get_forces(), float).copy()
+
+    return high_after_high, high_after_low, low_after_high, low_after_low
+
+
+def test_raw_force_is_independent_of_high_residual_history(force_histories):
+    _, _, low_after_high, low_after_low = force_histories
+    np.testing.assert_array_equal(low_after_high, low_after_low)
+
+
+def test_raw_force_is_independent_of_low_residual_history(force_histories):
+    high_after_high, high_after_low, _, _ = force_histories
+    np.testing.assert_array_equal(high_after_high, high_after_low)


### PR DESCRIPTION
> **Merge order:** independently mergeable. #582 must use the same enforced `m=1` projection for its exact HVP.

## Problem

`VmecModel.evaluate()` returns different forces for the same 3D state depending on the previously evaluated state. This breaks the advertised `F(x)` contract for external optimizers and finite-difference Hessian-vector products.

The discrepancy is not a stale transform buffer or `tcon` warmup. It is the legacy `m=1` projection gate. `IdealMhdModel::update()` tests the previous evaluation's `fsqz` before zeroing the constrained `fzcs` and `fzcc` coefficients. The current `fsqz` is computed later. Crossing the `1e-6` threshold therefore applies the previous state's projection policy once.

VMEC2000, educational VMEC, and jVMEC use the same previous-residual rule during native iteration. That trajectory behavior must remain available for compatibility, but it is not a valid default for a reusable force operator.

## Change

- Add an explicit `M1ConstraintMode` to the core update.
- Enforce the exact constrained subspace by default for `VmecModel.evaluate()`.
- Make the Python native-iteration loop opt into the legacy previous-residual policy.
- Add high-to-low and low-to-high history tests on the CTH-like 3D case.

Closes #624.

## Verification

### Test fails on main

```text
$ uv run pytest tests/test_internal_gradient.py -q
...FF                                                                    [100%]
E   AssertionError: Arrays are not equal
E   Mismatched elements: 36 / 1650 (2.18%)
E   Max absolute difference among violations: 1.55724155e-06
E   AssertionError: Arrays are not equal
E   Mismatched elements: 36 / 1650 (2.18%)
E   Max absolute difference among violations: 0.00027851
2 failed, 3 passed in 1.16s
```

### Test passes after fix

```text
$ uv run pytest tests/test_internal_gradient.py -q
.....                                                                    [100%]
5 passed in 23.78s

$ uv run pytest tests/ -q
183 passed, 2 skipped, 66 warnings in 34.51s

$ uv run pytest tests/test_internal_gradient.py tests/test_iteration.py -q
23 passed in 31.64s

$ cd src/vmecpp/cpp && bazel build //... && bazel test //vmecpp/...
Build completed successfully, 132 total actions
Executed 20 out of 20 tests: 20 tests pass
```

Pre-commit passes on all five changed files. The iteration suite verifies that the explicit legacy policy preserves the Python/native trajectory behavior.

