### PR TITLE
Fix typos in documentation

### DIFF
--- a/examples/data/README.md
+++ b/examples/data/README.md
@@ -1,13 +1,13 @@
 # Example input and output files for VMEC++
 
-A few cases are available for testing VMCE++ and experimenting with it:
+A few cases are available for testing VMEC++ and experimenting with it:
 
 1. `cth_like_fixed_bdy.json` - Stellarator case, similar to the Compact Toroidal Hybrid ([CTH](https://www.auburn.edu/cosam/departments/physics/research/plasma_physics/compact_toroidal_hybrid/index.htm)) device
    1. `input.cth_like_fixed_bdy` - Fortran namelist input file to be used with Fortran VMEC
    1. `cth_like_fixed_bdy.json` - JSON input file for VMEC++, derived from `input.cth_like_fixed_bdy` using [`indata2json`](https://github.com/jonathanschilling/indata2json)
    1. `wout_cth_like_fixed_bdy.nc` - NetCDF output file, produced using [`PARVMEC`](https://github.com/ORNL-Fusion/PARVMEC) from `input.cth_like_fixed_bdy`, for testing the loading of a `wout` file using VMEC++'s tooling
 
-1. `input.nfp4_QH_warm_start` - quasi-helically example for use with SIMSOPT
+1. `input.nfp4_QH_warm_start` - quasi-helical example for use with SIMSOPT
 
 1. `solovev` - axisymmetric Tokamak case, similar to the Solov'ev equilibrium used in the [1983 Hirshman & Whitson article](https://doi.org/10.1063/1.864116)
     1. `input.solovev` - Fortran namelist input file for use with Fortran VMEC

--- a/src/vmecpp/cpp/docker/tsan/README.md
+++ b/src/vmecpp/cpp/docker/tsan/README.md
@@ -1,6 +1,6 @@
 # OpenMP-aware ThreadSanitizer
 
-This is a tutorial how to build `clang` and `libomp` with ThreadSanitizer (TSan)
+This is a tutorial on how to build `clang` and `libomp` with ThreadSanitizer (TSan)
 support for being able to check OpenMP-parallelized C/C++ code.
 
 ## Perform ThreadSanitizer runs on code in the Proxima Fusion monorepo

--- a/src/vmecpp/cpp/docker/tsan/background_info.md
+++ b/src/vmecpp/cpp/docker/tsan/background_info.md
@@ -28,7 +28,7 @@ found here:
 - https://www.vi-hps.org/cms/upload/material/tw30/Archer.pdf (slide 8 and onwards)
 
 Turns out, this is **deprecated** as well and Archer was integrated into the
-LLVM project in the mean time.
+LLVM project in the meantime.
 
 This seems to be the **state of things as of Oct 2023**. Indeed, Archer can be
 found in the `llvm` source tree:
@@ -46,7 +46,7 @@ https://packages.ubuntu.com/jammy/clang
 ## Setting up a first test case
 
 TL;DR: This is an example commonly presented as a case for data races. As will
-be seen when running this example, the errornous output due to a data race is
+be seen when running this example, the erroneous output due to a data race is
 not reliably reproduced. Thus, skip this section if you are looking for an
 example that breaks reliably.
 
@@ -223,7 +223,7 @@ int main(int argc, char** argv) {
 }
 ```
 
-Compile it (for now without TSan to not clobber the console when things to
+Compile it (for now without TSan to not clobber the console when things go
 sideways):
 
 ```bash
@@ -313,7 +313,7 @@ Now run it (two threads should be enough to trigger the data race checks):
 OMP_NUM_THREADS=2 ./pi_example
 ```
 
-However, contrary to the expection, TSan report data races, even though the
+However, contrary to the expectation, TSan reports data races, even though the
 result is always computed correctly:
 
 ```
@@ -427,7 +427,7 @@ Now, adjust the command line as requested:
 OMP_NUM_THREADS=1 ARCHER_OPTIONS='verbose=1' TSAN_OPTIONS='ignore_noninstrumented_modules=1' ./pi_example
 ```
 
-and we gete:
+and we get:
 
 ```
 Archer detected OpenMP application with TSan, supplying OpenMP synchronization semantics
@@ -505,7 +505,7 @@ This is what we work on next.
 
 ## Build the stage1 demo using a custom toolchain
 
-from: https://bazel.build/tutorials/ccp-toolchain-config
+from: https://bazel.build/tutorials/cpp-toolchain-config
 
 This uses a system-provided `clang` installation (instead of the default
 compiler Bazel uses).
@@ -529,7 +529,7 @@ bazel build --config=clang_config //abseil-hello:hello_main
 bazel-bin/abseil-hello/hello_main "from Abseil"
 ```
 
-Fixed by added `-lm` to standard linker flags. This was inspired by:
+Fixed by adding `-lm` to standard linker flags. This was inspired by:
 https://github.com/bazelbuild/bazel/issues/934#issuecomment-193474914
 
 Even the unit test works if a recent version of `googletest` is used:
@@ -633,7 +633,7 @@ Delete the Bazel cache:
 bazel clean --expunge
 ```
 
-The PDF files of the slides mentioned in this articles are mirrored locally
+The PDF files of the slides mentioned in this article are mirrored locally
 here:
 
 https://drive.google.com/drive/folders/1NBNTr4jDQy951CoG-AYqpDfKKpNKNSzh?usp=sharing


### PR DESCRIPTION
Typo fixes in the documentation, no functional changes:

- `examples/data/README.md`: "VMCE++" corrected to "VMEC++"; "quasi-helically example" corrected to "quasi-helical example"
- `src/vmecpp/cpp/docker/tsan/README.md`: "a tutorial how to build" corrected to "a tutorial on how to build"
- `src/vmecpp/cpp/docker/tsan/background_info.md`: "errornous" corrected to "erroneous"; "expection" corrected to "expectation"; "TSan report" corrected to "TSan reports"; "gete" corrected to "get"; "in the mean time" corrected to "in the meantime"; "things to sideways" corrected to "things go sideways"; "Fixed by added" corrected to "Fixed by adding"; "this articles" corrected to "this article"; the Bazel tutorial link fixed from `ccp-toolchain-config` to `cpp-toolchain-config` (the former 404s)
