### PR TITLE
Tolerate corrupted string variables in from_wout_file

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -1608,13 +1608,6 @@ class VmecWOut(BaseModelWithNumpy):
                             raw_bytes.decode("ascii").strip("\x00").strip()
                         )
                     except UnicodeDecodeError:
-                        # Some Fortran VMEC codes (e.g. PARVMEC) can leave
-                        # cosmetic string fields such as `curlabel` filled with
-                        # uninitialized memory instead of valid text when they
-                        # fail to read the corresponding mgrid attribute. These
-                        # fields are never used in the physics, so don't let a
-                        # single corrupted string abort loading an otherwise
-                        # valid wout file.
                         logger.warning(
                             "Could not decode variable '%s' as ascii text; "
                             "replacing it with an empty string.",

--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -1601,14 +1601,26 @@ class VmecWOut(BaseModelWithNumpy):
             attrs = {}
             for var_name, variable in fnc.variables.items():
                 if variable.dtype is str or variable.dtype == "S1":
-                    # Remove both zero-padding and whitespaces.
-                    attrs[var_name] = (
-                        fnc[var_name][()]
-                        .tobytes()
-                        .decode("ascii")
-                        .strip("\x00")
-                        .strip()
-                    )
+                    raw_bytes = fnc[var_name][()].tobytes()
+                    try:
+                        # Remove both zero-padding and whitespaces.
+                        attrs[var_name] = (
+                            raw_bytes.decode("ascii").strip("\x00").strip()
+                        )
+                    except UnicodeDecodeError:
+                        # Some Fortran VMEC codes (e.g. PARVMEC) can leave
+                        # cosmetic string fields such as `curlabel` filled with
+                        # uninitialized memory instead of valid text when they
+                        # fail to read the corresponding mgrid attribute. These
+                        # fields are never used in the physics, so don't let a
+                        # single corrupted string abort loading an otherwise
+                        # valid wout file.
+                        logger.warning(
+                            "Could not decode variable '%s' as ascii text; "
+                            "replacing it with an empty string.",
+                            var_name,
+                        )
+                        attrs[var_name] = ""
                 elif variable.ndim == 2:
                     # We transpose the 2D arrays to map from
                     # Column-major convention (Fortran) to Row-major (Python, C++)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,7 +8,9 @@ Physics correctness is checked at the level of the C++ core.
 """
 
 import json
+import logging
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -115,6 +117,31 @@ def test_vmecwout_load_from_fortran():
     wout_filename = REPO_ROOT / "examples" / "data" / "wout_cth_like_fixed_bdy.nc"
     loaded_wout = vmecpp.VmecWOut.from_wout_file(wout_filename)
     assert loaded_wout is not None
+
+
+def test_vmecwout_load_tolerates_corrupted_string_variable(tmp_path, caplog):
+    """A Fortran VMEC wout can have cosmetic string fields (e.g. `curlabel`) filled with
+    uninitialized/non-ASCII bytes when the code that produced it failed to read some
+    upstream attribute (this happens with PARVMEC and a single-coil-group mgrid file,
+    for instance).
+
+    Such garbage should not prevent loading the rest of an otherwise-valid wout file.
+    """
+    wout_filename = REPO_ROOT / "examples" / "data" / "wout_cth_like_fixed_bdy.nc"
+    corrupted_wout_filename = tmp_path / "wout_corrupted_string.nc"
+    shutil.copyfile(wout_filename, corrupted_wout_filename)
+
+    with netCDF4.Dataset(corrupted_wout_filename, "r+") as fnc:
+        raw = bytearray(fnc.variables["mgrid_file"][:].tobytes())
+        raw[3] = 0xDD  # not valid ASCII/UTF-8
+        fnc.variables["mgrid_file"][:] = np.frombuffer(bytes(raw), dtype="S1")
+
+    with caplog.at_level(logging.WARNING):
+        loaded_wout = vmecpp.VmecWOut.from_wout_file(corrupted_wout_filename)
+
+    assert loaded_wout is not None
+    assert loaded_wout.mgrid_file == ""
+    assert "mgrid_file" in caplog.text
 
 
 def test_vmecinput_io():

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -120,10 +120,7 @@ def test_vmecwout_load_from_fortran():
 
 
 def test_vmecwout_load_tolerates_corrupted_string_variable(tmp_path, caplog):
-    """A Fortran VMEC wout can have cosmetic string fields (e.g. `curlabel`) filled with
-    uninitialized/non-ASCII bytes when the code that produced it failed to read some
-    upstream attribute (this happens with PARVMEC and a single-coil-group mgrid file,
-    for instance).
+    """Robust against uninitialized/non-ASCII bytes.
 
     Such garbage should not prevent loading the rest of an otherwise-valid wout file.
     """


### PR DESCRIPTION
Some codes can leave cosmetic string fields such as curlabel filled with uninitialized memory instead of valid text, when they fail to read a corresponding mgrid attribute (observed with a single-coil-group mgrid file).
from_wout_file previously ASCII-decoded every string/char netCDF variable unconditionally, so one such garbage field aborted loading an otherwise perfectly valid wout file.

Catch UnicodeDecodeError per variable and fall back to an empty string with a logged warning instead.