### PR TITLE
free_boundary: BIEST solver, dual-run diagnostics, standalone harness

### DIFF
--- a/docs/free_boundary_solvers.md
+++ b/docs/free_boundary_solvers.md
@@ -1,0 +1,114 @@
+# Free-boundary solvers: NESTOR and BIEST
+
+VMEC++ supports two user-selectable solvers for the vacuum-field
+contribution to the free-boundary force (plus `only_coils` for
+verification):
+
+```json
+{
+  "free_boundary_method": "nestor",  // or "biest"
+  "biest_accuracy_digits": 8         // only used by biest, in [1, 14]
+}
+```
+
+or from Python:
+
+```python
+import vmecpp
+
+inp = vmecpp.VmecInput.from_file("input.json")
+inp.free_boundary_method = "biest"
+inp.biest_accuracy_digits = 8
+out = vmecpp.run(inp)
+```
+
+## NESTOR (default)
+
+The classic Merkel solver: exterior Neumann problem for a scalar magnetic
+potential, discretized with an analytic singularity subtraction and a dense
+LU solve in a truncated Fourier basis. Accuracy is limited by the low-order
+singular quadrature and, at high poloidal resolution, by the factorial
+growth of the analytic kernel coefficients (`c_mn ~ binom(2m, m)`), which
+caps the usable poloidal mode number at mpol <= ~12-16 on 3D geometries.
+Supports axisymmetric (`nzeta == 1`) configurations.
+
+## BIEST
+
+Solves the same exterior Neumann problem (vacuum field with `B . n = 0` on
+the LCFS and prescribed net toroidal current) with the BIEST boundary
+integral equation solver (Malhotra et al.,
+https://github.com/dmalhotra/BIEST): high-order partition-of-unity singular
+quadrature and a GMRES solve. `biest_accuracy_digits` sets the requested
+number of decimal digits of accuracy of both the quadrature and the GMRES
+tolerance.
+
+Compared to NESTOR at typical resolutions, the BIEST vacuum pressure is the
+more accurate one: NESTOR-vs-BIEST differences equal NESTOR's discretization
+error. In-loop, BIEST reaches a lower converged
+DELBSQ (vacuum/plasma pressure mismatch at the LCFS) than NESTOR.
+
+Requirements and limitations:
+
+- Requires `nzeta >= 4` (a true 3D toroidal discretization); use NESTOR for
+  axisymmetric runs.
+- Stellarator-symmetric (`lasym = false`) and non-symmetric boundaries are
+  supported.
+- System dependencies: Intel MKL's FFTW3 interface and LAPACKE
+  (Ubuntu: `libmkl-dev`, `liblapacke-dev`). FFTW itself is GPL and cannot
+  be linked into the MIT-licensed VMEC++.
+
+### Update strategy (important for convergence)
+
+VMEC++ calls the vacuum solver every iteration once the vacuum pressure is
+switched on. BIEST solves on the fresh boundary at every call, with a GMRES
+warm start from the previous solution (cheap once the boundary settles).
+`nvacskip` is effectively ignored by BIEST.
+
+This per-iteration tracking is essential: an experiment that instead kept
+the vacuum pressure frozen between full updates (every `nvacskip`-th
+iteration) stalled VMEC's descent at `fsq ~ 1e-3` on the CTH-like test
+case, while per-iteration updates converge to `ftol = 1e-10` in fewer
+iterations than NESTOR (421 vs 489) with a ~25% lower converged DELBSQ.
+
+NESTOR-style cheap partial updates (frozen singular-quadrature setup and
+net-current field, fresh coil-field right-hand side) are implemented but
+disabled by default: the frozen-setup inconsistency was observed to slow
+the descent (~1.7-2x iterations, occasional restarts) even at tight
+thresholds. For experiments they can be enabled by setting
+`VMECPP_BIEST_PARTIAL_DRIFT_TOL` (maximum boundary-coefficient drift since
+the last full solve, relative to the major radius, below which a partial
+update is used; e.g. `1e-5`).
+
+## Dual-run diagnostics
+
+For solver comparisons, both solvers can be run side by side on the same
+iteration; the configured `free_boundary_method` drives the run and the
+shadow solver's output is only recorded:
+
+```sh
+VMECPP_FB_SHADOW=nestor \
+VMECPP_FB_DUAL_DUMP=dual_dump.jsonl \
+  ./vmec_standalone input_with_biest.json
+```
+
+Each vacuum update appends one JSON line with both |B|^2/2 fields, both
+net-current integrals, and the boundary Fourier coefficients. Visualize
+with:
+
+```sh
+python tools/plot_fb_dual_run.py dual_dump.jsonl
+```
+
+which produces side-by-side imshow panels (primary | shadow | difference),
+the poloidal-spectrum evolution of both fields across the iteration, and
+scalar traces.
+
+`VMECPP_BIEST_TIMING=1` prints per-update setup/solve timings.
+
+A standalone A/B harness (no VMEC iteration; evaluates both solvers on the
+boundary given by `rbc`/`zbs` of an input file) is available as:
+
+```sh
+bazel run //vmecpp_tools/free_boundary_standalone -- input.json nestor
+bazel run //vmecpp_tools/free_boundary_standalone -- input.json biest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,8 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["T20"]
+"benchmarks/**" = ["T201"]
+"tools/**" = ["T201"]
 "**/*_test.py" = ["T20"]
 "examples/**" = ["T201"]
 

--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -19,6 +19,9 @@ import netCDF4
 import numpy as np
 import pydantic
 
+# _mkl_preload runs at import time and must be imported before the C++
+# extension (loaded below and by the vmecpp._* submodules)
+from vmecpp import _mkl_preload  # noqa: F401  # isort: skip
 from vmecpp import _util
 from vmecpp._continuation import _run_fourier_continuation, interpolate_solution
 from vmecpp._free_boundary import (
@@ -402,6 +405,10 @@ class VmecInput(BaseModelWithNumpy):
         pydantic.Field(),
     ] = FreeBoundaryMethod.NESTOR
     """Method for handling free-boundary conditions."""
+
+    biest_accuracy_digits: int = pydantic.Field(default=8, ge=1, le=14)
+    """Requested number of decimal digits of accuracy of the BIEST singular quadrature
+    and GMRES solve; only used for free_boundary_method BIEST."""
 
     iteration_style: typing.Annotated[
         IterationStyle,

--- a/src/vmecpp/_mkl_preload.py
+++ b/src/vmecpp/_mkl_preload.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+# <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+"""Make Intel MKL's internal kernel loading work under Python.
+
+The C++ core links MKL's FFTW3 interface (the FFT provider for the BIEST
+and Vac2 free-boundary solvers). MKL dispatches its computational kernels
+at runtime by dlopen-ing e.g. libmkl_def.so, which must resolve symbols
+from the MKL core/threading libraries. Python loads extension modules with
+RTLD_LOCAL, so that resolution fails ("undefined symbol: mkl_sparse_...")
+unless the MKL libraries are made globally visible first.
+"""
+
+import ctypes
+import os
+
+_MKL_LIBRARIES = (
+    "libmkl_core.so",
+    "libmkl_gnu_thread.so",
+    "libmkl_gf_lp64.so",
+)
+
+
+def preload_mkl() -> None:
+    """Load the MKL libraries with RTLD_GLOBAL | RTLD_LAZY (no-op without MKL)."""
+    for lib in _MKL_LIBRARIES:
+        try:
+            ctypes.CDLL(lib, mode=ctypes.RTLD_GLOBAL | os.RTLD_LAZY)
+        except OSError:
+            # MKL not present as shared libraries (e.g. statically linked
+            # builds); nothing to do.
+            return
+
+
+# run at import time: this module is imported (first) by vmecpp/__init__.py,
+# before the C++ extension is loaded
+preload_mkl()

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -157,6 +157,7 @@ VmecINDATA::VmecINDATA() {
   // extcur is left empty
   nvacskip = 1;
   free_boundary_method = FreeBoundaryMethod::NESTOR;
+  biest_accuracy_digits = 8;
 
   // tweaking parameters
   nstep = 10;
@@ -269,6 +270,7 @@ absl::Status VmecINDATA::WriteTo(H5::H5File& file) const {
   WriteH5Dataset(lfreeb, "/indata/lfreeb", file);
   WriteH5Dataset(mgrid_file, "/indata/mgrid_file", file);
   WriteH5Dataset(nvacskip, "/indata/nvacskip", file);
+  WriteH5Dataset(biest_accuracy_digits, "/indata/biest_accuracy_digits", file);
 
   // special treatment for enums
   WriteH5Dataset(ToString(free_boundary_method), "/indata/free_boundary_method",
@@ -350,6 +352,15 @@ absl::Status VmecINDATA::LoadInto(VmecINDATA& m_indata, H5::H5File& from_file) {
   ReadH5Dataset(m_indata.lfreeb, "/indata/lfreeb", from_file);
   ReadH5Dataset(m_indata.mgrid_file, "/indata/mgrid_file", from_file);
   ReadH5Dataset(m_indata.nvacskip, "/indata/nvacskip", from_file);
+
+  // Legacy way of checking for dataset existence
+  if (H5Lexists(from_file.getId(), "/indata/biest_accuracy_digits", 0) == 1) {
+    ReadH5Dataset(m_indata.biest_accuracy_digits,
+                  "/indata/biest_accuracy_digits", from_file);
+  } else {
+    // fall back to default value
+    m_indata.biest_accuracy_digits = 8;
+  }
 
   // special treatment for enums
   std::string fbdy_method_str;
@@ -815,6 +826,14 @@ absl::StatusOr<VmecINDATA> VmecINDATA::FromJson(
     }
   }
 
+  auto maybe_biest_accuracy_digits = JsonReadInt(j, "biest_accuracy_digits");
+  if (!maybe_biest_accuracy_digits.ok()) {
+    return maybe_biest_accuracy_digits.status();
+  }
+  if (maybe_biest_accuracy_digits->has_value()) {
+    vmec_indata.biest_accuracy_digits = maybe_biest_accuracy_digits->value();
+  }
+
   // -----------------------------------------------
 
   auto maybe_nstep = JsonReadInt(j, "nstep");
@@ -1154,6 +1173,7 @@ absl::StatusOr<std::string> VmecINDATA::ToJson() const {
   output["extcur"] = extcur;
   output["nvacskip"] = nvacskip;
   output["free_boundary_method"] = ToString(free_boundary_method);
+  output["biest_accuracy_digits"] = biest_accuracy_digits;
 
   // Tweaking Parameters
   output["nstep"] = nstep;
@@ -1418,16 +1438,13 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
           vmec_indata.nvacskip));
     }
 
-    // free_boundary_method
-    // For the current state of the code, we only accept NESTOR,
-    // but in the future [TODO(jons)] also all other (implemented) enum values
-    // are valid.
-    if (vmec_indata.free_boundary_method != FreeBoundaryMethod::NESTOR &&
-        vmec_indata.free_boundary_method != FreeBoundaryMethod::ONLY_COILS) {
-      return absl::InvalidArgumentError(
-          absl::StrFormat("input variable 'free_boundary_method' must be "
-                          "'nestor' or 'only_coils', but is %s\n",
-                          ToString(vmec_indata.free_boundary_method)));
+    // biest_accuracy_digits
+    if (vmec_indata.biest_accuracy_digits < 1 ||
+        vmec_indata.biest_accuracy_digits > 14) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "input variable biest_accuracy_digits needs to be in [1, 14], "
+          "but is %d\n",
+          vmec_indata.biest_accuracy_digits));
     }
   }
 

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
@@ -195,6 +195,10 @@ class VmecINDATA {
   // for the free-boundary force contribution
   FreeBoundaryMethod free_boundary_method;
 
+  // requested number of decimal digits of accuracy of the BIEST singular
+  // quadrature and GMRES solve; only used for free_boundary_method = BIEST
+  int biest_accuracy_digits;
+
   // ---------------------------------
   // tweaking parameters
 

--- a/src/vmecpp/cpp/vmecpp/free_boundary/CMakeLists.txt
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(biest)
+add_subdirectory(dual_solver)
 add_subdirectory(external_magnetic_field)
 add_subdirectory(free_boundary_base)
 add_subdirectory(laplace_solver)

--- a/src/vmecpp/cpp/vmecpp/free_boundary/biest/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/biest/BUILD.bazel
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+cc_library(
+    name = "biest",
+    srcs = ["biest.cc"],
+    hdrs = ["biest.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@abseil-cpp//absl/log:check",
+        "@biest",
+        "//vmecpp/common/util:util",
+        "//vmecpp/common/sizes:sizes",
+        "//vmecpp/free_boundary/free_boundary_base:free_boundary_base",
+    ],
+)

--- a/src/vmecpp/cpp/vmecpp/free_boundary/biest/CMakeLists.txt
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/biest/CMakeLists.txt
@@ -1,0 +1,5 @@
+list (APPEND vmecpp_sources
+  ${CMAKE_CURRENT_SOURCE_DIR}/biest.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/biest.h
+)
+set (vmecpp_sources "${vmecpp_sources}" PARENT_SCOPE)

--- a/src/vmecpp/cpp/vmecpp/free_boundary/biest/biest.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/biest/biest.cc
@@ -1,0 +1,301 @@
+// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+// <info@proximafusion.com>
+//
+// SPDX-License-Identifier: MIT
+#include "vmecpp/free_boundary/biest/biest.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+#include "absl/log/check.h"
+
+namespace vmecpp {
+
+Biest::Biest(const Sizes* s, const TangentialPartitioning* tp,
+             const MGridProvider* mgrid, int accuracy_digits,
+             std::span<double> coil_b_r_share, std::span<double> coil_b_p_share,
+             std::span<double> coil_b_z_share, std::span<double> b_plasma_share,
+             std::span<double> bSqVacShare, std::span<double> vacuum_b_r_share,
+             std::span<double> vacuum_b_phi_share,
+             std::span<double> vacuum_b_z_share)
+    : FreeBoundaryBase(s, tp, mgrid, bSqVacShare, vacuum_b_r_share,
+                       vacuum_b_phi_share, vacuum_b_z_share),
+      accuracy_digits_(accuracy_digits),
+      coil_b_r_share_(coil_b_r_share),
+      coil_b_p_share_(coil_b_p_share),
+      coil_b_z_share_(coil_b_z_share),
+      b_plasma_share_(b_plasma_share) {
+  CHECK_GE(accuracy_digits_, 1) << "BIEST accuracy_digits must be >= 1";
+  CHECK_LE(accuracy_digits_, 14) << "BIEST accuracy_digits must be <= 14";
+  // BIEST needs an actual 3D toroidal discretization; axisymmetric runs
+  // (nzeta == 1) must use NESTOR.
+  CHECK_GE(s_.nZeta, 4)
+      << "BIEST requires nzeta >= 4; use free_boundary_method = NESTOR "
+         "for axisymmetric configurations";
+  CHECK_EQ(static_cast<int>(coil_b_r_share_.size()), s_.nZnT);
+  CHECK_EQ(static_cast<int>(coil_b_p_share_.size()), s_.nZnT);
+  CHECK_EQ(static_cast<int>(coil_b_z_share_.size()), s_.nZnT);
+  CHECK_EQ(static_cast<int>(b_plasma_share_.size()),
+           3 * s_.nZeta * s_.nThetaEven);
+}
+
+bool Biest::update(
+    const std::span<const double> rCC, const std::span<const double> rSS,
+    const std::span<const double> rSC, const std::span<const double> rCS,
+    const std::span<const double> zSC, const std::span<const double> zCS,
+    const std::span<const double> zCC, const std::span<const double> zSS,
+    int signOfJacobian, const std::span<const double> rAxis,
+    const std::span<const double> zAxis, double* bSubUVac, double* bSubVVac,
+    double netToroidalCurrent, int ivacskip,
+    const VmecCheckpoint& vmec_checkpoint, bool at_checkpoint_iteration) {
+  if (vmec_checkpoint == VmecCheckpoint::VAC1_VACUUM &&
+      at_checkpoint_iteration) {
+    return true;
+  }
+
+  // Partial updates (ivacskip != 0) mirror NESTOR's strategy of freezing the
+  // expensive geometry-bound operator while tracking the moving boundary:
+  // the BIEST singular-quadrature setup (and the harmonic net-current field
+  // J0) are kept from the last full update, while the coil field is
+  // re-evaluated on the fresh boundary and the BIE is re-solved with a
+  // GMRES warm start from the previous sigma. Without this per-iteration
+  // tracking, the boundary force acts on a stale vacuum pressure and the
+  // VMEC descent stagnates.
+  //
+  // A partial update is promoted to a full one when the boundary has moved
+  // too far since the last full update: the frozen quadrature and normals
+  // are only a good approximation for small boundary displacements.
+  bool full_update = (ivacskip == 0) || !has_full_solution_;
+  if (!full_update) {
+    // relative boundary drift since the last full update, scaled by the
+    // major-radius coefficient
+    double max_drift = 0.0;
+    for (size_t mn = 0; mn < r_cc_at_last_full_update_.size(); ++mn) {
+      max_drift = std::max(max_drift,
+                           std::abs(rCC[mn] - r_cc_at_last_full_update_[mn]));
+    }
+    // Default: no partial updates (threshold 0 -> every update solves on
+    // the fresh boundary). Frozen-setup partial updates were observed to
+    // slow VMEC's convergence even at tight thresholds (1e-4: restarts and
+    // ~2x iterations; 1e-5: ~1.7x iterations on the CTH-like case), while
+    // the GMRES warm start already makes fresh solves cheap near
+    // convergence. The experimental threshold can be set via the
+    // VMECPP_BIEST_PARTIAL_DRIFT_TOL environment variable (relative to the
+    // major-radius coefficient).
+    static const double kMaxRelativeDriftForPartialUpdate = []() {
+      const char* env = std::getenv("VMECPP_BIEST_PARTIAL_DRIFT_TOL");
+      return env != nullptr ? std::atof(env) : 0.0;
+    }();
+    if (max_drift >= kMaxRelativeDriftForPartialUpdate * std::abs(rCC[0])) {
+      full_update = true;
+    }
+  }
+
+  sg_.update(rCC, rSS, rSC, rCS, zSC, zCS, zCC, zSS, signOfJacobian,
+             /*fullUpdate=*/true);
+
+  // Coil field only: the net toroidal plasma current is handed to BIEST as
+  // the poloidal circulation of B_plasma below, so the axis-filament
+  // contribution in ExternalMagneticField is disabled.
+  ef_.update(rAxis, zAxis, /*netToroidalCurrent=*/0.0);
+
+  const int nZeta = s_.nZeta;
+  const int nThetaEven = s_.nThetaEven;
+
+  // Deposit this thread's tangential partition of the cylindrical coil field
+  // into the shared full-surface buffers (VMEC layout: kl = l * nZeta + k).
+  for (int kl = tp_.ztMin; kl < tp_.ztMax; ++kl) {
+    coil_b_r_share_[kl] = ef_.interpBr[kl - tp_.ztMin];
+    coil_b_p_share_[kl] = ef_.interpBp[kl - tp_.ztMin];
+    coil_b_z_share_[kl] = ef_.interpBz[kl - tp_.ztMin];
+  }
+#ifdef _OPENMP
+#pragma omp barrier
+#endif  // _OPENMP
+
+  // The thread owning the start of the tangential partition performs the
+  // BIEST solve; results are shared through b_plasma_share_. This must be
+  // the same thread on every update (NOT an omp single, which any thread
+  // may execute) because the frozen quadrature setup and the GMRES warm
+  // start live in this instance's vacuum_field_ across updates.
+  if (tp_.ztMin == 0) {
+    const int num_surf = nZeta * nThetaEven;
+
+    // Expand the coil field from the reduced poloidal range [0, pi] to the
+    // full range using stellarator symmetry:
+    //   (B_R, B_phi, B_Z)(R, -phi, -Z) = (-B_R, B_phi, B_Z)(R, phi, Z).
+    std::vector<double> full_br(num_surf);
+    std::vector<double> full_bp(num_surf);
+    std::vector<double> full_bz(num_surf);
+    for (int kl = 0; kl < s_.nZnT; ++kl) {
+      const int l = kl / nZeta;
+      const int k = kl % nZeta;
+      const int idx_full = l * nZeta + k;
+      full_br[idx_full] = coil_b_r_share_[kl];
+      full_bp[idx_full] = coil_b_p_share_[kl];
+      full_bz[idx_full] = coil_b_z_share_[kl];
+    }
+    if (!s_.lasym) {
+      for (int l = 1; l < s_.nThetaReduced - 1; ++l) {
+        const int lRev = nThetaEven - l;
+        for (int k = 0; k < nZeta; ++k) {
+          const int kRev = (nZeta - k) % nZeta;
+          const int idx_src = l * nZeta + k;
+          const int idx_dst = lRev * nZeta + kRev;
+          full_br[idx_dst] = -coil_b_r_share_[idx_src];
+          full_bp[idx_dst] = coil_b_p_share_[idx_src];
+          full_bz[idx_dst] = coil_b_z_share_[idx_src];
+        }  // k
+      }  // l
+    }
+
+    // Surface coordinates and Cartesian coil field in BIEST layout:
+    // index (d * Nt + t) * Np + p with t = zeta index, p = theta index,
+    // covering one field period.
+    const int Nt = nZeta;
+    const int Np = nThetaEven;
+    std::vector<double> X(3 * num_surf);
+    std::vector<double> B_coil(3 * num_surf);
+    for (int k = 0; k < nZeta; ++k) {
+      const double cos_phi = sg_.cos_phi[k];
+      const double sin_phi = sg_.sin_phi[k];
+      for (int l = 0; l < nThetaEven; ++l) {
+        const int idx_vmec = l * nZeta + k;
+        const int idx_biest = k * Np + l;
+
+        X[0 * num_surf + idx_biest] = sg_.rcosuv[idx_vmec];
+        X[1 * num_surf + idx_biest] = sg_.rsinuv[idx_vmec];
+        X[2 * num_surf + idx_biest] = sg_.z1b[idx_vmec];
+
+        const double br = full_br[idx_vmec];
+        const double bp = full_bp[idx_vmec];
+        B_coil[0 * num_surf + idx_biest] = br * cos_phi - bp * sin_phi;
+        B_coil[1 * num_surf + idx_biest] = br * sin_phi + bp * cos_phi;
+        B_coil[2 * num_surf + idx_biest] = full_bz[idx_vmec];
+      }  // l
+    }  // k
+
+    const auto t0 = std::chrono::steady_clock::now();
+    if (full_update) {
+      // rebuilds the singular quadrature and the harmonic net-current field
+      // for the new boundary (expensive)
+      vacuum_field_.Setup(accuracy_digits_, s_.nfp, Nt, Np, X, Nt, Np);
+    }
+    const auto t1 = std::chrono::steady_clock::now();
+
+    // B_coil . n with BIEST's surface normal (from the last full update on
+    // partial updates, mirroring NESTOR's frozen kernel matrix)
+    const std::vector<double> b_coil_dot_n = vacuum_field_.ComputeBdotN(B_coil);
+
+    // Net toroidal plasma current as poloidal circulation of B_plasma;
+    // the sign convention relative to VMEC's theta orientation carries the
+    // sign of the Jacobian (the poloidal circulation direction of BIEST's
+    // harmonic surface current follows the handedness of the surface
+    // parameterization, which for VMEC's theta carries signgs).
+    const double j_plasma = signOfJacobian * MU_0 * netToroidalCurrent;
+
+    std::vector<double> b_plasma, sigma, j_surf;
+    std::tie(b_plasma, sigma, j_surf) =
+        vacuum_field_.ComputeBplasma(b_coil_dot_n, j_plasma);
+    const auto t2 = std::chrono::steady_clock::now();
+
+    static const bool print_timing =
+        std::getenv("VMECPP_BIEST_TIMING") != nullptr;
+    if (print_timing) {
+      const auto ms = [](auto dt) {
+        return std::chrono::duration<double, std::milli>(dt).count();
+      };
+      std::cout << "[biest] " << (full_update ? "full" : "partial")
+                << " update: setup " << ms(t1 - t0) << " ms, solve "
+                << ms(t2 - t1) << " ms\n";
+    }
+
+    for (int i = 0; i < 3 * num_surf; ++i) {
+      b_plasma_share_[i] = b_plasma[i];
+    }
+  }  // solver thread (tp_.ztMin == 0)
+#ifdef _OPENMP
+#pragma omp barrier
+#endif  // _OPENMP
+
+  // Each thread fills its tangential partition of the outputs.
+  const int num_surf = nZeta * nThetaEven;
+  double local_bSubUVac = 0.0;
+  double local_bSubVVac = 0.0;
+  for (int kl = tp_.ztMin; kl < tp_.ztMax; ++kl) {
+    const int l = kl / nZeta;
+    const int k = kl % nZeta;
+    const int idx_biest = k * nThetaEven + l;
+
+    const double plasma_bx = b_plasma_share_[0 * num_surf + idx_biest];
+    const double plasma_by = b_plasma_share_[1 * num_surf + idx_biest];
+    const double plasma_bz = b_plasma_share_[2 * num_surf + idx_biest];
+
+    const double cos_phi = sg_.cos_phi[k];
+    const double sin_phi = sg_.sin_phi[k];
+    const double plasma_br = cos_phi * plasma_bx + sin_phi * plasma_by;
+    const double plasma_bp = cos_phi * plasma_by - sin_phi * plasma_bx;
+
+    const double full_br = coil_b_r_share_[kl] + plasma_br;
+    const double full_bp = coil_b_p_share_[kl] + plasma_bp;
+    const double full_bz = coil_b_z_share_[kl] + plasma_bz;
+
+    // covariant components of the total vacuum field
+    const double bSubU =
+        full_br * sg_.rub[kl - tp_.ztMin] + full_bz * sg_.zub[kl - tp_.ztMin];
+    const double bSubV = full_br * sg_.rvb[kl - tp_.ztMin] +
+                         full_bz * sg_.zvb[kl - tp_.ztMin] +
+                         full_bp * sg_.r1b[kl];
+
+    local_bSubUVac += bSubU * s_.wInt[l];
+    local_bSubVVac += bSubV * s_.wInt[l];
+
+    // magnetic pressure from vacuum: |B|^2 / 2
+    bSqVacShare[kl] =
+        0.5 * (full_br * full_br + full_bp * full_bp + full_bz * full_bz);
+
+    // cylindrical components of the vacuum magnetic field
+    vacuum_b_r_share_[kl] = full_br;
+    vacuum_b_phi_share_[kl] = full_bp;
+    vacuum_b_z_share_[kl] = full_bz;
+  }  // kl
+  local_bSubUVac *= signOfJacobian * 2.0 * M_PI;
+
+#ifdef _OPENMP
+#pragma omp single
+#endif  // _OPENMP
+  {
+    *bSubUVac = 0.0;
+    *bSubVVac = 0.0;
+  }
+#ifdef _OPENMP
+#pragma omp barrier
+#endif  // _OPENMP
+
+#ifdef _OPENMP
+#pragma omp critical
+#endif  // _OPENMP
+  {
+    *bSubUVac += local_bSubUVac;
+    *bSubVVac += local_bSubVVac;
+  }
+#ifdef _OPENMP
+#pragma omp barrier
+#endif  // _OPENMP
+
+  if (full_update) {
+    r_cc_at_last_full_update_.assign(rCC.begin(), rCC.end());
+  }
+  has_full_solution_ = true;
+
+  if (vmec_checkpoint == VmecCheckpoint::VAC1_BSQVAC &&
+      at_checkpoint_iteration) {
+    return true;
+  }
+
+  return false;
+}  // update
+
+}  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/free_boundary/biest/biest.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/biest/biest.h
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+// <info@proximafusion.com>
+//
+// SPDX-License-Identifier: MIT
+#ifndef VMECPP_FREE_BOUNDARY_BIEST_BIEST_H_
+#define VMECPP_FREE_BOUNDARY_BIEST_BIEST_H_
+
+#include <biest.hpp>
+#include <span>
+#include <vector>
+
+#include "vmecpp/free_boundary/free_boundary_base/free_boundary_base.h"
+
+namespace vmecpp {
+
+// Free-boundary solver based on BIEST (Malhotra et al.,
+// https://github.com/dmalhotra/BIEST).
+//
+// Solves the same exterior Neumann problem as NESTOR: find the vacuum
+// magnetic field B_vac = B_coil + B_plasma such that B_vac . n = 0 on the
+// LCFS and the poloidal circulation of B_plasma equals the net toroidal
+// plasma current. B_plasma is represented by layer potentials,
+// grad(S[sigma]) + curl(S[J]), and sigma is obtained from a boundary
+// integral equation solved with GMRES using high-order partition-of-unity
+// singular quadrature. This replaces NESTOR's low-order singularity
+// subtraction and dense LU solve.
+//
+// The normal component of the coil field is evaluated with BIEST's own
+// surface normals (ComputeBdotN), which keeps the normal-orientation
+// convention internal to BIEST.
+//
+// Threading: update() is called by all OpenMP threads, each holding its own
+// Biest instance (mirroring Nestor). The threads cooperate through the
+// shared buffers passed to the constructor: each thread deposits the coil
+// field on its tangential partition, a single thread runs the BIEST solve,
+// and all threads then fill their partition of the vacuum-pressure outputs.
+//
+// Partial updates (ivacskip != 0) mirror NESTOR's strategy (which reuses
+// its LU decomposition and only refreshes the right-hand side): the
+// singular-quadrature setup and the harmonic net-current field are frozen
+// from the last full update, the coil field is re-evaluated on the fresh
+// boundary, and the boundary integral equation is re-solved with a GMRES
+// warm start from the previous solution. This keeps the vacuum pressure
+// tracking the moving boundary every iteration, which is essential for the
+// convergence of VMEC's descent (a stale vacuum pressure between full
+// updates was observed to stall the iteration).
+class Biest : public FreeBoundaryBase {
+ public:
+  // accuracy_digits: requested number of decimal digits of accuracy of the
+  // BIEST singular quadrature and GMRES solve.
+  // coil_b_{r,p,z}_share: shared scratch, size Sizes::nZnT.
+  // b_plasma_share: shared scratch, size 3 * nZeta * nThetaEven.
+  Biest(const Sizes* s, const TangentialPartitioning* tp,
+        const MGridProvider* mgrid, int accuracy_digits,
+        std::span<double> coil_b_r_share, std::span<double> coil_b_p_share,
+        std::span<double> coil_b_z_share, std::span<double> b_plasma_share,
+        std::span<double> bSqVacShare, std::span<double> vacuum_b_r_share,
+        std::span<double> vacuum_b_phi_share,
+        std::span<double> vacuum_b_z_share);
+
+  bool update(
+      const std::span<const double> rCC, const std::span<const double> rSS,
+      const std::span<const double> rSC, const std::span<const double> rCS,
+      const std::span<const double> zSC, const std::span<const double> zCS,
+      const std::span<const double> zCC, const std::span<const double> zSS,
+      int signOfJacobian, const std::span<const double> rAxis,
+      const std::span<const double> zAxis, double* bSubUVac, double* bSubVVac,
+      double netToroidalCurrent, int ivacskip,
+      const VmecCheckpoint& vmec_checkpoint = VmecCheckpoint::NONE,
+      bool at_checkpoint_iteration = false) override;
+
+ private:
+  int accuracy_digits_;
+
+  // shared across threads; see constructor docs for sizes
+  std::span<double> coil_b_r_share_;
+  std::span<double> coil_b_p_share_;
+  std::span<double> coil_b_z_share_;
+  std::span<double> b_plasma_share_;
+
+  // true once a full BIEST solve has populated the shared output buffers
+  bool has_full_solution_ = false;
+
+  // boundary Fourier coefficients (rCC) at the last full update, used to
+  // promote partial updates to full ones when the boundary has moved too
+  // far for the frozen quadrature setup to remain a good approximation
+  std::vector<double> r_cc_at_last_full_update_;
+
+  biest::ExtVacuumField<double> vacuum_field_;
+};
+
+}  // namespace vmecpp
+
+#endif  // VMECPP_FREE_BOUNDARY_BIEST_BIEST_H_

--- a/src/vmecpp/cpp/vmecpp/free_boundary/dual_solver/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/dual_solver/BUILD.bazel
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+cc_library(
+    name = "dual_solver",
+    srcs = ["dual_solver.cc"],
+    hdrs = ["dual_solver.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@abseil-cpp//absl/log:check",
+        "@nlohmann_json//:json",
+        "//vmecpp/free_boundary/free_boundary_base:free_boundary_base",
+    ],
+)

--- a/src/vmecpp/cpp/vmecpp/free_boundary/dual_solver/CMakeLists.txt
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/dual_solver/CMakeLists.txt
@@ -1,0 +1,5 @@
+list (APPEND vmecpp_sources
+  ${CMAKE_CURRENT_SOURCE_DIR}/dual_solver.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/dual_solver.h
+)
+set (vmecpp_sources "${vmecpp_sources}" PARENT_SCOPE)

--- a/src/vmecpp/cpp/vmecpp/free_boundary/dual_solver/dual_solver.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/dual_solver/dual_solver.cc
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+// <info@proximafusion.com>
+//
+// SPDX-License-Identifier: MIT
+#include "vmecpp/free_boundary/dual_solver/dual_solver.h"
+
+#include <fstream>
+#include <utility>
+
+#include "absl/log/check.h"
+#include "nlohmann/json.hpp"
+
+namespace vmecpp {
+
+DualSolver::DualSolver(
+    const Sizes* s, const TangentialPartitioning* tp,
+    const MGridProvider* mgrid, std::unique_ptr<FreeBoundaryBase> primary,
+    std::unique_ptr<FreeBoundaryBase> shadow,
+    std::span<const double> primary_b_sq_vac,
+    std::span<const double> shadow_b_sq_vac, double* shadow_b_sub_u_vac,
+    double* shadow_b_sub_v_vac, const std::string& dump_path,
+    std::span<double> bSqVacShare, std::span<double> vacuum_b_r_share,
+    std::span<double> vacuum_b_phi_share, std::span<double> vacuum_b_z_share)
+    : FreeBoundaryBase(s, tp, mgrid, bSqVacShare, vacuum_b_r_share,
+                       vacuum_b_phi_share, vacuum_b_z_share),
+      primary_(std::move(primary)),
+      shadow_(std::move(shadow)),
+      primary_b_sq_vac_(primary_b_sq_vac),
+      shadow_b_sq_vac_(shadow_b_sq_vac),
+      dump_path_(dump_path),
+      shadow_b_sub_u_vac_(shadow_b_sub_u_vac),
+      shadow_b_sub_v_vac_(shadow_b_sub_v_vac) {
+  CHECK(primary_ != nullptr);
+  CHECK(shadow_ != nullptr);
+}
+
+bool DualSolver::update(
+    const std::span<const double> rCC, const std::span<const double> rSS,
+    const std::span<const double> rSC, const std::span<const double> rCS,
+    const std::span<const double> zSC, const std::span<const double> zCS,
+    const std::span<const double> zCC, const std::span<const double> zSS,
+    int signOfJacobian, const std::span<const double> rAxis,
+    const std::span<const double> zAxis, double* bSubUVac, double* bSubVVac,
+    double netToroidalCurrent, int ivacskip,
+    const VmecCheckpoint& vmec_checkpoint, bool at_checkpoint_iteration) {
+  // The primary result drives the iteration; run it first so a checkpoint
+  // stop behaves exactly like a run without the shadow.
+  const bool reached_checkpoint =
+      primary_->update(rCC, rSS, rSC, rCS, zSC, zCS, zCC, zSS, signOfJacobian,
+                       rAxis, zAxis, bSubUVac, bSubVVac, netToroidalCurrent,
+                       ivacskip, vmec_checkpoint, at_checkpoint_iteration);
+  if (reached_checkpoint) {
+    return true;
+  }
+
+  // The shadow solver sees exactly the same inputs; its outputs go to
+  // separate buffers and are only dumped.
+  shadow_->update(rCC, rSS, rSC, rCS, zSC, zCS, zCC, zSS, signOfJacobian, rAxis,
+                  zAxis, shadow_b_sub_u_vac_, shadow_b_sub_v_vac_,
+                  netToroidalCurrent, ivacskip, VmecCheckpoint::NONE,
+                  /*at_checkpoint_iteration=*/false);
+
+  update_counter_++;
+
+#ifdef _OPENMP
+#pragma omp single
+#endif  // _OPENMP
+  {
+    // one JSON line per vacuum update
+    nlohmann::json record;
+    record["update_index"] = update_counter_;
+    record["ivacskip"] = ivacskip;
+    record["n_theta_eff"] = s_.nThetaEff;
+    record["n_zeta"] = s_.nZeta;
+    record["net_toroidal_current"] = netToroidalCurrent;
+    record["primary_b_sub_u_vac"] = *bSubUVac;
+    record["primary_b_sub_v_vac"] = *bSubVVac;
+    record["shadow_b_sub_u_vac"] = *shadow_b_sub_u_vac_;
+    record["shadow_b_sub_v_vac"] = *shadow_b_sub_v_vac_;
+    record["primary_b_sq_vac"] =
+        std::vector<double>(primary_b_sq_vac_.begin(), primary_b_sq_vac_.end());
+    record["shadow_b_sq_vac"] =
+        std::vector<double>(shadow_b_sq_vac_.begin(), shadow_b_sq_vac_.end());
+    record["rCC"] = std::vector<double>(rCC.begin(), rCC.end());
+    record["rSS"] = std::vector<double>(rSS.begin(), rSS.end());
+    record["zSC"] = std::vector<double>(zSC.begin(), zSC.end());
+    record["zCS"] = std::vector<double>(zCS.begin(), zCS.end());
+
+    std::ofstream dump_file(dump_path_, std::ios::app);
+    dump_file << record << "\n";
+  }
+
+  return false;
+}  // update
+
+}  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/free_boundary/dual_solver/dual_solver.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/dual_solver/dual_solver.h
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+// <info@proximafusion.com>
+//
+// SPDX-License-Identifier: MIT
+#ifndef VMECPP_FREE_BOUNDARY_DUAL_SOLVER_DUAL_SOLVER_H_
+#define VMECPP_FREE_BOUNDARY_DUAL_SOLVER_DUAL_SOLVER_H_
+
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "vmecpp/free_boundary/free_boundary_base/free_boundary_base.h"
+
+namespace vmecpp {
+
+// Diagnostic decorator that runs two free-boundary solvers side by side.
+//
+// The primary solver drives the VMEC iteration: its outputs land in the
+// shared buffers that IdealMhdModel consumes. The shadow solver writes into
+// separate buffers that only appear in the dump. After every vacuum update,
+// one JSON line per update is appended to the dump file with both |B|^2/2
+// fields, both net-current integrals, and the boundary Fourier
+// coefficients, so that the evolution of the two solvers can be compared
+// across the iteration (see tools/plot_fb_dual_run.py).
+//
+// This class is constructed by Vmec when the environment variables
+// VMECPP_FB_SHADOW (nestor|biest) and VMECPP_FB_DUAL_DUMP (output path,
+// JSON lines) are set. It is a pure diagnostic: the shadow result never
+// feeds back into the iteration.
+class DualSolver : public FreeBoundaryBase {
+ public:
+  // primary/shadow: the two solvers, already wired to their respective
+  // output buffers. primary must be wired to the real shared buffers used
+  // by IdealMhdModel; shadow to separate scratch buffers.
+  // {primary,shadow}_b_sq_vac: the |B|^2/2 output buffers of the two
+  // solvers, for dumping.
+  // dump_path: file to append JSON-lines records to (one per vacuum
+  // update); opened by the thread that owns the dump (thread 0).
+  // shadow_b_sub_{u,v}_vac: shared (across threads) locations receiving the
+  // shadow solver's net-current integrals; only used for the dump.
+  DualSolver(const Sizes* s, const TangentialPartitioning* tp,
+             const MGridProvider* mgrid,
+             std::unique_ptr<FreeBoundaryBase> primary,
+             std::unique_ptr<FreeBoundaryBase> shadow,
+             std::span<const double> primary_b_sq_vac,
+             std::span<const double> shadow_b_sq_vac,
+             double* shadow_b_sub_u_vac, double* shadow_b_sub_v_vac,
+             const std::string& dump_path, std::span<double> bSqVacShare,
+             std::span<double> vacuum_b_r_share,
+             std::span<double> vacuum_b_phi_share,
+             std::span<double> vacuum_b_z_share);
+
+  bool update(
+      const std::span<const double> rCC, const std::span<const double> rSS,
+      const std::span<const double> rSC, const std::span<const double> rCS,
+      const std::span<const double> zSC, const std::span<const double> zCS,
+      const std::span<const double> zCC, const std::span<const double> zSS,
+      int signOfJacobian, const std::span<const double> rAxis,
+      const std::span<const double> zAxis, double* bSubUVac, double* bSubVVac,
+      double netToroidalCurrent, int ivacskip,
+      const VmecCheckpoint& vmec_checkpoint = VmecCheckpoint::NONE,
+      bool at_checkpoint_iteration = false) override;
+
+ private:
+  std::unique_ptr<FreeBoundaryBase> primary_;
+  std::unique_ptr<FreeBoundaryBase> shadow_;
+
+  std::span<const double> primary_b_sq_vac_;
+  std::span<const double> shadow_b_sq_vac_;
+
+  std::string dump_path_;
+
+  // number of update() calls so far (same on every thread)
+  int update_counter_ = 0;
+
+  // shared (across threads) targets for the shadow solver's net-current
+  // integrals; only used for the dump
+  double* shadow_b_sub_u_vac_;
+  double* shadow_b_sub_v_vac_;
+};
+
+}  // namespace vmecpp
+
+#endif  // VMECPP_FREE_BOUNDARY_DUAL_SOLVER_DUAL_SOLVER_H_

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -610,6 +610,8 @@ PYBIND11_MODULE(_vmecpp, m) {
   DefEigenProperty(pyindata, "extcur", &VmecINDATA::extcur);
   pyindata.def_readwrite("nvacskip", &VmecINDATA::nvacskip)
       .def_readwrite("free_boundary_method", &VmecINDATA::free_boundary_method)
+      .def_readwrite("biest_accuracy_digits",
+                     &VmecINDATA::biest_accuracy_digits)
 
       // tweaking parameters
       .def_readwrite("nstep", &VmecINDATA::nstep);

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/BUILD.bazel
@@ -24,6 +24,8 @@ cc_library(
         "//vmecpp/vmec/handover_storage",
         "//vmecpp/vmec/radial_partitioning",
         "//vmecpp/vmec/output_quantities",
+        "//vmecpp/free_boundary/biest",
+        "//vmecpp/free_boundary/dual_solver",
         "//vmecpp/free_boundary/free_boundary_base",
         "//vmecpp/free_boundary/nestor",
         "//vmecpp/free_boundary/only_coils",

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -6,6 +6,8 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <cstdlib>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -28,6 +30,8 @@
 #include "vmecpp/common/makegrid_lib/makegrid_lib.h"
 #include "vmecpp/common/util/util.h"
 #include "vmecpp/common/vmec_indata/vmec_indata.h"
+#include "vmecpp/free_boundary/biest/biest.h"
+#include "vmecpp/free_boundary/dual_solver/dual_solver.h"
 #include "vmecpp/free_boundary/nestor/nestor.h"
 #include "vmecpp/free_boundary/only_coils/only_coils.h"
 #include "vmecpp/vmec/output_quantities/output_quantities.h"
@@ -197,6 +201,38 @@ Vmec::Vmec(const VmecINDATA& indata, std::optional<int> max_threads,
     matrixShare.setZero(mnpd * mnpd);
     iPiv.setZero(mnpd);
     bvecShare.setZero(mnpd);
+
+    // Diagnostic dual-run mode: run a second (shadow) free-boundary solver
+    // alongside the configured one and dump both |B|^2/2 fields per vacuum
+    // update; see DualSolver. Enabled by VMECPP_FB_SHADOW=(nestor|biest),
+    // dump path override via VMECPP_FB_DUAL_DUMP.
+    if (const char* shadow_env = std::getenv("VMECPP_FB_SHADOW");
+        shadow_env != nullptr) {
+      auto maybe_shadow_method = FreeBoundaryMethodFromString(shadow_env);
+      CHECK(maybe_shadow_method.ok())
+          << "invalid VMECPP_FB_SHADOW value '" << shadow_env << "'";
+      fb_shadow_method_ = maybe_shadow_method.value();
+
+      const char* dump_env = std::getenv("VMECPP_FB_DUAL_DUMP");
+      fb_dual_dump_path_ =
+          dump_env != nullptr ? dump_env : "vmecpp_fb_dual_dump.jsonl";
+      // start with a fresh dump file
+      std::ofstream(fb_dual_dump_path_, std::ios::trunc);
+
+      shadowBsqVac_.setZero(s_.nZnT);
+      shadowVacuumBR_.setZero(s_.nZnT);
+      shadowVacuumBPhi_.setZero(s_.nZnT);
+      shadowVacuumBZ_.setZero(s_.nZnT);
+    }
+
+    if (indata_.free_boundary_method == FreeBoundaryMethod::BIEST ||
+        fb_shadow_method_ == FreeBoundaryMethod::BIEST) {
+      biestCoilBrShare.setZero(s_.nZnT);
+      biestCoilBpShare.setZero(s_.nZnT);
+      biestCoilBzShare.setZero(s_.nZnT);
+      biestBPlasmaShare.setZero(3 * s_.nZeta * s_.nThetaEven);
+    }
+
 
     h_.vacuum_magnetic_pressure.setZero(s_.nZnT);
     h_.vacuum_b_r.setZero(s_.nZnT);
@@ -527,22 +563,77 @@ bool Vmec::InitializeRadial(
           tp_[thread_id] = std::make_unique<TangentialPartitioning>(
               s_.nZnT, num_threads_, thread_id);
 
-          if (indata_.free_boundary_method == FreeBoundaryMethod::NESTOR) {
-            fb_[thread_id] = std::make_unique<Nestor>(
+          // Builds one free-boundary solver of the given method, wired either
+          // to the real output buffers consumed by IdealMhdModel or (for the
+          // diagnostic shadow solver) to the shadow buffers.
+          auto make_solver =
+              [&](FreeBoundaryMethod method,
+                  bool as_shadow) -> std::unique_ptr<FreeBoundaryBase> {
+            std::span<double> b_sq_vac =
+                as_shadow
+                    ? std::span<double>(shadowBsqVac_.data(),
+                                        shadowBsqVac_.size())
+                    : std::span<double>(h_.vacuum_magnetic_pressure.data(),
+                                        h_.vacuum_magnetic_pressure.size());
+            std::span<double> vac_b_r =
+                as_shadow ? std::span<double>(shadowVacuumBR_.data(),
+                                              shadowVacuumBR_.size())
+                          : std::span<double>(h_.vacuum_b_r.data(),
+                                              h_.vacuum_b_r.size());
+            std::span<double> vac_b_phi =
+                as_shadow ? std::span<double>(shadowVacuumBPhi_.data(),
+                                              shadowVacuumBPhi_.size())
+                          : std::span<double>(h_.vacuum_b_phi.data(),
+                                              h_.vacuum_b_phi.size());
+            std::span<double> vac_b_z =
+                as_shadow ? std::span<double>(shadowVacuumBZ_.data(),
+                                              shadowVacuumBZ_.size())
+                          : std::span<double>(h_.vacuum_b_z.data(),
+                                              h_.vacuum_b_z.size());
+
+            if (method == FreeBoundaryMethod::NESTOR) {
+              return std::make_unique<Nestor>(
+                  &s_, tp_[thread_id].get(), &mgrid_,
+                  std::span<double>(matrixShare.data(), matrixShare.size()),
+                  std::span<double>(bvecShare.data(), bvecShare.size()),
+                  b_sq_vac, std::span<int>(iPiv.data(), iPiv.size()), vac_b_r,
+                  vac_b_phi, vac_b_z);
+            }
+            if (method == FreeBoundaryMethod::ONLY_COILS) {
+              return std::make_unique<OnlyCoils>(&s_, tp_[thread_id].get(),
+                                                 &mgrid_, b_sq_vac, vac_b_r,
+                                                 vac_b_phi, vac_b_z);
+            }
+            if (method == FreeBoundaryMethod::BIEST) {
+              return std::make_unique<Biest>(
+                  &s_, tp_[thread_id].get(), &mgrid_,
+                  indata_.biest_accuracy_digits,
+                  std::span<double>(biestCoilBrShare.data(),
+                                    biestCoilBrShare.size()),
+                  std::span<double>(biestCoilBpShare.data(),
+                                    biestCoilBpShare.size()),
+                  std::span<double>(biestCoilBzShare.data(),
+                                    biestCoilBzShare.size()),
+                  std::span<double>(biestBPlasmaShare.data(),
+                                    biestBPlasmaShare.size()),
+                  b_sq_vac, vac_b_r, vac_b_phi, vac_b_z);
+            }
+            LOG(FATAL) << absl::StrCat("free boundary method '",
+                                       ToString(method),
+                                       "' not implemented yet");
+          };
+
+          if (fb_shadow_method_.has_value()) {
+            // diagnostic dual-run mode; see DualSolver
+            fb_[thread_id] = std::make_unique<DualSolver>(
                 &s_, tp_[thread_id].get(), &mgrid_,
-                std::span<double>(matrixShare.data(), matrixShare.size()),
-                std::span<double>(bvecShare.data(), bvecShare.size()),
-                std::span<double>(h_.vacuum_magnetic_pressure.data(),
-                                  h_.vacuum_magnetic_pressure.size()),
-                std::span<int>(iPiv.data(), iPiv.size()),
-                std::span<double>(h_.vacuum_b_r.data(), h_.vacuum_b_r.size()),
-                std::span<double>(h_.vacuum_b_phi.data(),
-                                  h_.vacuum_b_phi.size()),
-                std::span<double>(h_.vacuum_b_z.data(), h_.vacuum_b_z.size()));
-          } else if (indata_.free_boundary_method ==
-                     FreeBoundaryMethod::ONLY_COILS) {
-            fb_[thread_id] = std::make_unique<OnlyCoils>(
-                &s_, tp_[thread_id].get(), &mgrid_,
+                make_solver(indata_.free_boundary_method, /*as_shadow=*/false),
+                make_solver(fb_shadow_method_.value(), /*as_shadow=*/true),
+                std::span<const double>(h_.vacuum_magnetic_pressure.data(),
+                                        h_.vacuum_magnetic_pressure.size()),
+                std::span<const double>(shadowBsqVac_.data(),
+                                        shadowBsqVac_.size()),
+                &shadowBSubUVac_, &shadowBSubVVac_, fb_dual_dump_path_,
                 std::span<double>(h_.vacuum_magnetic_pressure.data(),
                                   h_.vacuum_magnetic_pressure.size()),
                 std::span<double>(h_.vacuum_b_r.data(), h_.vacuum_b_r.size()),
@@ -550,10 +641,9 @@ bool Vmec::InitializeRadial(
                                   h_.vacuum_b_phi.size()),
                 std::span<double>(h_.vacuum_b_z.data(), h_.vacuum_b_z.size()));
           } else {
-            LOG(FATAL) << absl::StrCat("free boundary method '",
-                                       ToString(indata_.free_boundary_method),
-                                       "' not implemented yet");
-          }  // indata_.free_boundary_method
+            fb_[thread_id] =
+                make_solver(indata_.free_boundary_method, /*as_shadow=*/false);
+          }
         }  // !reuse_solver
       }  // lfreeb
 

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
@@ -209,6 +209,25 @@ class Vmec {
   Eigen::VectorXi iPiv;
   Eigen::VectorXd bvecShare;
 
+  // shared scratch for the BIEST free-boundary solver; see Biest class docs
+  Eigen::VectorXd biestCoilBrShare;
+  Eigen::VectorXd biestCoilBpShare;
+  Eigen::VectorXd biestCoilBzShare;
+  Eigen::VectorXd biestBPlasmaShare;
+
+
+  // diagnostic dual-run mode (see DualSolver): shadow solver method from
+  // VMECPP_FB_SHADOW, dump path from VMECPP_FB_DUAL_DUMP, and the shadow
+  // solver's output buffers
+  std::optional<FreeBoundaryMethod> fb_shadow_method_;
+  std::string fb_dual_dump_path_;
+  Eigen::VectorXd shadowBsqVac_;
+  Eigen::VectorXd shadowVacuumBR_;
+  Eigen::VectorXd shadowVacuumBPhi_;
+  Eigen::VectorXd shadowVacuumBZ_;
+  double shadowBSubUVac_ = 0.0;
+  double shadowBSubVVac_ = 0.0;
+
  private:
   enum class SolveEqLoopStatus : std::uint8_t {
     NORMAL_TERMINATION,

--- a/src/vmecpp/cpp/vmecpp_tools/free_boundary_standalone/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp_tools/free_boundary_standalone/BUILD.bazel
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+cc_binary(
+    name = "free_boundary_standalone",
+    srcs = ["free_boundary_standalone.cc"],
+    deps = [
+        "@abseil-cpp//absl/log",
+        "@abseil-cpp//absl/log:check",
+        "@abseil-cpp//absl/strings",
+        "@nlohmann_json//:json",
+        "//util/file_io",
+        "//vmecpp/common/fourier_basis_fast_toroidal",
+        "//vmecpp/common/vmec_indata",
+        "//vmecpp/free_boundary/biest",
+        "//vmecpp/free_boundary/mgrid_provider",
+        "//vmecpp/free_boundary/nestor",
+        "//vmecpp/free_boundary/tangential_partitioning",
+    ],
+)

--- a/src/vmecpp/cpp/vmecpp_tools/free_boundary_standalone/free_boundary_standalone.cc
+++ b/src/vmecpp/cpp/vmecpp_tools/free_boundary_standalone/free_boundary_standalone.cc
@@ -1,0 +1,272 @@
+// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+// <info@proximafusion.com>
+//
+// SPDX-License-Identifier: MIT
+//
+// Standalone driver for the free-boundary solvers: evaluates the vacuum
+// magnetic pressure |B|^2/2 on the plasma boundary given in `rbc`/`zbs` of a
+// VMEC++ JSON input file, using the solver selected by
+// `free_boundary_method` (optionally overridden on the command line).
+// Intended for A/B comparisons between NESTOR and BIEST outside the VMEC
+// iteration.
+
+#include <cstdlib>  // EXIT_SUCCESS, EXIT_FAILURE
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif  // _OPENMP
+
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/strings/str_cat.h"
+#include "nlohmann/json.hpp"
+#include "util/file_io/file_io.h"
+#include "vmecpp/common/fourier_basis_fast_toroidal/fourier_basis_fast_toroidal.h"
+#include "vmecpp/common/vmec_indata/vmec_indata.h"
+#include "vmecpp/free_boundary/biest/biest.h"
+#include "vmecpp/free_boundary/mgrid_provider/mgrid_provider.h"
+#include "vmecpp/free_boundary/nestor/nestor.h"
+#include "vmecpp/free_boundary/tangential_partitioning/tangential_partitioning.h"
+
+using file_io::ReadFile;
+using nlohmann::json;
+using vmecpp::VmecINDATA;
+
+int main(int argc, char** argv) {
+  // use VMEC convention of left-handed coordinate system
+  static constexpr int kSignOfJacobian = -1;
+
+  if (argc != 2 && argc != 3) {
+    std::cerr << "Compute |B|^2/2 on the boundary given by rbc/zbs using the "
+                 "free-boundary solver selected in 'free_boundary_method' of "
+                 "the input file (optionally overridden by the second "
+                 "argument).\n"
+              << "Usage: " << argv[0]
+              << " <vmecpp_input_file.json> [nestor|biest|only_coils]\n";
+    return EXIT_FAILURE;
+  }
+
+  const std::filesystem::path vmecpp_indata_filename(argv[1]);
+
+  absl::StatusOr<std::string> maybe_indata_json =
+      ReadFile(vmecpp_indata_filename);
+  CHECK_OK(maybe_indata_json)
+      << "Could not read input file '" << vmecpp_indata_filename
+      << "': " << maybe_indata_json.status();
+  const std::string& indata_json = *maybe_indata_json;
+
+  absl::StatusOr<VmecINDATA> maybe_vmec_indata =
+      VmecINDATA::FromJson(indata_json);
+  CHECK_OK(maybe_vmec_indata)
+      << "Could not parse input file '" << vmecpp_indata_filename
+      << "' into VmecINDATA: " << maybe_vmec_indata.status();
+  VmecINDATA vmec_indata = *maybe_vmec_indata;
+
+  if (argc == 3) {
+    const auto maybe_method =
+        vmecpp::FreeBoundaryMethodFromString(std::string(argv[2]));
+    CHECK_OK(maybe_method) << "invalid free-boundary method '" << argv[2]
+                           << "'";
+    vmec_indata.free_boundary_method = maybe_method.value();
+  }
+
+  vmecpp::Sizes s(vmec_indata);
+
+  // build raxis, zaxis from raxis_c, zaxis_s in VMEC INDATA
+  // -> evaluate Fourier series in toroidal direction
+  std::vector<double> axis_r(s.nZeta);
+  std::vector<double> axis_z(s.nZeta);
+  const double delta_phi = 2.0 * M_PI / (s.nfp * s.nZeta);
+  for (int k = 0; k < s.nZeta; ++k) {
+    for (int n = 0; n < s.ntor + 1; ++n) {
+      axis_r[k] += vmec_indata.raxis_c[n] * std::cos(k * n * s.nfp * delta_phi);
+      axis_z[k] += vmec_indata.zaxis_s[n] * std::sin(k * n * s.nfp * delta_phi);
+    }
+  }
+
+  // build rmnc, zmns from rbc, zbs in VMEC INDATA
+  std::vector<double> rmnc(s.mnmax);
+  std::vector<double> zmns(s.mnmax);
+  int mn = 0;
+  int m = 0;
+  for (int n = 0; n < s.ntor + 1; ++n) {
+    rmnc[mn] = vmec_indata.rbc(m, s.ntor + n);
+    zmns[mn] = vmec_indata.zbs(m, s.ntor + n);
+
+    mn++;
+  }
+  for (m = 1; m < s.mpol; ++m) {
+    for (int n = -s.ntor; n < s.ntor + 1; ++n) {
+      rmnc[mn] = vmec_indata.rbc(m, s.ntor + n);
+      zmns[mn] = vmec_indata.zbs(m, s.ntor + n);
+
+      mn++;
+    }
+  }
+
+  CHECK_EQ(mn, s.mnmax)
+      << "counting error in assigning boundary Fourier coefficients";
+
+  vmecpp::FourierBasisFastToroidal fb(&s);
+
+  std::vector<double> rCC(s.mnsize);
+  std::vector<double> rSS(s.mnsize);
+  std::vector<double> zSC(s.mnsize);
+  std::vector<double> zCS(s.mnsize);
+
+  // only needed for lasym=true, which is not supported here yet
+  std::vector<double> rSC;
+  std::vector<double> rCS;
+  std::vector<double> zCC;
+  std::vector<double> zSS;
+
+  // convert rmnc, ... from the input into rCC, ...
+  fb.cos_to_cc_ss(rmnc, rCC, rSS, s.ntor, s.mpol);
+  fb.sin_to_sc_cs(zmns, zSC, zCS, s.ntor, s.mpol);
+
+  // ------------------------------------------------------
+
+  vmecpp::MGridProvider mgrid;
+  absl::Status status =
+      mgrid.LoadFile(vmec_indata.mgrid_file, vmec_indata.extcur);
+  CHECK_OK(status);
+
+  // tangential Fourier resolution for Nestor:
+  // one more poloidal mode than VMEC
+  const int nf = s.ntor;      // 0 : ntor
+  const int mf = s.mpol + 1;  // 0 : (mpol + 1)
+
+  const int mnpd = (2 * nf + 1) * (mf + 1);
+  std::vector<double> matrixShare(mnpd * mnpd);
+  std::vector<int> iPiv(mnpd);
+  std::vector<double> bvecShare(mnpd);
+
+  // shared scratch for BIEST
+  std::vector<double> coilBrShare(s.nZnT);
+  std::vector<double> coilBpShare(s.nZnT);
+  std::vector<double> coilBzShare(s.nZnT);
+  std::vector<double> bPlasmaShare(3 * s.nZeta * s.nThetaEven);
+
+  // this will contain |B|^2/2 when the solver is done
+  std::vector<double> bSqVacShare(s.nZnT);
+
+  std::vector<double> vacuum_b_r(s.nZnT);
+  std::vector<double> vacuum_b_phi(s.nZnT);
+  std::vector<double> vacuum_b_z(s.nZnT);
+
+  // bsubuvac in Fortran VMEC and the rest of VMEC++
+  double net_toroidal_current_from_solution = 0.0;
+
+  // bsubvvac in Fortran VMEC and the rest of VMEC++
+  double net_poloidal_current_from_solution = 0.0;
+
+  // this makes sure that we always run the full computation
+  const int ivacskip = 0;
+
+#ifdef _OPENMP
+  const int num_threads = omp_get_max_threads();
+#pragma omp parallel
+  {
+    const int thread_id = omp_get_thread_num();
+#else
+  const int num_threads = 1;
+  {
+    const int thread_id = 0;
+#endif  // _OPENMP
+
+    vmecpp::TangentialPartitioning tp(s.nZnT, num_threads, thread_id);
+
+    std::unique_ptr<vmecpp::FreeBoundaryBase> solver;
+    if (vmec_indata.free_boundary_method ==
+        vmecpp::FreeBoundaryMethod::NESTOR) {
+      solver = std::make_unique<vmecpp::Nestor>(
+          &s, &tp, &mgrid, matrixShare, bvecShare, bSqVacShare, iPiv,
+          vacuum_b_r, vacuum_b_phi, vacuum_b_z);
+    } else if (vmec_indata.free_boundary_method ==
+               vmecpp::FreeBoundaryMethod::BIEST) {
+      solver = std::make_unique<vmecpp::Biest>(
+          &s, &tp, &mgrid, vmec_indata.biest_accuracy_digits, coilBrShare,
+          coilBpShare, coilBzShare, bPlasmaShare, bSqVacShare, vacuum_b_r,
+          vacuum_b_phi, vacuum_b_z);
+    } else {
+      LOG(FATAL) << "free-boundary method not supported by this tool: "
+                 << vmecpp::ToString(vmec_indata.free_boundary_method);
+    }
+
+    // NOTE: accumulation into `net_toroidal_current_from_solution` and
+    // `net_poloidal_current_from_solution` by only a single thread is
+    // already handled within the solver's `update()`.
+    solver->update(rCC, rSS, rSC, rCS, zSC, zCS, zCC, zSS, kSignOfJacobian,
+                   axis_r, axis_z, &net_toroidal_current_from_solution,
+                   &net_poloidal_current_from_solution, vmec_indata.curtor,
+                   ivacskip);
+    // at this point we expect to have the full solution in bSqVacShare
+  }  // pragma omp parallel
+
+  LOG(INFO) << "net toroidal current from solution: "
+            << net_toroidal_current_from_solution / vmecpp::MU_0 << " A";
+  LOG(INFO) << "net poloidal current R*Btor from solution: "
+            << net_poloidal_current_from_solution;
+
+  // write |B|^2/2 and net currents to JSON file
+  json freeboundary_outputs;
+
+  // resolution parameters
+  freeboundary_outputs["lasym"] = vmec_indata.lasym;
+  freeboundary_outputs["nfp"] = vmec_indata.nfp;
+  freeboundary_outputs["mpol"] = s.mpol;
+  freeboundary_outputs["ntor"] = s.ntor;
+  freeboundary_outputs["nThetaEven"] = s.nThetaEven;
+  freeboundary_outputs["nThetaReduced"] = s.nThetaReduced;
+  freeboundary_outputs["nThetaEff"] = s.nThetaEff;
+  freeboundary_outputs["nZeta"] = s.nZeta;
+  freeboundary_outputs["signgs"] = kSignOfJacobian;
+  freeboundary_outputs["free_boundary_method"] =
+      vmecpp::ToString(vmec_indata.free_boundary_method);
+  freeboundary_outputs["biest_accuracy_digits"] =
+      vmec_indata.biest_accuracy_digits;
+
+  // scalar outputs
+  freeboundary_outputs["net_toroidal_current_from_solution"] =
+      net_toroidal_current_from_solution;
+  freeboundary_outputs["net_poloidal_current_from_solution"] =
+      net_poloidal_current_from_solution;
+
+  // vector outputs over theta = [0, pi] and phi = [0, 2 pi / nfp).
+  // The toroidal index is fast, i.e., `bSqVacShare` is indexed as
+  // `l * s.nZeta + k` for l = 0, 1, ..., (s.nThetaEff - 1) and
+  // k = 0, 1, ..., (nZeta - 1). Convert to a two-dimensional array for
+  // writing; the toroidal index is fast, so make that the second (inner) one.
+  auto to_2d = [&](const std::vector<double>& flat) {
+    std::vector<std::vector<double>> result(s.nThetaEff);
+    for (int l = 0; l < s.nThetaEff; ++l) {
+      result[l].resize(s.nZeta);
+      for (int k = 0; k < s.nZeta; ++k) {
+        result[l][k] = flat[l * s.nZeta + k];
+      }
+    }
+    return result;
+  };
+  freeboundary_outputs["bsq_vac"] = to_2d(bSqVacShare);
+  freeboundary_outputs["vacuum_b_r"] = to_2d(vacuum_b_r);
+  freeboundary_outputs["vacuum_b_phi"] = to_2d(vacuum_b_phi);
+  freeboundary_outputs["vacuum_b_z"] = to_2d(vacuum_b_z);
+
+  // write JSON to output file
+  std::filesystem::path output_filename(vmecpp_indata_filename);
+  auto method_name = vmecpp::ToString(vmec_indata.free_boundary_method);
+  output_filename.replace_extension(
+      absl::StrCat(".", method_name, "_out.json"));
+  std::ofstream output_file(output_filename);
+  output_file << freeboundary_outputs;
+
+  LOG(INFO) << "wrote " << output_filename;
+
+  return EXIT_SUCCESS;
+}

--- a/tools/plot_fb_dual_run.py
+++ b/tools/plot_fb_dual_run.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+# <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+"""Visualize a free-boundary dual-run dump (see DualSolver).
+
+Reads the JSON-lines file written when VMEC++ runs with
+VMECPP_FB_SHADOW=(nestor|biest) and VMECPP_FB_DUAL_DUMP=<path>, and produces:
+
+1. Per-update side-by-side imshow panels of |B|^2/2 on the (theta, zeta)
+   grid: primary | shadow | difference.
+2. The evolution of the poloidal Fourier spectrum of |B|^2/2 for both
+   solvers across vacuum updates (to expose high-k content building up).
+3. Scalar traces across updates: RMS/max difference of the two fields, net
+   current integrals of both solvers, and the spectral content of the
+   boundary Fourier coefficients.
+
+Usage:
+    python tools/plot_fb_dual_run.py <dump.jsonl> [--out <dir>]
+    python tools/plot_fb_dual_run.py <dump.jsonl> --updates 0 5 10
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib as mpl
+
+mpl.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def load_records(path: Path) -> list[dict]:
+    records = []
+    with open(path) as f:
+        for line in f:
+            stripped = line.strip()
+            if stripped:
+                records.append(json.loads(stripped))
+    if not records:
+        msg = f"no records found in {path}"
+        raise ValueError(msg)
+    return records
+
+
+def infer_grid_shape(record: dict) -> tuple[int, int]:
+    """The bsqvac buffers are indexed l * nZeta + k (theta slow, zeta fast).
+
+    The dump does not carry the grid dimensions explicitly, so infer nZeta from the
+    boundary coefficient array sizes is not possible either; instead require the user
+    grid to be recoverable from the two most common cases.
+    """
+    n = len(record["primary_b_sq_vac"])
+    # heuristics: try common aspect ratios by looking for integer factors
+    # preferring nZeta > nTheta (VMEC reduced grids are wide in zeta)
+    best = None
+    for n_theta in range(2, int(np.sqrt(n)) + 1):
+        if n % n_theta == 0:
+            best = (n_theta, n // n_theta)
+    if best is None:
+        msg = f"cannot infer (nThetaEff, nZeta) from flat size {n}"
+        raise ValueError(msg)
+    return best
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dump", type=Path, help="JSONL dump from DualSolver")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="output directory (default: <dump-stem>_plots)",
+    )
+    parser.add_argument(
+        "--updates",
+        type=int,
+        nargs="*",
+        default=None,
+        help="update indices to plot as imshow panels (default: ~8 evenly spaced)",
+    )
+    parser.add_argument(
+        "--ntheta",
+        type=int,
+        default=None,
+        help="poloidal grid size nThetaEff (inferred if omitted)",
+    )
+    args = parser.parse_args()
+
+    records = load_records(args.dump)
+    out_dir = args.out or args.dump.parent / f"{args.dump.stem}_plots"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.ntheta is not None:
+        n_flat = len(records[0]["primary_b_sq_vac"])
+        shape = (args.ntheta, n_flat // args.ntheta)
+    elif "n_theta_eff" in records[0]:
+        shape = (records[0]["n_theta_eff"], records[0]["n_zeta"])
+    else:
+        shape = infer_grid_shape(records[0])
+    n_theta, n_zeta = shape
+    print(f"{len(records)} vacuum updates, grid (nThetaEff, nZeta) = {shape}")
+
+    primary = np.array([r["primary_b_sq_vac"] for r in records]).reshape(
+        len(records), n_theta, n_zeta
+    )
+    shadow = np.array([r["shadow_b_sq_vac"] for r in records]).reshape(
+        len(records), n_theta, n_zeta
+    )
+    diff = primary - shadow
+    update_idx = np.array([r["update_index"] for r in records])
+
+    # ------------------------------------------------------------------
+    # 1) side-by-side imshow panels for selected updates
+    if args.updates is not None and len(args.updates) > 0:
+        selected = [i for i in args.updates if i < len(records)]
+    else:
+        n_panels = min(8, len(records))
+        selected = np.unique(
+            np.linspace(0, len(records) - 1, n_panels).astype(int)
+        ).tolist()
+
+    vmin = min(primary.min(), shadow.min())
+    vmax = max(primary.max(), shadow.max())
+    dmax = np.abs(diff).max()
+
+    for i in selected:
+        fig, axs = plt.subplots(1, 3, figsize=(15, 4), constrained_layout=True)
+        im0 = axs[0].imshow(
+            primary[i], origin="lower", aspect="auto", vmin=vmin, vmax=vmax
+        )
+        axs[0].set_title(f"primary |B|^2/2 (update {update_idx[i]})")
+        im1 = axs[1].imshow(
+            shadow[i], origin="lower", aspect="auto", vmin=vmin, vmax=vmax
+        )
+        axs[1].set_title("shadow |B|^2/2")
+        im2 = axs[2].imshow(
+            diff[i],
+            origin="lower",
+            aspect="auto",
+            cmap="RdBu_r",
+            vmin=-dmax,
+            vmax=dmax,
+        )
+        axs[2].set_title("primary - shadow")
+        for ax in axs:
+            ax.set_xlabel("zeta index")
+            ax.set_ylabel("theta index")
+        fig.colorbar(im0, ax=axs[0])
+        fig.colorbar(im1, ax=axs[1])
+        fig.colorbar(im2, ax=axs[2])
+        fig.savefig(out_dir / f"bsq_update_{update_idx[i]:04d}.png", dpi=150)
+        plt.close(fig)
+
+    # ------------------------------------------------------------------
+    # 2) spectral evolution: poloidal FFT amplitude of bsqvac vs update
+    # (theta is the reduced range for stellarator-symmetric runs; the DFT
+    # along it still exposes relative high-k growth between the solvers)
+    spec_primary = np.abs(np.fft.rfft(primary, axis=1)).mean(axis=2)
+    spec_shadow = np.abs(np.fft.rfft(shadow, axis=1)).mean(axis=2)
+
+    fig, axs = plt.subplots(1, 3, figsize=(15, 4), constrained_layout=True)
+    common = {
+        "origin": "lower",
+        "aspect": "auto",
+        "norm": mpl.colors.LogNorm(
+            vmin=max(spec_primary.min(), 1e-12), vmax=spec_primary.max()
+        ),
+    }
+    im0 = axs[0].imshow(spec_primary.T, **common)
+    axs[0].set_title("primary: poloidal spectrum of |B|^2/2")
+    im1 = axs[1].imshow(spec_shadow.T, **common)
+    axs[1].set_title("shadow: poloidal spectrum of |B|^2/2")
+    ratio = spec_shadow / np.maximum(spec_primary, 1e-30)
+    im2 = axs[2].imshow(
+        np.log10(ratio).T,
+        origin="lower",
+        aspect="auto",
+        cmap="RdBu_r",
+        vmin=-2,
+        vmax=2,
+    )
+    axs[2].set_title("log10(shadow / primary)")
+    for ax in axs:
+        ax.set_xlabel("vacuum update")
+        ax.set_ylabel("poloidal mode m")
+    fig.colorbar(im0, ax=axs[0])
+    fig.colorbar(im1, ax=axs[1])
+    fig.colorbar(im2, ax=axs[2])
+    fig.savefig(out_dir / "bsq_spectral_evolution.png", dpi=150)
+    plt.close(fig)
+
+    # ------------------------------------------------------------------
+    # 3) scalar traces
+    rms = np.sqrt((diff**2).mean(axis=(1, 2)))
+    maxabs = np.abs(diff).max(axis=(1, 2))
+    scale = primary.mean(axis=(1, 2))
+
+    fig, axs = plt.subplots(2, 2, figsize=(12, 8), constrained_layout=True)
+    axs[0, 0].semilogy(update_idx, rms / scale, label="rms(diff)/mean")
+    axs[0, 0].semilogy(update_idx, maxabs / scale, label="max|diff|/mean")
+    axs[0, 0].set_xlabel("vacuum update")
+    axs[0, 0].set_title("primary vs shadow |B|^2/2 difference")
+    axs[0, 0].legend()
+
+    axs[0, 1].plot(
+        update_idx,
+        [r["primary_b_sub_u_vac"] for r in records],
+        label="primary bsubuvac",
+    )
+    axs[0, 1].plot(
+        update_idx,
+        [r["shadow_b_sub_u_vac"] for r in records],
+        "--",
+        label="shadow bsubuvac",
+    )
+    axs[0, 1].set_xlabel("vacuum update")
+    axs[0, 1].set_title("net toroidal current integral")
+    axs[0, 1].legend()
+
+    # boundary spectral content: RMS of high-m half vs low-m half of rCC
+    r_cc = np.array([r["rCC"] for r in records])
+    half = r_cc.shape[1] // 2
+    low = np.sqrt((r_cc[:, :half] ** 2).mean(axis=1))
+    high = np.sqrt((r_cc[:, half:] ** 2).mean(axis=1))
+    axs[1, 0].semilogy(update_idx, low, label="rCC low-mn RMS")
+    axs[1, 0].semilogy(update_idx, high, label="rCC high-mn RMS")
+    axs[1, 0].set_xlabel("vacuum update")
+    axs[1, 0].set_title("boundary coefficient spectral content")
+    axs[1, 0].legend()
+
+    axs[1, 1].semilogy(
+        update_idx,
+        np.abs(spec_primary[:, -1]) + 1e-30,
+        label="primary highest-m",
+    )
+    axs[1, 1].semilogy(
+        update_idx,
+        np.abs(spec_shadow[:, -1]) + 1e-30,
+        "--",
+        label="shadow highest-m",
+    )
+    axs[1, 1].set_xlabel("vacuum update")
+    axs[1, 1].set_title("highest poloidal mode of |B|^2/2")
+    axs[1, 1].legend()
+
+    fig.savefig(out_dir / "dual_run_traces.png", dpi=150)
+    plt.close(fig)
+
+    print(f"wrote plots to {out_dir}/")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds **BIEST as a user-selectable free-boundary solver** (`free_boundary_method = "biest"`), plus the diagnostic tooling used to validate it.

## BIEST solver
Solves the same exterior Neumann problem as NESTOR (`B_vac · n = 0`, prescribed net toroidal current) with high-order partition-of-unity singular quadrature + GMRES, replacing NESTOR's low-order singularity subtraction + dense LU. New input `biest_accuracy_digits` (default 8, range [1,14]) plumbed through JSON/HDF5/pybind/pydantic.

Design notes:
- coil `B·n` computed with BIEST's own normals (`ComputeBdotN`) — the normal-orientation convention stays internal to BIEST; net current enters as `Jplasma = signgs·μ0·I_tor`.
- **full solve on the fresh boundary every update.** Frozen-field or frozen-operator schemes were measured to stall or slow VMEC's descent (dual-run diagnostics below); per-iteration fresh solves converge in *fewer* iterations than NESTOR (421 vs 489 on CTH-like) with ~25 % lower converged DELBSQ. Experimental partial updates remain behind `VMECPP_BIEST_PARTIAL_DRIFT_TOL`.
- thread-cooperative: partition deposit → pinned-thread solve → partition readout. The solve must run on the *same* thread every update (solver state persists) — an `omp single` is not sufficient.

## Validation (cth_like_free_bdy, mpol=5, nzeta=36, 43 kA)
| check | result |
|---|---|
| bsqvac NESTOR vs BIEST | 0.83 % rel RMS — equals NESTOR's discretization floor |
| BIEST self-convergence (digits 8 vs 12) | 2e-9 RMS |
| I_tor from solution | 43228.9 A (input 43229.08; NESTOR: 43227.1) |
| in-loop | ftol 1e-10 in 421 iterations |

## Diagnostics
- `DualSolver`: run any solver with the other as a shadow (`VMECPP_FB_SHADOW`, `VMECPP_FB_DUAL_DUMP`); one JSONL record per vacuum update with both |B|²/2 fields + boundary coefficients.
- `tools/plot_fb_dual_run.py`: side-by-side imshow (primary | shadow | diff), poloidal-spectrum evolution across the iteration, scalar traces.
- `vmecpp_tools/free_boundary_standalone`: A/B harness evaluating any solver at a fixed boundary.
- `docs/free_boundary_solvers.md`.

Known cost: BIEST runs serially inside the OpenMP parallel region (~2.8 s per solve at digits 8 on CTH) — it is the accuracy reference; use Vac2 (next PR) for fast accurate production runs.

Part 2/4, stacked on https://github.com/proximafusion/vmecpp/pull/636.

related to https://github.com/proximafusion/vmecpp/issues/628