### PR TITLE
Re-ramp vacuum pressure activation on every multigrid stage transition

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -664,6 +664,15 @@ bool Vmec::InitializeRadial(
 
     // INTERPOLATE FROM COARSE (ns_old) TO NEXT FINER (ns) RADIAL GRID
     if (linterp) {
+      if (fc_.lfreeb) {
+        // Re-arm the vacuum pressure ramp for the new grid: the interpolated
+        // interior is only an approximate force-balance guess on the finer
+        // mesh, so ease the vacuum contribution back in (and re-trigger the
+        // one-time delt0 soft-start restart once it reaches kInitialized)
+        // instead of carrying over the previous stage's fully active state.
+        vacuum_pressure_state_ = VacuumPressureState::kOff;
+      }
+
       InterpolateToNextMultigridStep(fc_.ns, fc_.ns_old, p_, r_, old_r_,
                                      decomposed_x_, old_xc_scaled_);
 

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
@@ -172,12 +172,15 @@ TEST(TestVmec, CheckInMemoryMgrid) {
 }  // CheckInMemoryMgrid
 
 // A multi-grid free-boundary equilibrium (cth_like_free_bdy with an added grid
-// step) must converge. The free-boundary (Nestor) solver, together with its
-// accumulated vacuum response matrix and right-hand side, is kept in memory
-// across the multi-grid steps (reproducing Fortran VMEC's persistent vacuum
-// state), so this also exercises that the reused solver state stays valid
-// across a grid-size change. The step-by-step agreement against the Fortran
-// reference is exercised in vmecpp_large_cpp_tests.
+// step) must converge. The free-boundary (Nestor) solver object, together
+// with its accumulated vacuum response matrix and right-hand side, is kept
+// in memory across the multi-grid steps, so this also exercises that the
+// reused solver state stays valid across a grid-size change. The vacuum
+// pressure *activation* state is intentionally not carried over between
+// stages (see the re-ramp in Vmec::InitializeRadial) -- this deliberately
+// deviates from Fortran VMEC/PARVMEC, which never resets it either, in
+// exchange for robustness against a poorly-interpolated interior on large
+// radial-resolution jumps.
 TEST(TestVmec, MultiGridFreeBoundary) {
   const std::string filename =
       "vmecpp/test_data/cth_like_free_bdy_multigrid.json";
@@ -191,7 +194,10 @@ TEST(TestVmec, MultiGridFreeBoundary) {
   const auto output = vmecpp::run(*indata, std::nullopt, 1);
   ASSERT_TRUE(output.ok());
 
-  // Regression guard for issue #330/#640 and other changes to the multigrid
-  // convergence path
-  EXPECT_EQ(output->wout.niter, 344);
+  // Regression guard for the multigrid convergence path: on every stage
+  // transition, the vacuum pressure contribution is now re-ramped from
+  // scratch (instead of carrying over as fully active from the previous
+  // stage), so the last stage goes through the full turn-on sequence again.
+  // Pinned exactly since max_threads=1 above makes this deterministic.
+  EXPECT_EQ(output->wout.niter, 544);
 }  // MultiGridFreeBoundary


### PR DESCRIPTION
Free-boundary multigrid stage transitions carried the previous stage's
fully-active vacuum_pressure_state_ forward, so the Nestor solve and its
I_TOR-mismatch check ran unconditionally against a barely-relaxed
interpolated interior. Fortran VMEC/PARVMEC has the same limitation
(ivac is never reset on a normal ns_array transition, only on a
bad-Jacobian restart or the very first activation), so this is a
deliberate deviation from upstream: reset vacuum_pressure_state_ to
kOff on every stage transition so the gradual activation ramp (and its
one-time delt0 soft-start restart) re-arms each time, trading some
convergence speed for robustness against large radial-resolution jumps.