### PR TITLE
docs: fix 'As a Python package' example to reference `vmec_output`

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ print(vmec_output.mercier.iota)
 vmec_output.wout.save("wout_w7x.nc")
 ```
 
-All other output files are accessible via members of the `output` object called `threed1_volumetrics`, `jxbout` and `mercier`.
+All other output files are accessible via members of the `vmec_output` object called `threed1_volumetrics`, `jxbout` and `mercier`.
 
 ### With SIMSOPT
 


### PR DESCRIPTION
## What

In the README's [**Usage → As a Python package**](https://github.com/proximafusion/vmecpp/blob/main/README.md#as-a-python-package) section, the prose after the snippet refers to an `output` object:

> All other output files are accessible via members of the `output` object called `threed1_volumetrics`, `jxbout` and `mercier`.

…but the snippet names the run result `vmec_output`:

```python
vmec_output = vmecpp.run(vmec_input)
```

There is no `output` variable in this section, so a reader who follows the prose (`output.threed1_volumetrics`) hits a `NameError`. (`output` is only introduced later, in the internally-consistent Hot restart example.)

## Change

One-line docs fix: rename the reference in that sentence from `output` → `vmec_output` so it matches the variable defined in the same snippet.

Fixes #630