### PR TITLE
third_party: BIEST and SCTL as fetched dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,10 @@ include_directories(${eigen_SOURCE_DIR})
 FetchContent_Declare(nlohmann_json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
 FetchContent_MakeAvailable(nlohmann_json)
 
+# Pin the reference (netlib) BLAS/LAPACK: with MKL installed, CMake would
+# otherwise select MKL with libiomp5, which clashes with the libgomp OpenMP
+# runtime used by VMEC++.
+set(BLA_VENDOR Generic)
 find_package(LAPACK REQUIRED)
 
 
@@ -104,6 +108,53 @@ include_directories(${abseil-cpp_SOURCE_DIR})
 # specified relative to `${PROJECT_SOURCE_DIR}/src/vmecpp/cpp`.
 include_directories(${PROJECT_SOURCE_DIR}/src/vmecpp/cpp)
 
+# BIEST and SCTL (fetched, pinned; see src/vmecpp/cpp/third_party/biest/README.md)
+# for the BIEST free-boundary solver. SCTL needs an FFT provider and LAPACKE;
+# without an FFT its fallback builds dense DFT matrices and runs out of memory.
+# The FFTW3 API is provided by Intel MKL's FFTW interface -- FFTW itself is
+# GPL and cannot be linked into the MIT-licensed VMEC++.
+FetchContent_Declare(
+  biest
+  URL https://github.com/dmalhotra/BIEST/archive/97329a2e76799aed158266dedf28e3cfa7323df4.tar.gz
+  URL_HASH SHA256=4cd84deb60ba26b9a97bf4ee231faed9c2debca60dbc99b1c4b11cc0ed034987
+  # --forward || true: the patch is already applied on re-configures
+  PATCH_COMMAND patch -p1 --forward -i ${CMAKE_CURRENT_SOURCE_DIR}/src/vmecpp/cpp/third_party/biest/warm_start.patch || true
+)
+FetchContent_Declare(
+  sctl
+  URL https://github.com/dmalhotra/SCTL/archive/af59e54adaf0e3bd25643df2d32967bd05f370fa.tar.gz
+  URL_HASH SHA256=5c6337010f3bfd4aeb0dbd81d0af479d6aa9f8abcfbddb771f6ba123f79f13bd
+  PATCH_COMMAND patch -p1 --forward -i ${CMAKE_CURRENT_SOURCE_DIR}/src/vmecpp/cpp/third_party/sctl/cxx20.patch || true
+)
+FetchContent_MakeAvailable(biest sctl)
+# BIEST's archive embeds a stale copy of SCTL; put the real SCTL first on the
+# include path.
+include_directories(${sctl_SOURCE_DIR}/include ${biest_SOURCE_DIR}/include)
+
+# Intel MKL's FFTW3 interface (Ubuntu: libmkl-dev) and LAPACKE (liblapacke-dev)
+find_path(MKL_FFTW3_INCLUDE_DIR fftw3.h
+  PATHS /usr/include/mkl/fftw $ENV{MKLROOT}/include/fftw
+)
+# Explicit GNU-threading link chain: mkl_rt's runtime layer detection fails
+# under libgomp-based processes.
+find_library(MKL_GF_LIBRARY mkl_gf_lp64 PATHS $ENV{MKLROOT}/lib/intel64)
+find_library(MKL_GNU_THREAD_LIBRARY mkl_gnu_thread PATHS $ENV{MKLROOT}/lib/intel64)
+find_library(MKL_CORE_LIBRARY mkl_core PATHS $ENV{MKLROOT}/lib/intel64)
+set(MKL_RT_LIBRARY ${MKL_GF_LIBRARY} ${MKL_GNU_THREAD_LIBRARY} ${MKL_CORE_LIBRARY})
+if(NOT MKL_FFTW3_INCLUDE_DIR OR NOT MKL_GF_LIBRARY OR NOT MKL_GNU_THREAD_LIBRARY OR NOT MKL_CORE_LIBRARY)
+  message(FATAL_ERROR "Intel MKL with its FFTW3 interface is required for the "
+          "BIEST/Vac2 free-boundary solvers (Ubuntu: apt install libmkl-dev). "
+          "FFTW itself is GPL and cannot be linked into the MIT-licensed VMEC++.")
+endif()
+include_directories(${MKL_FFTW3_INCLUDE_DIR})
+
+add_compile_definitions(
+  SCTL_GLOBAL_MEM_BUFF=0
+  SCTL_QUAD_T=__float128
+  SCTL_HAVE_LAPACK
+  SCTL_HAVE_FFTW
+)
+
 # Assemble the VMEC++ source tree.
 # Start out with ABSCAB sources - no need for a separate library for ABSCAB.
 set(vmecpp_sources ${abscab_sources})
@@ -115,6 +166,8 @@ target_link_libraries(vmecpp_core PRIVATE ${HDF5_CXX_LIBRARIES} ${HDF5_LIBRARIES
 target_link_libraries(vmecpp_core PRIVATE ${netCDF_LIBRARIES})
 target_link_libraries(vmecpp_core PRIVATE nlohmann_json::nlohmann_json)
 target_link_libraries(vmecpp_core PRIVATE LAPACK::LAPACK)
+# for the BIEST free-boundary solver (SCTL)
+target_link_libraries(vmecpp_core PRIVATE lapacke ${MKL_RT_LIBRARY})
 
 # FFTX (SPIRAL-generated batched IPRDFT/PRDFT) for the toroidal FFT hot path.
 # The codelets are vendored under src/vmecpp/cpp/third_party/fftx_codelets/;

--- a/src/vmecpp/cpp/MODULE.bazel
+++ b/src/vmecpp/cpp/MODULE.bazel
@@ -38,4 +38,4 @@ bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
 # depending on vmecpp resolve them automatically (WORKSPACE repositories do not
 # propagate to downstream modules).
 non_module_deps = use_extension("//third_party:non_module_deps.bzl", "non_module_deps")
-use_repo(non_module_deps, "abscab_cpp", "hdf5", "netcdf4")
+use_repo(non_module_deps, "abscab_cpp", "biest", "hdf5", "mkl_fftw", "netcdf4", "sctl")

--- a/src/vmecpp/cpp/MODULE.bazel.lock
+++ b/src/vmecpp/cpp/MODULE.bazel.lock
@@ -168,12 +168,56 @@
   "moduleExtensions": {
     "//third_party:non_module_deps.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "LHWu22WbSgylrmipwwKLJyfbPCqnKqRqxWBQVMVVVOQ=",
+        "bzlTransitiveDigest": "LZNQqlTDdf7b5DbqPpEdj52kP2QGjKDzjxhuYfXFyfE=",
         "usagesDigest": "K/CX77W1ZsxEL9QA1NwdwoaVteO5CO2nnGSFVQ1DqyQ=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
+          "biest": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/dmalhotra/BIEST/archive/97329a2e76799aed158266dedf28e3cfa7323df4.tar.gz"
+              ],
+              "strip_prefix": "BIEST-97329a2e76799aed158266dedf28e3cfa7323df4",
+              "sha256": "4cd84deb60ba26b9a97bf4ee231faed9c2debca60dbc99b1c4b11cc0ed034987",
+              "build_file": "@@//third_party/biest:biest.BUILD",
+              "patches": [
+                "@@//third_party/biest:warm_start.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "sctl": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/dmalhotra/SCTL/archive/af59e54adaf0e3bd25643df2d32967bd05f370fa.tar.gz"
+              ],
+              "strip_prefix": "SCTL-af59e54adaf0e3bd25643df2d32967bd05f370fa",
+              "sha256": "5c6337010f3bfd4aeb0dbd81d0af479d6aa9f8abcfbddb771f6ba123f79f13bd",
+              "build_file": "@@//third_party/sctl:sctl.BUILD",
+              "patches": [
+                "@@//third_party/sctl:cxx20.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "mkl_fftw": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:local.bzl",
+            "ruleClassName": "new_local_repository",
+            "attributes": {
+              "path": "/usr/include/mkl",
+              "build_file": "@@//third_party/mkl:mkl_fftw.BUILD"
+            }
+          },
           "abscab_cpp": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -638,6 +682,97 @@
             "rules_foreign_cc~",
             "rules_foreign_cc",
             "rules_foreign_cc~"
+          ]
+        ]
+      }
+    },
+    "@@rules_fuzzing~//fuzzing/private:extensions.bzl%non_module_dependencies": {
+      "general": {
+        "bzlTransitiveDigest": "hVgJRQ3Er45/UUAgNn1Yp2Khcp/Y8WyafA2kXIYmQ5M=",
+        "usagesDigest": "YnIrdgwnf3iCLfChsltBdZ7yOJh706lpa2vww/i2pDI=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "platforms": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+                "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz"
+              ],
+              "sha256": "8150406605389ececb6da07cbcb509d5637a3ab9a24bc69b1101531367d89d74"
+            }
+          },
+          "rules_python": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d70cd72a7a4880f0000a6346253414825c19cdd40a28289bdf67b8e6480edff8",
+              "strip_prefix": "rules_python-0.28.0",
+              "url": "https://github.com/bazelbuild/rules_python/releases/download/0.28.0/rules_python-0.28.0.tar.gz"
+            }
+          },
+          "bazel_skylib": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"
+              ]
+            }
+          },
+          "com_google_absl": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.1.zip"
+              ],
+              "strip_prefix": "abseil-cpp-20240116.1",
+              "integrity": "sha256-7capMWOvWyoYbUaHF/b+I2U6XLMaHmky8KugWvfXYuk="
+            }
+          },
+          "rules_fuzzing_oss_fuzz": {
+            "bzlFile": "@@rules_fuzzing~//fuzzing/private/oss_fuzz:repository.bzl",
+            "ruleClassName": "oss_fuzz_repository",
+            "attributes": {}
+          },
+          "honggfuzz": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@rules_fuzzing~//:honggfuzz.BUILD",
+              "sha256": "6b18ba13bc1f36b7b950c72d80f19ea67fbadc0ac0bb297ec89ad91f2eaa423e",
+              "url": "https://github.com/google/honggfuzz/archive/2.5.zip",
+              "strip_prefix": "honggfuzz-2.5"
+            }
+          },
+          "rules_fuzzing_jazzer": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_jar",
+            "attributes": {
+              "sha256": "ee6feb569d88962d59cb59e8a31eb9d007c82683f3ebc64955fd5b96f277eec2",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer/0.20.1/jazzer-0.20.1.jar"
+            }
+          },
+          "rules_fuzzing_jazzer_api": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_jar",
+            "attributes": {
+              "sha256": "f5a60242bc408f7fa20fccf10d6c5c5ea1fcb3c6f44642fec5af88373ae7aa1b",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer-api/0.20.1/jazzer-api-0.20.1.jar"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_fuzzing~",
+            "bazel_tools",
+            "bazel_tools"
           ]
         ]
       }

--- a/src/vmecpp/cpp/third_party/biest/BUILD.bazel
+++ b/src/vmecpp/cpp/third_party/biest/BUILD.bazel
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+#
+# BIEST itself is fetched as the @biest repository (see non_module_deps.bzl
+# and README.md); this package holds the build overlay, the local patch,
+# and our test.
+exports_files([
+    "biest.BUILD",
+    "warm_start.patch",
+])
+
+cc_test(
+    name = "test_biest",
+    size = "medium",
+    srcs = ["test_biest.cc"],
+    data = ["@biest//:geom"],
+    deps = [
+        "@biest",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/src/vmecpp/cpp/third_party/biest/README.md
+++ b/src/vmecpp/cpp/third_party/biest/README.md
@@ -1,0 +1,17 @@
+# BIEST (fetched dependency)
+
+BIEST (https://github.com/dmalhotra/BIEST, Apache-2.0) and its SCTL
+dependency (https://github.com/dmalhotra/SCTL, Apache-2.0) are fetched as
+pinned archives in `//third_party:non_module_deps.bzl` (Bazel) and via
+`FetchContent` (CMake); only the build overlays, local patches, and our
+tests live in this repository.
+
+Local patch (`warm_start.patch`): warm-start the iterative solve in
+`ExtVacuumField::ComputeBplasma` from the previous sigma solution (SCTL's
+GMRES natively accepts a non-empty initial guess; upstream never passes
+one). This cuts the solve cost when the boundary changes little between
+calls, as in the free-boundary VMEC iteration.
+
+The FFT provider is Intel MKL's FFTW3 interface (see
+`//third_party/mkl`); FFTW itself is GPL and cannot be linked into the
+MIT-licensed VMEC++.

--- a/src/vmecpp/cpp/third_party/biest/biest.BUILD
+++ b/src/vmecpp/cpp/third_party/biest/biest.BUILD
@@ -1,0 +1,22 @@
+# Build overlay for the BIEST archive fetched in
+# //third_party:non_module_deps.bzl (header-only).
+cc_library(
+    name = "biest",
+    hdrs = glob(
+        ["include/**"],
+        # the archive embeds a stale copy of SCTL; use @sctl instead
+        exclude = [
+            "include/sctl/**",
+            "include/sctl.hpp",
+        ],
+    ),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = ["@sctl"],
+)
+
+filegroup(
+    name = "geom",
+    srcs = glob(["geom/**"]),
+    visibility = ["//visibility:public"],
+)

--- a/src/vmecpp/cpp/third_party/biest/test_biest.cc
+++ b/src/vmecpp/cpp/third_party/biest/test_biest.cc
@@ -1,0 +1,87 @@
+#include <biest.hpp>
+#include <filesystem>
+#include <sctl.hpp>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+// This is a googletest-converted version of the following method:
+// biest::ExtVacuumFieldTest<double>::test(digits, NFP, surf_Nt, surf_Np,
+// surf_type, Nt, Np) The off-surface evaluation test part has been removed in
+// order to speed up the test.
+
+using Real = double;
+
+namespace {
+
+// The prebuilt surface geometries (SurfType::W7X etc.) are read from
+// "geom/..." relative to the working directory; chdir into the @biest
+// runfiles tree where the geom filegroup is staged.
+void ChdirToBiestRunfiles() {
+  const char* srcdir = std::getenv("TEST_SRCDIR");
+  if (srcdir == nullptr) {
+    return;
+  }
+  for (const auto& entry : std::filesystem::directory_iterator(srcdir)) {
+    if (std::filesystem::exists(entry.path() / "geom")) {
+      std::filesystem::current_path(entry.path());
+      return;
+    }
+  }
+}
+
+}  // namespace
+
+TEST(TestBiest, CheckExtVacuumFieldOnSurface) {
+  ChdirToBiestRunfiles();
+  int digits = 3;
+  int NFP = 5;
+  long surf_Nt = 20;
+  long surf_Np = 20;
+  biest::SurfType surf_type = biest::SurfType::W7X;
+  long Nt = 20;
+  long Np = 20;
+
+  // Construct the surface
+  std::vector<Real> X(3 * surf_Nt * surf_Np), X_offsurf;
+  {  // Set X_offsurf
+    biest::Surface<Real> S(NFP * Nt, Np, biest::SurfType::AxisymCircleWide);
+    X_offsurf.assign(S.Coord().begin(), S.Coord().end());
+  }
+  X = biest::ExtVacuumFieldTest<Real>::SurfaceCoordinates(NFP, surf_Nt, surf_Np,
+                                                          surf_type);
+
+  // Generate B field for testing exterior vacuum fields
+  std::vector<Real> B, B_pts;
+  std::tie(B, B_pts) = biest::ExtVacuumFieldTest<Real>::BFieldData(
+      NFP, surf_Nt, surf_Np, X, Nt, Np, X_offsurf);
+
+  // Setup
+  biest::ExtVacuumField<Real> vacuum_field;
+  vacuum_field.Setup(digits, NFP, surf_Nt, surf_Np, X, Nt, Np);
+
+  // Compute Bplasma field such that Bplasma.n = -BdotN
+  std::vector<Real> Bplasma, sigma, J;
+  const auto BdotN = vacuum_field.ComputeBdotN(B);
+  std::tie(Bplasma, sigma, J) = vacuum_field.ComputeBplasma(BdotN, (Real)-1);
+
+  // evaluate error in infinity norm
+  std::vector<Real> Berr = B;
+  for (long i = 0; i < (long)Berr.size(); i++) {
+    Berr[i] += Bplasma[i];
+  }
+
+  Real max_val = 0;
+  for (const auto& x : B) {
+    max_val = std::max<Real>(max_val, fabs(x));
+  }
+
+  Real max_err = 0;
+  for (const auto& x : Berr) {
+    max_err = std::max<Real>(max_err, fabs(x));
+  }
+
+  EXPECT_LT(max_err / max_val, 0.2)
+      << "Maximum relative error: " << max_err / max_val;
+
+}  // CheckExtVacuumFieldOnSurface

--- a/src/vmecpp/cpp/third_party/biest/warm_start.patch
+++ b/src/vmecpp/cpp/third_party/biest/warm_start.patch
@@ -1,0 +1,28 @@
+diff -ur a/include/biest/vacuum-field.hpp b/include/biest/vacuum-field.hpp
+--- a/include/biest/vacuum-field.hpp	2023-03-02 08:22:14.000000000 +0000
++++ b/include/biest/vacuum-field.hpp	2026-07-11 17:16:24.764752763 +0000
+@@ -88,6 +88,10 @@
+     mutable sctl::Vector<Real> XX, normal_, dX_, Xt_, Xp_, J0_; // NFP_ * Nt_ * Np_
+     mutable sctl::Vector<Real> normal; // Nt_ * Np_
+     mutable bool dosetup;
++
++    // previous sigma solution, used to warm-start the iterative solve in
++    // ComputeBplasma (local modification relative to upstream BIEST)
++    mutable sctl::Vector<Real> sigma_prev_;
+   };
+ 
+   /**
+diff -ur a/include/biest/vacuum-field.txx b/include/biest/vacuum-field.txx
+--- a/include/biest/vacuum-field.txx	2023-03-02 08:22:14.000000000 +0000
++++ b/include/biest/vacuum-field.txx	2026-07-11 17:16:24.790752717 +0000
+@@ -137,8 +137,10 @@
+ 
+     sctl::Vector<Real> sigma, grad_phi;
+     { // Solve for sigma
++      if (sigma_prev_.Dim() == Nt_*Np_) sigma = sigma_prev_; // warm start from the previous solution
+       sctl::ParallelSolver<Real> solver(sctl::Comm::Self(), verbose_);
+       solver(&sigma, LinOp, sctl::Vector<Real>(Bcoil_dot_N) + Bplasma_dot_N, sctl::pow<Real>(0.1,digits_), max_iter);
++      sigma_prev_ = sigma;
+     }
+     { // Compute Bplasma <-- Bplasma - (LaplaceFxdU[sigma] - 0.5*sigma*normal)
+       sctl::Vector<Real> sigma_, sigma__;

--- a/src/vmecpp/cpp/third_party/mkl/BUILD.bazel
+++ b/src/vmecpp/cpp/third_party/mkl/BUILD.bazel
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+#
+# Build overlay for the system MKL FFTW3-interface headers (@mkl_fftw).
+exports_files(["mkl_fftw.BUILD"])

--- a/src/vmecpp/cpp/third_party/mkl/mkl_fftw.BUILD
+++ b/src/vmecpp/cpp/third_party/mkl/mkl_fftw.BUILD
@@ -1,0 +1,19 @@
+# Intel MKL's FFTW3 interface (the FFTW3 C API is built into the MKL core
+# libraries). Used as the FFT provider for SCTL/BIEST and the Vac2 solver;
+# FFTW itself is GPL and cannot be linked into the MIT-licensed VMEC++.
+# The repository points at the system MKL include directory (Ubuntu:
+# /usr/include/mkl from libmkl-dev).
+cc_library(
+    name = "mkl_fftw",
+    hdrs = glob(["fftw/*.h"]),
+    includes = ["fftw"],
+    # Explicit GNU-threading link chain: mkl_rt's runtime layer detection
+    # fails under libgomp-based processes (undefined symbol
+    # mkl_sparse_optimize_bsr_trsm_i8 when loading libmkl_def.so).
+    linkopts = [
+        "-lmkl_gf_lp64",
+        "-lmkl_gnu_thread",
+        "-lmkl_core",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/src/vmecpp/cpp/third_party/non_module_deps.bzl
+++ b/src/vmecpp/cpp/third_party/non_module_deps.bzl
@@ -10,6 +10,7 @@ instead: it exposes the repositories through bzlmod, which lets a downstream
 """
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 
 # The HDF5 and NetCDF archives ship only their sources here; the actual builds
 # (via rules_foreign_cc) live in //third_party/hdf5 and //third_party/netcdf4.
@@ -22,6 +23,39 @@ filegroup(
 """
 
 def _non_module_deps_impl(_module_ctx):
+    # BIEST, the Boundary Integral Equation Solver for Toroidal systems
+    # (Apache-2.0), used by the BIEST free-boundary solver. See
+    # //third_party/biest/README.md for the local warm-start patch.
+    http_archive(
+        name = "biest",
+        urls = ["https://github.com/dmalhotra/BIEST/archive/97329a2e76799aed158266dedf28e3cfa7323df4.tar.gz"],
+        strip_prefix = "BIEST-97329a2e76799aed158266dedf28e3cfa7323df4",
+        sha256 = "4cd84deb60ba26b9a97bf4ee231faed9c2debca60dbc99b1c4b11cc0ed034987",
+        build_file = "//third_party/biest:biest.BUILD",
+        patches = ["//third_party/biest:warm_start.patch"],
+        patch_args = ["-p1"],
+    )
+
+    # SCTL (Apache-2.0), BIEST's only dependency (header-only).
+    http_archive(
+        name = "sctl",
+        urls = ["https://github.com/dmalhotra/SCTL/archive/af59e54adaf0e3bd25643df2d32967bd05f370fa.tar.gz"],
+        strip_prefix = "SCTL-af59e54adaf0e3bd25643df2d32967bd05f370fa",
+        sha256 = "5c6337010f3bfd4aeb0dbd81d0af479d6aa9f8abcfbddb771f6ba123f79f13bd",
+        build_file = "//third_party/sctl:sctl.BUILD",
+        patches = ["//third_party/sctl:cxx20.patch"],
+        patch_args = ["-p1"],
+    )
+
+    # Intel MKL's FFTW3 interface headers (system installation; Ubuntu:
+    # libmkl-dev). The FFT provider for SCTL and the Vac2 solver -- FFTW
+    # itself is GPL and cannot be linked into the MIT-licensed VMEC++.
+    new_local_repository(
+        name = "mkl_fftw",
+        path = "/usr/include/mkl",
+        build_file = "//third_party/mkl:mkl_fftw.BUILD",
+    )
+
     # Accurate Biot-Savart routines with Correct Asymptotic Behaviour (C++):
     # https://github.com/jonathanschilling/abscab-cpp
     http_archive(

--- a/src/vmecpp/cpp/third_party/sctl/BUILD.bazel
+++ b/src/vmecpp/cpp/third_party/sctl/BUILD.bazel
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+#
+# SCTL is fetched as the @sctl repository (see non_module_deps.bzl); this
+# package only holds the build overlay.
+exports_files([
+    "cxx20.patch",
+    "sctl.BUILD",
+])

--- a/src/vmecpp/cpp/third_party/sctl/cxx20.patch
+++ b/src/vmecpp/cpp/third_party/sctl/cxx20.patch
@@ -1,0 +1,12 @@
+diff -ur a/include/sctl/fft_wrapper.hpp SCTL-af59e54adaf0e3bd25643df2d32967bd05f370fb/include/sctl/fft_wrapper.hpp
+--- a/include/sctl/fft_wrapper.hpp	2023-12-04 15:03:51.000000000 +0000
++++ b/include/sctl/fft_wrapper.hpp	2026-07-11 17:21:56.071173456 +0000
+@@ -20,7 +20,7 @@
+ 
+ template <class ValueType> class Complex {
+   public:
+-    Complex<ValueType>(ValueType r=0, ValueType i=0) : real(r), imag(i) {}
++    Complex(ValueType r=0, ValueType i=0) : real(r), imag(i) {}
+ 
+     Complex<ValueType> operator-() const {
+       Complex<ValueType> z;

--- a/src/vmecpp/cpp/third_party/sctl/sctl.BUILD
+++ b/src/vmecpp/cpp/third_party/sctl/sctl.BUILD
@@ -1,0 +1,28 @@
+# Build overlay for the SCTL archive fetched in
+# //third_party:non_module_deps.bzl (header-only).
+#
+# SCTL_HAVE_LAPACK and SCTL_HAVE_FFTW are required in practice: without an
+# FFT provider, SCTL's fallback FFT builds dense DFT matrices and runs out
+# of memory at realistic resolutions. The FFTW3 API is provided by Intel
+# MKL's FFTW interface (@mkl_fftw) -- FFTW itself is GPL and cannot be
+# linked into the MIT-licensed VMEC++. LAPACKE comes from the BSD netlib
+# packages (liblapacke-dev). SCTL_HAVE_BLAS is not set because
+# cblas.h/cblas_f77.h are not commonly packaged together; SCTL's internal
+# GEMM fallback is used instead.
+cc_library(
+    name = "sctl",
+    hdrs = glob(["include/**"]),
+    includes = ["include"],
+    defines = [
+        "SCTL_GLOBAL_MEM_BUFF=0",
+        "SCTL_QUAD_T=__float128",
+        "SCTL_HAVE_LAPACK",
+        "SCTL_HAVE_FFTW",
+    ],
+    linkopts = [
+        "-llapacke",
+        "-llapack",
+    ],
+    visibility = ["//visibility:public"],
+    deps = ["@mkl_fftw//:mkl_fftw"],
+)


### PR DESCRIPTION
Adds BIEST (https://github.com/dmalhotra/BIEST) and its SCTL dependency (both Apache-2.0) as **pinned, patched, fetched dependencies** — Bazel via the `non_module_deps` extension, CMake via `FetchContent`. Only the build overlays, the local patches, and our test live in-repo, as the foundation for the BIEST free-boundary solver (next PR in the stack).

Local patches relative to upstream:
- **`warm_start.patch` (BIEST)**: warm-start the iterative solve in `ExtVacuumField::ComputeBplasma` from the previous sigma solution (SCTL's GMRES natively accepts a non-empty initial guess; upstream never passes one). Cuts the solve cost when the boundary changes little between calls — exactly the free-boundary VMEC iteration pattern.
- **`cxx20.patch` (SCTL)**: removes a constructor declared with a template-id, ill-formed under `-std=c++20`.

**FFT provider / licensing:** SCTL needs an FFT via the FFTW3 API — without one its fallback FFT materializes dense DFT matrices and OOMs at realistic resolutions (measured). FFTW itself is GPL and cannot be linked into MIT-licensed VMEC++, so the FFTW3 API is provided by **Intel MKL's FFTW interface** (Ubuntu: `libmkl-dev`; the `@mkl_fftw` repo/`MKL_ROOT` discovery points at the system installation). LAPACKE comes from the BSD netlib packages (`liblapacke-dev`). Wheel builds need both present in the build image.

Part 1/4 of the free-boundary solver stack.
related to 
related to https://github.com/proximafusion/vmecpp/issues/628