### PR TITLE
Fix regression in multigrid freeboundary

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -596,8 +596,8 @@ absl::StatusOr<bool> IdealMhdModel::update(
 
   // back in funct3d, free-boundary force contribution active?
   // This can even happen in the first iteration when hot-restarted.
-  if (m_fc_.lfreeb &&
-      (iter2 > 1 || m_vacuum_pressure_state_ != VacuumPressureState::kOff)) {
+  if (m_fc_.lfreeb && (iter2 > 1 || m_vacuum_pressure_state_ ==
+                                        VacuumPressureState::kInitialized)) {
 // protect read of m_vacuum_pressure_state_ below from write above
 #ifdef _OPENMP
 #pragma omp barrier


### PR DESCRIPTION
A regression was introduced by #330 for multigrid free boundary runs. Pressure was activated immediately for subsequent multigrid iterations, NOT JUST when hot restarted, which was an unintended.

The result was a change in convergence rate, improving in many cases, but regressing in some.

It went unnoticed for so long, because only the extended verification suite covered this case, not the small one, which was rarely run. Adding it to CI surfaced this issue.