### PR TITLE
Add iteration-count regression guard to multigrid free-boundary test

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
@@ -188,6 +188,10 @@ TEST(TestVmec, MultiGridFreeBoundary) {
   ASSERT_TRUE(indata.ok());
   ASSERT_EQ(indata->ns_array.size(), 2u);
 
-  const auto output = vmecpp::run(*indata);
+  const auto output = vmecpp::run(*indata, std::nullopt, 1);
   ASSERT_TRUE(output.ok());
+
+  // Regression guard for issue #330/#640 and other changes to the multigrid
+  // convergence path
+  EXPECT_EQ(output->wout.niter, 344);
 }  // MultiGridFreeBoundary


### PR DESCRIPTION
The existing MultiGridFreeBoundary test only checked that the run converged, so it didn't catch the #330/#640 vacuum_pressure_state_ carryover regression: the run still converged, just via a different path once the vacuum term switched on a stage too early.