### PR TITLE
Decouple NESTOR vacuum solve thread count from the radial solver

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/util/util.cc
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.cc
@@ -327,4 +327,15 @@ int vmec_adjust_num_threads(const int max_threads,
   return num_threads;
 }
 
+int vmec_adjust_vacuum_num_threads(const int max_threads, const int n_znt) {
+  // The vacuum solve distributes nZnT tangential grid points among the threads
+  // (see TangentialPartitioning). There is no minimum-points-per-thread
+  // constraint like the radial solve's shared half-grid point, so we can use up
+  // to nZnT threads. In practice nZnT >> max_threads, so this returns
+  // max_threads. Deliberately does NOT call omp_set_num_threads: the vacuum
+  // solve runs in a nested parallel region with an explicit num_threads()
+  // clause.
+  return std::min(max_threads, n_znt);
+}
+
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/common/util/util.h
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.h
@@ -237,6 +237,17 @@ void TridiagonalSolveOpenMP(
 // radial resolution and adjust the number of OpenMP threads accordingly.
 int vmec_adjust_num_threads(int max_threads, int num_surfaces_to_distribute);
 
+// Compute the number of threads to use for the free-boundary (NESTOR) vacuum
+// solve. The vacuum solve is parallelized over the tangential boundary grid
+// (nZnT points), so - unlike the radial solve, which is capped at ns/2 - it can
+// use as many threads as there are tangential grid points. This count is
+// deliberately decoupled from the radial thread count so the vacuum solve can
+// use the full thread budget even at coarse multigrid steps (small ns).
+// Unlike vmec_adjust_num_threads, this does NOT call omp_set_num_threads: the
+// vacuum solve runs in a nested parallel region with an explicit num_threads()
+// clause.
+int vmec_adjust_vacuum_num_threads(int max_threads, int n_znt);
+
 }  // namespace vmecpp
 
 #endif  // VMECPP_COMMON_UTIL_UTIL_H_

--- a/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
@@ -176,6 +176,14 @@ class HandoverStorage {
   // [nZnT] cylindrical B^Z of Nestor's vacuum magnetic field
   Eigen::VectorXd vacuum_b_z;
 
+  // Whether the free-boundary vacuum solve requested an early exit at a
+  // debug checkpoint (VmecCheckpoint). The vacuum solve now runs in a nested
+  // parallel region driven by a single radial thread, so this shared flag
+  // broadcasts that thread's checkpoint result to the whole radial team (which
+  // reads it after the enclosing 'omp single' barrier). Always false during
+  // normal runs (checkpoint == NONE).
+  bool vacuum_reached_checkpoint = false;
+
  private:
   const Sizes& s_;
 

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/fft_toroidal_bench.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/fft_toroidal_bench.cc
@@ -108,8 +108,8 @@ struct BenchFixture {
 
     model = std::make_unique<IdealMhdModel>(
         fc.get(), &s, &fb, rprof.get(), &constants, &ls, handover.get(), &rp,
-        /*m_fb=*/nullptr, /*signOfJacobian=*/-1, /*nvacskip=*/0,
-        &vacuum_pressure_state);
+        /*m_fb_vac=*/nullptr, /*vac_num_threads=*/0, /*signOfJacobian=*/-1,
+        /*nvacskip=*/0, &vacuum_pressure_state);
 
     phys_x = std::make_unique<FourierGeometry>(&s, &rp, kNs);
     std::mt19937 rng(42);

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -170,7 +170,8 @@ IdealMhdModel::IdealMhdModel(
     FlowControl* m_fc, const Sizes* s, const FourierBasisFastPoloidal* t,
     RadialProfiles* m_p, const VmecConstants* constants,
     ThreadLocalStorage* m_ls, HandoverStorage* m_h, const RadialPartitioning* r,
-    FreeBoundaryBase* m_fb, int signOfJacobian, int nvacskip,
+    const std::vector<std::unique_ptr<FreeBoundaryBase>>* m_fb_vac,
+    int vac_num_threads, int signOfJacobian, int nvacskip,
     VacuumPressureState* m_vacuum_pressure_state)
     : m_fc_(*m_fc),
       s_(*s),
@@ -180,7 +181,8 @@ IdealMhdModel::IdealMhdModel(
       m_ls_(*m_ls),
       m_h_(*m_h),
       r_(*r),
-      m_fb_(m_fb),
+      m_fb_vac_(m_fb_vac),
+      m_vac_num_threads_(vac_num_threads),
       m_vacuum_pressure_state_(*m_vacuum_pressure_state),
 #ifdef VMECPP_USE_FFTX
       fft_plans_(s->nZeta, s->nfp, s->mpol),
@@ -191,8 +193,10 @@ IdealMhdModel::IdealMhdModel(
   CHECK_GE(nvacskip, 0)
       << "Should never happen: should be checked by VmecINDATA";
   if (m_fc_.lfreeb) {
-    CHECK(m_fb_ != nullptr)
+    CHECK(m_fb_vac_ != nullptr && !m_fb_vac_->empty())
         << "Free-boundary configuration requires a Free-boundary solver";
+    CHECK_GT(m_vac_num_threads_, 0)
+        << "Free-boundary configuration requires vac_num_threads > 0";
   }
 
   // init members
@@ -670,13 +674,52 @@ absl::StatusOr<bool> IdealMhdModel::update(
 #pragma omp barrier
 #endif  // _OPENMP
       const double netToroidalCurrent = m_h_.cTor / MU_0;
-      bool reached_checkpoint = m_fb_->update(
-          m_h_.rCC_LCFS, m_h_.rSS_LCFS, m_h_.rSC_LCFS, m_h_.rCS_LCFS,
-          m_h_.zSC_LCFS, m_h_.zCS_LCFS, m_h_.zCC_LCFS, m_h_.zSS_LCFS,
-          signOfJacobian, m_h_.rAxis, m_h_.zAxis, &(m_h_.bSubUVac),
-          &(m_h_.bSubVVac), netToroidalCurrent, ivacskip, checkpoint,
-          iter2 >= iterations_before_checkpointing);
-      if (reached_checkpoint) {
+      const bool at_checkpoint_iteration =
+          iter2 >= iterations_before_checkpointing;
+
+      // Run the free-boundary vacuum solve in a parallel region nested inside
+      // the persistent radial parallel region. This gives the vacuum solve its
+      // own thread count (m_vac_num_threads_), decoupled from the radial thread
+      // count (which is capped at ns/2). A single radial thread drives it; the
+      // other radial threads wait at the implicit barrier at the end of the
+      // 'omp single'. NESTOR reads its inputs from and writes its outputs to
+      // shared handover storage (m_h_), so the nested team - not the radial
+      // team - performs the whole solve.
+#ifdef _OPENMP
+#pragma omp single
+#endif  // _OPENMP
+      {
+#ifdef _OPENMP
+#pragma omp parallel num_threads(m_vac_num_threads_)
+#endif  // _OPENMP
+        {
+          int vac_thread_id = 0;
+#ifdef _OPENMP
+          vac_thread_id = omp_get_thread_num();
+          // Correctness depends on the nested team being granted exactly
+          // m_vac_num_threads_ threads: the tangential slices only cover the
+          // whole grid if every vac_thread_id runs. Fail loudly rather than
+          // silently under-cover the grid.
+          CHECK_EQ(omp_get_num_threads(), m_vac_num_threads_)
+              << "Nested vacuum parallel region was not granted the requested "
+                 "number of threads";
+#endif  // _OPENMP
+          const bool rc = (*m_fb_vac_)[vac_thread_id]->update(
+              m_h_.rCC_LCFS, m_h_.rSS_LCFS, m_h_.rSC_LCFS, m_h_.rCS_LCFS,
+              m_h_.zSC_LCFS, m_h_.zCS_LCFS, m_h_.zCC_LCFS, m_h_.zSS_LCFS,
+              signOfJacobian, m_h_.rAxis, m_h_.zAxis, &(m_h_.bSubUVac),
+              &(m_h_.bSubVVac), netToroidalCurrent, ivacskip, checkpoint,
+              at_checkpoint_iteration);
+          // All nested threads follow identical control flow and compute the
+          // same checkpoint result; record it once for the radial team.
+          if (vac_thread_id == 0) {
+            m_h_.vacuum_reached_checkpoint = rc;
+          }
+        }
+      }
+      // The 'omp single' implicit barrier publishes the shared vacuum outputs
+      // and the broadcast flag to all radial threads.
+      if (m_h_.vacuum_reached_checkpoint) {
         return true;
       }
 

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
@@ -7,7 +7,9 @@
 
 #include <Eigen/Dense>
 #include <climits>
+#include <memory>
 #include <span>
+#include <vector>
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -49,7 +51,8 @@ class IdealMhdModel {
                 const FourierBasisFastPoloidal* t, RadialProfiles* m_p,
                 const VmecConstants* constants, ThreadLocalStorage* m_ls,
                 HandoverStorage* m_h, const RadialPartitioning* r,
-                FreeBoundaryBase* m_fb, int signOfJacobian, int nvacskip,
+                const std::vector<std::unique_ptr<FreeBoundaryBase>>* m_fb_vac,
+                int vac_num_threads, int signOfJacobian, int nvacskip,
                 VacuumPressureState* m_vacuum_pressure_state);
 
   void setFromINDATA(int ncurr, double adiabaticIndex, double tCon0);
@@ -410,7 +413,14 @@ class IdealMhdModel {
   ThreadLocalStorage& m_ls_;
   HandoverStorage& m_h_;
   const RadialPartitioning& r_;
-  FreeBoundaryBase* m_fb_;
+  // Free-boundary vacuum solvers, shared across all radial threads and sized to
+  // m_vac_num_threads_ (decoupled from the radial thread count). The vacuum
+  // solve is driven from a nested parallel region in update(): a single radial
+  // thread spawns a team of m_vac_num_threads_ threads, each invoking
+  // (*m_fb_vac_)[vac_thread_id]->update() on its tangential slice. Owned by
+  // Vmec; may be nullptr / empty for fixed-boundary runs.
+  const std::vector<std::unique_ptr<FreeBoundaryBase>>* m_fb_vac_;
+  int m_vac_num_threads_;
   VacuumPressureState& m_vacuum_pressure_state_;
   std::int64_t force_evaluation_count_ = 0;
 

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -413,6 +413,54 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
   return false;
 }  // run
 
+void Vmec::SetupVacuumSolvers() {
+  // Compute the vacuum thread count once; it is ns-independent (depends only on
+  // the tangential grid size nZnT and the thread budget).
+  vac_num_threads_ = vmec_adjust_vacuum_num_threads(fc_.max_threads(), s_.nZnT);
+
+#ifdef _OPENMP
+  // The vacuum solve runs in a parallel region nested inside the persistent
+  // radial parallel region (see IdealMhdModel::update). Allow at least two
+  // active parallel levels so the nested team is actually granted its threads
+  // rather than being serialized to one.
+  omp_set_max_active_levels(2);
+#endif  // _OPENMP
+
+  fb_vac_.resize(vac_num_threads_);
+  tp_vac_.resize(vac_num_threads_);
+
+  for (int vac_thread_id = 0; vac_thread_id < vac_num_threads_;
+       ++vac_thread_id) {
+    tp_vac_[vac_thread_id] = std::make_unique<TangentialPartitioning>(
+        s_.nZnT, vac_num_threads_, vac_thread_id);
+
+    if (indata_.free_boundary_method == FreeBoundaryMethod::NESTOR) {
+      fb_vac_[vac_thread_id] = std::make_unique<Nestor>(
+          &s_, tp_vac_[vac_thread_id].get(), &mgrid_,
+          std::span<double>(matrixShare.data(), matrixShare.size()),
+          std::span<double>(bvecShare.data(), bvecShare.size()),
+          std::span<double>(h_.vacuum_magnetic_pressure.data(),
+                            h_.vacuum_magnetic_pressure.size()),
+          std::span<int>(iPiv.data(), iPiv.size()),
+          std::span<double>(h_.vacuum_b_r.data(), h_.vacuum_b_r.size()),
+          std::span<double>(h_.vacuum_b_phi.data(), h_.vacuum_b_phi.size()),
+          std::span<double>(h_.vacuum_b_z.data(), h_.vacuum_b_z.size()));
+    } else if (indata_.free_boundary_method == FreeBoundaryMethod::ONLY_COILS) {
+      fb_vac_[vac_thread_id] = std::make_unique<OnlyCoils>(
+          &s_, tp_vac_[vac_thread_id].get(), &mgrid_,
+          std::span<double>(h_.vacuum_magnetic_pressure.data(),
+                            h_.vacuum_magnetic_pressure.size()),
+          std::span<double>(h_.vacuum_b_r.data(), h_.vacuum_b_r.size()),
+          std::span<double>(h_.vacuum_b_phi.data(), h_.vacuum_b_phi.size()),
+          std::span<double>(h_.vacuum_b_z.data(), h_.vacuum_b_z.size()));
+    } else {
+      LOG(FATAL) << absl::StrCat("free boundary method '",
+                                 ToString(indata_.free_boundary_method),
+                                 "' not implemented yet");
+    }  // indata_.free_boundary_method
+  }  // vac_thread_id
+}  // SetupVacuumSolvers
+
 // initialize_radial quantities, return true if a checkpoint was reached
 bool Vmec::InitializeRadial(
     VmecCheckpoint checkpoint, int iterations_before_checkpointing, int nsval,
@@ -480,11 +528,21 @@ bool Vmec::InitializeRadial(
     num_threads_ = vmec_adjust_num_threads(fc_.max_threads(),
                                            fc_.num_surfaces_to_distribute);
 
+    // Set up the free-boundary vacuum solvers exactly once. Their thread count
+    // (vac_num_threads_) is decoupled from the radial num_threads_ and is
+    // ns-independent: the vacuum solve is parallelized over the tangential grid
+    // (nZnT), so it can use the full thread budget even at coarse multigrid
+    // steps where num_threads_ is capped at ns/2. The solvers (and their
+    // accumulated vacuum response matrix/RHS, which live in ns-independent
+    // Fourier space) persist across multigrid steps, reproducing Fortran VMEC's
+    // persistent vacuum state.
+    if (fc_.lfreeb && fb_vac_.empty()) {
+      SetupVacuumSolvers();
+    }
+
     r_.resize(num_threads_);
     ls_.resize(num_threads_);
     p_.resize(num_threads_);
-    fb_.resize(num_threads_);
-    tp_.resize(num_threads_);
     m_.resize(num_threads_);
     decomposed_x_.resize(num_threads_);
     physical_x_backup_.resize(num_threads_);
@@ -515,53 +573,14 @@ bool Vmec::InitializeRadial(
       // update profile parameterizations based on p****_type strings
       p_[thread_id]->setupInputProfiles();
 
-      // setup free-boundary solver
-      if (fc_.lfreeb) {
-        // Keep the existing free-boundary solver (and its accumulated vacuum
-        // response matrix and RHS, which live in ns-independent Fourier space)
-        // across multi-grid steps, reproducing Fortran VMEC's persistent vacuum
-        // state. On the first grid step there is no solver yet and it is built;
-        // later steps reuse it.
-        const bool reuse_solver = fb_[thread_id] != nullptr;
-        if (!reuse_solver) {
-          tp_[thread_id] = std::make_unique<TangentialPartitioning>(
-              s_.nZnT, num_threads_, thread_id);
-
-          if (indata_.free_boundary_method == FreeBoundaryMethod::NESTOR) {
-            fb_[thread_id] = std::make_unique<Nestor>(
-                &s_, tp_[thread_id].get(), &mgrid_,
-                std::span<double>(matrixShare.data(), matrixShare.size()),
-                std::span<double>(bvecShare.data(), bvecShare.size()),
-                std::span<double>(h_.vacuum_magnetic_pressure.data(),
-                                  h_.vacuum_magnetic_pressure.size()),
-                std::span<int>(iPiv.data(), iPiv.size()),
-                std::span<double>(h_.vacuum_b_r.data(), h_.vacuum_b_r.size()),
-                std::span<double>(h_.vacuum_b_phi.data(),
-                                  h_.vacuum_b_phi.size()),
-                std::span<double>(h_.vacuum_b_z.data(), h_.vacuum_b_z.size()));
-          } else if (indata_.free_boundary_method ==
-                     FreeBoundaryMethod::ONLY_COILS) {
-            fb_[thread_id] = std::make_unique<OnlyCoils>(
-                &s_, tp_[thread_id].get(), &mgrid_,
-                std::span<double>(h_.vacuum_magnetic_pressure.data(),
-                                  h_.vacuum_magnetic_pressure.size()),
-                std::span<double>(h_.vacuum_b_r.data(), h_.vacuum_b_r.size()),
-                std::span<double>(h_.vacuum_b_phi.data(),
-                                  h_.vacuum_b_phi.size()),
-                std::span<double>(h_.vacuum_b_z.data(), h_.vacuum_b_z.size()));
-          } else {
-            LOG(FATAL) << absl::StrCat("free boundary method '",
-                                       ToString(indata_.free_boundary_method),
-                                       "' not implemented yet");
-          }  // indata_.free_boundary_method
-        }  // !reuse_solver
-      }  // lfreeb
-
-      // setup MHD model
+      // setup MHD model. The free-boundary vacuum solvers (fb_vac_) are shared
+      // across all radial threads and driven from a nested parallel region, so
+      // the whole vector - not a per-thread solver - is handed to the model.
       m_[thread_id] = std::make_unique<IdealMhdModel>(
           &fc_, &s_, &t_, p_[thread_id].get(), &constants_,
-          ls_[thread_id].get(), &h_, r_[thread_id].get(), fb_[thread_id].get(),
-          kSignOfJacobian, indata_.nvacskip, &vacuum_pressure_state_);
+          ls_[thread_id].get(), &h_, r_[thread_id].get(), &fb_vac_,
+          vac_num_threads_, kSignOfJacobian, indata_.nvacskip,
+          &vacuum_pressure_state_);
       m_[thread_id]->setFromINDATA(indata_.ncurr, indata_.gamma, indata_.tcon0);
     }  // thread_id
 

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
@@ -117,6 +117,12 @@ class Vmec {
 
   // -------------------
 
+  // Build the free-boundary vacuum solvers (fb_vac_/tp_vac_) and compute
+  // vac_num_threads_. Call once, only when lfreeb is set and after the mgrid
+  // has been loaded. The solvers are ns-independent and persist across
+  // multigrid steps.
+  void SetupVacuumSolvers();
+
   bool InitializeRadial(
       VmecCheckpoint checkpoint, int maximum_iterations, int nsval, int ns_old,
       double& m_delt0,
@@ -184,11 +190,20 @@ class Vmec {
   OutputQuantities output_quantities_;
 
   int num_threads_;
+  // Thread count for the free-boundary (NESTOR) vacuum solve. Decoupled from
+  // num_threads_ (which is capped at ns/2) so the vacuum solve, which is
+  // parallelized over the tangential grid, can use the full thread budget even
+  // at coarse multigrid steps. Computed once (ns-independent).
+  int vac_num_threads_ = 0;
   std::vector<std::unique_ptr<RadialPartitioning>> r_;
   std::vector<std::unique_ptr<ThreadLocalStorage>> ls_;
   std::vector<std::unique_ptr<RadialProfiles>> p_;
-  std::vector<std::unique_ptr<FreeBoundaryBase>> fb_;
-  std::vector<std::unique_ptr<TangentialPartitioning>> tp_;
+  // Free-boundary vacuum solvers and their tangential partitioning. Sized to
+  // vac_num_threads_ and built exactly once (the vacuum solve is
+  // ns-independent). Driven from a nested parallel region; see
+  // IdealMhdModel::update.
+  std::vector<std::unique_ptr<FreeBoundaryBase>> fb_vac_;
+  std::vector<std::unique_ptr<TangentialPartitioning>> tp_vac_;
   std::vector<std::unique_ptr<IdealMhdModel>> m_;
   std::vector<std::unique_ptr<FourierGeometry>> decomposed_x_;
   std::vector<std::unique_ptr<FourierGeometry>> physical_x_backup_;

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
@@ -190,18 +190,12 @@ class Vmec {
   OutputQuantities output_quantities_;
 
   int num_threads_;
-  // Thread count for the free-boundary (NESTOR) vacuum solve. Decoupled from
-  // num_threads_ (which is capped at ns/2) so the vacuum solve, which is
-  // parallelized over the tangential grid, can use the full thread budget even
-  // at coarse multigrid steps. Computed once (ns-independent).
+  // Thread count for the free-boundary solve is decoupled from
+  // num_threads_ (which is capped at ns/2), since it's ns-independent.
   int vac_num_threads_ = 0;
   std::vector<std::unique_ptr<RadialPartitioning>> r_;
   std::vector<std::unique_ptr<ThreadLocalStorage>> ls_;
   std::vector<std::unique_ptr<RadialProfiles>> p_;
-  // Free-boundary vacuum solvers and their tangential partitioning. Sized to
-  // vac_num_threads_ and built exactly once (the vacuum solve is
-  // ns-independent). Driven from a nested parallel region; see
-  // IdealMhdModel::update.
   std::vector<std::unique_ptr<FreeBoundaryBase>> fb_vac_;
   std::vector<std::unique_ptr<TangentialPartitioning>> tp_vac_;
   std::vector<std::unique_ptr<IdealMhdModel>> m_;

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/external_magnetic_field/external_magnetic_field_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/external_magnetic_field/external_magnetic_field_test.cc
@@ -72,9 +72,9 @@ TEST_P(ExternalMagneticFieldTest, CheckExternalMagneticField) {
     ASSERT_TRUE(ifs_vac1n_bextern.is_open());
     json vac1n_bextern = json::parse(ifs_vac1n_bextern);
 
-    for (int thread_id = 0; thread_id < vmec.num_threads_; ++thread_id) {
-      const FreeBoundaryBase& n = *vmec.fb_[thread_id];
-      const TangentialPartitioning& tp = *vmec.tp_[thread_id];
+    for (int thread_id = 0; thread_id < vmec.vac_num_threads_; ++thread_id) {
+      const FreeBoundaryBase& n = *vmec.fb_vac_[thread_id];
+      const TangentialPartitioning& tp = *vmec.tp_vac_[thread_id];
       const ExternalMagneticField& ef = n.GetExternalMagneticField();
 
       // current along magnetic axis in Amperes

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/laplace_solver/laplace_solver_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/laplace_solver/laplace_solver_test.cc
@@ -81,10 +81,10 @@ TEST_P(FourPTest, CheckFourP) {
     const int nf = s.ntor;
     const int mf = s.mpol + 1;
 
-    for (int thread_id = 0; thread_id < vmec.num_threads_; ++thread_id) {
-      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_[thread_id]);
+    for (int thread_id = 0; thread_id < vmec.vac_num_threads_; ++thread_id) {
+      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_vac_[thread_id]);
 
-      const TangentialPartitioning& tp = *vmec.tp_[thread_id];
+      const TangentialPartitioning& tp = *vmec.tp_vac_[thread_id];
       const int numLocal = tp.ztMax - tp.ztMin;
 
       const SingularIntegrals& si = n.GetSingularIntegrals();
@@ -197,8 +197,8 @@ TEST_P(FourISymmTest, CheckFourISymm) {
     // in order to compare against Fortran single-threaded data
     std::vector<double> gstore_symm(s.nThetaReduced * s.nZeta);
 
-    for (int thread_id = 0; thread_id < vmec.num_threads_; ++thread_id) {
-      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_[thread_id]);
+    for (int thread_id = 0; thread_id < vmec.vac_num_threads_; ++thread_id) {
+      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_vac_[thread_id]);
 
       const LaplaceSolver& ls = n.GetLaplaceSolver();
 
@@ -274,10 +274,10 @@ TEST_P(FourIAccumulateGrpmnTest, CheckFourIAccumulateGrpmn) {
     const int nf = s.ntor;
     const int mf = s.mpol + 1;
 
-    for (int thread_id = 0; thread_id < vmec.num_threads_; ++thread_id) {
-      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_[thread_id]);
+    for (int thread_id = 0; thread_id < vmec.vac_num_threads_; ++thread_id) {
+      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_vac_[thread_id]);
 
-      const TangentialPartitioning& tp = *vmec.tp_[thread_id];
+      const TangentialPartitioning& tp = *vmec.tp_vac_[thread_id];
       const int numLocal = tp.ztMax - tp.ztMin;
 
       const LaplaceSolver& ls = n.GetLaplaceSolver();
@@ -377,8 +377,8 @@ TEST_P(FourIKvDftTest, CheckFourIKvDft) {
     const int size_a_temp = mnpd * (2 * nf + 1) * s.nThetaEff;
     std::vector<double> actemp_full(size_a_temp, 0.0);
     std::vector<double> astemp_full(size_a_temp);
-    for (int thread_id = 0; thread_id < vmec.num_threads_; ++thread_id) {
-      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_[thread_id]);
+    for (int thread_id = 0; thread_id < vmec.vac_num_threads_; ++thread_id) {
+      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_vac_[thread_id]);
 
       const LaplaceSolver& ls = n.GetLaplaceSolver();
 
@@ -522,8 +522,8 @@ TEST_P(FourIKuDftTest, CheckFourIKuDft) {
     // there must construct it here as well for testing
     std::vector<double> bvec_sin(mnpd);
 
-    for (int thread_id = 0; thread_id < vmec.num_threads_; ++thread_id) {
-      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_[thread_id]);
+    for (int thread_id = 0; thread_id < vmec.vac_num_threads_; ++thread_id) {
+      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_vac_[thread_id]);
 
       const LaplaceSolver& ls = n.GetLaplaceSolver();
       const SingularIntegrals& si = n.GetSingularIntegrals();
@@ -634,8 +634,8 @@ TEST_P(SolverInputsTest, CheckSolverInputs) {
     // there must construct it here as well for testing
     std::vector<double> bvec_sin(mnpd);
 
-    for (int thread_id = 0; thread_id < vmec.num_threads_; ++thread_id) {
-      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_[thread_id]);
+    for (int thread_id = 0; thread_id < vmec.vac_num_threads_; ++thread_id) {
+      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_vac_[thread_id]);
 
       const LaplaceSolver& ls = n.GetLaplaceSolver();
       const SingularIntegrals& si = n.GetSingularIntegrals();

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/nestor/nestor_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/nestor/nestor_test.cc
@@ -179,9 +179,9 @@ TEST_P(BsqVacTest, CheckBsqVac) {
     ASSERT_TRUE(ifs_vac1n_bsqvac.is_open());
     json vac1n_bsqvac = json::parse(ifs_vac1n_bsqvac);
 
-    for (int thread_id = 0; thread_id < vmec.num_threads_; ++thread_id) {
-      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_[thread_id]);
-      const TangentialPartitioning& tp = *vmec.tp_[thread_id];
+    for (int thread_id = 0; thread_id < vmec.vac_num_threads_; ++thread_id) {
+      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_vac_[thread_id]);
+      const TangentialPartitioning& tp = *vmec.tp_vac_[thread_id];
 
       for (int kl = tp.ztMin; kl < tp.ztMax; ++kl) {
         const int l = kl / s.nZeta;

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/regularized_integrals/regularized_integrals_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/regularized_integrals/regularized_integrals_test.cc
@@ -72,8 +72,8 @@ TEST_P(TanuTanvTest, CheckTanuTanv) {
         << "failed to open reference file: " << filename;
     json vac1n_precal = json::parse(ifs_vac1n_precal);
 
-    for (int thread_id = 0; thread_id < vmec.num_threads_; ++thread_id) {
-      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_[thread_id]);
+    for (int thread_id = 0; thread_id < vmec.vac_num_threads_; ++thread_id) {
+      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_vac_[thread_id]);
       const RegularizedIntegrals& ri = n.GetRegularizedIntegrals();
 
       for (int l = 0; l < s.nThetaEven; ++l) {
@@ -135,8 +135,8 @@ TEST_P(GreenFTest, CheckGreenF) {
     // accumulate contributions from all threads
     // in order to compare against Fortran single-threaded data
     std::vector<double> gstore(s.nZeta * s.nThetaEven);
-    for (int thread_id = 0; thread_id < vmec.num_threads_; ++thread_id) {
-      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_[thread_id]);
+    for (int thread_id = 0; thread_id < vmec.vac_num_threads_; ++thread_id) {
+      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_vac_[thread_id]);
       const RegularizedIntegrals& ri = n.GetRegularizedIntegrals();
       for (int kl = 0; kl < s.nZeta * s.nThetaEven; ++kl) {
         gstore[kl] += ri.gstore[kl];
@@ -158,9 +158,9 @@ TEST_P(GreenFTest, CheckGreenF) {
                                 tolerance));
     }
 
-    for (int thread_id = 0; thread_id < vmec.num_threads_; ++thread_id) {
-      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_[thread_id]);
-      const TangentialPartitioning& tp = *vmec.tp_[thread_id];
+    for (int thread_id = 0; thread_id < vmec.vac_num_threads_; ++thread_id) {
+      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_vac_[thread_id]);
+      const TangentialPartitioning& tp = *vmec.tp_vac_[thread_id];
       const RegularizedIntegrals& ri = n.GetRegularizedIntegrals();
 
       for (int klp = tp.ztMin; klp < tp.ztMax; ++klp) {

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/singular_integrals/singular_integrals_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/singular_integrals/singular_integrals_test.cc
@@ -79,8 +79,8 @@ TEST_P(CmnsTest, CheckCmns) {
     // included in cmns that must be accounted for in this test.
     const double alp = 2.0 * M_PI / s.nfp;
 
-    for (int thread_id = 0; thread_id < vmec.num_threads_; ++thread_id) {
-      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_[thread_id]);
+    for (int thread_id = 0; thread_id < vmec.vac_num_threads_; ++thread_id) {
+      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_vac_[thread_id]);
       const SingularIntegrals& si = n.GetSingularIntegrals();
 
       const int nf = s.ntor;
@@ -146,10 +146,10 @@ TEST_P(AnalytTest, CheckAnalyt) {
     const int mnfull = (2 * nf + 1) * (mf + 1);
     std::vector<double> bvec_sin(mnfull, 0.0);
 
-    for (int thread_id = 0; thread_id < vmec.num_threads_; ++thread_id) {
-      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_[thread_id]);
+    for (int thread_id = 0; thread_id < vmec.vac_num_threads_; ++thread_id) {
+      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_vac_[thread_id]);
 
-      const TangentialPartitioning& tp = *vmec.tp_[thread_id];
+      const TangentialPartitioning& tp = *vmec.tp_vac_[thread_id];
       const int numLocal = tp.ztMax - tp.ztMin;
 
       const SingularIntegrals& si = n.GetSingularIntegrals();

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/surface_geometry/surface_geometry_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/surface_geometry/surface_geometry_test.cc
@@ -77,9 +77,9 @@ TEST_P(SurfaceGeometryTest, CheckSurfaceGeometry) {
     ASSERT_TRUE(ifs_vac1n_surface.is_open());
     json vac1n_surface = json::parse(ifs_vac1n_surface);
 
-    for (int thread_id = 0; thread_id < vmec.num_threads_; ++thread_id) {
-      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_[thread_id]);
-      const TangentialPartitioning& tp = *vmec.tp_[thread_id];
+    for (int thread_id = 0; thread_id < vmec.vac_num_threads_; ++thread_id) {
+      const Nestor& n = static_cast<const Nestor&>(*vmec.fb_vac_[thread_id]);
+      const TangentialPartitioning& tp = *vmec.tp_vac_[thread_id];
       const SurfaceGeometry& sg = n.GetSurfaceGeometry();
 
       // full-surface quantities


### PR DESCRIPTION
## Problem

The whole equilibrium solve runs inside **one** persistent OpenMP parallel region (`Vmec::SolveEquilibrium`) whose team size is `num_threads_ = min(max_threads, ns/2)` — capped at `ns/2` because the radial descent needs ≥2 flux surfaces per thread.

The free-boundary **NESTOR vacuum solve runs inside that same region**, so it inherited the radial thread count. At the first multigrid step (`ns=5`) that is `min(16, 2) = 2` threads, even with `-t 16`. But NESTOR is parallelized over the tangential boundary grid `nZnT` (`nZeta·nThetaEff` ~ thousands of points), which could use the full thread budget. At coarse grids the vacuum solve was ~8× thread-starved. (Fortran PARVMEC avoids this with a separate vacuum communicator, `VNRANKS`.)

## Change

Give the vacuum solve its own thread count, decoupled from the radial one, via a **nested OpenMP region**:

- **`vac_num_threads_ = min(max_threads, nZnT)`** (`vmec_adjust_vacuum_num_threads`, `util.{h,cc}`) — computed once, ns-independent.
- **Vacuum solvers built once** in `Vmec::SetupVacuumSolvers()` (sized to `vac_num_threads_`), independent of the per-radial-thread setup loop. They persist across multigrid steps (the vacuum response matrix lives in ns-independent Fourier space).
- **`IdealMhdModel::update` drives the solve from a nested parallel region**: a single radial thread spawns `#pragma omp parallel num_threads(m_vac_num_threads_)`, each nested thread runs NESTOR on its tangential slice. `omp_set_max_active_levels(2)` enables nesting; a live `CHECK_EQ(omp_get_num_threads(), vac_num_threads_)` fails loudly if the team is under-provisioned (which would silently under-cover the tangential grid).
- **Checkpoint early-exit** is broadcast to the radial team via a shared `HandoverStorage::vacuum_reached_checkpoint` flag published by the `omp single` barrier.
- **Tests** under `vmecpp_large_cpp_tests/free_boundary/*` retargeted from `fb_`/`tp_`/`num_threads_` to `fb_vac_`/`tp_vac_`/`vac_num_threads_`.

### Why nested (not concurrent sections)
NESTOR is ~99% parallel (its only serial part, the LU solve, is ~0.3% of vacuum time), so the nested design already saturates all threads during the dominant vacuum phase. Overlapping the vacuum solve with the radial force work cannot beat it and is worse at coarse grids (it would reserve threads for near-zero radial work, starving the dominant vacuum workload).