### PR TITLE
Take the multigrid rollback backup after the radial interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ VMEC++:
 - supports inputs in the classic INDATA format as well as simpler-to-parse JSON files; it is also simple to construct input objects programmatically in Python
 - employs the same parallelization strategy as Fortran VMEC, but VMEC++ leverages OpenMP for a multi-thread implementation rather than Fortran VMEC's MPI parallelization: as a consequence it cannot parallelize over multiple nodes
 - Uses FFT kernels optimized for small mode numbers [generated using FFTX](https://github.com/spiral-software/fftx) instead of DFT for supported resolutions. They give a 10-20% speedup relative to the DFT counterparts.
-- implements the iteration algorithm of Fortran VMEC 8.52, which sometimes has different convergence behavior from (PAR)VMEC 9.0: some configurations might converge with VMEC++ and not with (PAR)VMEC 9.0, and vice versa
+- implements the iteration algorithm of Fortran VMEC 8.52, which sometimes has different convergence behavior from (PAR)VMEC 9.0: some configurations might converge with VMEC++ and not with (PAR)VMEC 9.0, and vice versa. One deliberate exception: at multigrid grid transitions, the rollback backup of the state vector is taken *after* the radial interpolation of the coarse-grid solution (matching PARVMEC/VMEC2000 since 2017-01-24, "SPH 012417"), not before it as in VMEC 8.52 -- with the 8.52 ordering, the first restart of a stage silently discards the interpolated state and the finer stages effectively re-solve from a cold start
 
 ### Limitations with respect to the Fortran implementations
 - non-stellarator-symmetric terms (`lasym == true`) are not supported yet

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/AGENTS.md
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/AGENTS.md
@@ -53,6 +53,12 @@ misbehaves, the velocity `decomposed_v_` is zeroed and the state is rolled back 
 - `BAD_PROGRESS` (residuals not decaying): `delt0r /= 1.03`.
 - `NO_RESTART` (good path): back up the current state into `physical_x_backup_`.
 
+At a multigrid stage transition, the initial backup is taken **after**
+`InterpolateToNextMultigridStep()`, so the stage's first rollback target is the
+interpolated coarse-grid solution. This follows PARVMEC/VMEC2000 (change
+"SPH 012417" in `initialize_radial.f`), deliberately deviating from VMEC 8.52,
+which backed up the pre-interpolation cold initial guess.
+
 Separately, **hot restart** seeds `run()` from a previously converged `HotRestartState`
 (`wout` + `indata`) via `FourierGeometry::InitFromState()`, used for parameter scans.
 The first element of `ns_array` must match the last `ns` of the restart state; subsequent

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -682,17 +682,6 @@ bool Vmec::InitializeRadial(
       return true;
     }
 
-    // restart_reason == NO_RESTART at entry of restart_iter means to store xc
-    // in xstore
-    for (int thread_id = 0; thread_id < num_threads_; ++thread_id) {
-      fc_.restart_reason = RestartReason::NO_RESTART;
-
-      // TODO(jons): what exactly happens here?
-      // Why do we mask potential changes on `indata_.delt` by passing a copy?
-      double delt_for_restart_iter = indata_.delt;
-      RestartIteration(delt_for_restart_iter, thread_id);
-    }
-
     // INTERPOLATE FROM COARSE (ns_old) TO NEXT FINER (ns) RADIAL GRID
     if (linterp) {
       InterpolateToNextMultigridStep(fc_.ns, fc_.ns_old, p_, r_, old_r_,
@@ -703,6 +692,20 @@ bool Vmec::InitializeRadial(
       if (checkpoint == VmecCheckpoint::INTERP) {
         return true;
       }
+    }
+
+    // restart_reason == NO_RESTART at entry of restart_iter means to store xc
+    // in xstore. The backup is taken AFTER the multigrid interpolation, so
+    // that the first rollback target of a continuation stage is the
+    // interpolated coarse-grid solution, not the cold boundary+axis initial
+    // guess that the interpolation overwrites. Fortran VMEC 8.52 backed up
+    // before the interpolation; PARVMEC/VMEC2000 moved the backup after it
+    // ("SPH 012417" in initialize_radial.f), which is what VMEC++ follows.
+    for (int thread_id = 0; thread_id < num_threads_; ++thread_id) {
+      fc_.restart_reason = RestartReason::NO_RESTART;
+
+      // RestartIteration does not modify the time step when NO_RESTART.
+      RestartIteration(indata_.delt, thread_id);
     }
 
     fc_.ns_old = fc_.ns;


### PR DESCRIPTION
Migrates one fix in iteration flow control that the Fortran VMEC lineage made after 8.52: at a multigrid grid transition, take the rollback backup *after* the radial interpolation, not before it. The catalog below maps every flow-control difference between VMEC 8.52 and PARVMEC/VMEC2000 to exact source lines, so this and any future adoption is deliberate and verifiable.

## Sources and how the changes are dated

| Lineage | Repo @ pinned commit | Role |
|---|---|---|
| VMEC 8.52 | [educational_VMEC @ 494ea11](https://github.com/jonathanschilling/educational_VMEC/tree/494ea119158480606001896aafb1dccc3256b49c) | faithful 8.52 reference; what VMEC++ is ported from |
| PARVMEC | [ORNL-Fusion/PARVMEC @ 385ab34](https://github.com/ORNL-Fusion/PARVMEC/tree/385ab341436a9d3050a5876b941b35af449b1d71) | post-2017 lineage |
| VMEC2000 | [hiddenSymmetries/VMEC2000 @ 728af8b](https://github.com/hiddenSymmetries/VMEC2000/tree/728af8bd6c796b36a0aa85fe298e507791e57c6e) | same flow control as PARVMEC (verified by diff of `evolve.f`, `eqsolve.f`, `initialize_radial.f`, `runvmec.f`: differences are MPI plumbing, buffer zeroing, and GMRES step limits only; all SPH tags and `TimeStepControl` identical) |

**There are no upstream commits to link.** PARVMEC's GitHub history starts with a bulk import on 2020-10-13 ([96e530d "Initial checkin of sources and build system"](https://github.com/ORNL-Fusion/PARVMEC/commit/96e530d)); the pre-2020 ORNL history is not public. Dating therefore relies on in-code comment tags (`SPH 012417` = 2017-01-24, `SPH:042117` = 2017-04-21, `M Drevlak 20130114` = 2013-01-14). Changes without a tag are placed by their structural coupling to tagged rewrites.

## Changes datable to the 8.52 -> 2017-01-24 window

### 1. Backup after (not before) the multigrid interpolation -- **adopted by this PR**

- 8.52: the rollback backup (`xstore <- xc` via `restart_iter`) is taken at [initialize_radial.f90#L97](https://github.com/jonathanschilling/educational_VMEC/blob/494ea119158480606001896aafb1dccc3256b49c/src/initialize_radial.f90#L97), *before* `interp` overwrites `xc` at [initialize_radial.f90#L103](https://github.com/jonathanschilling/educational_VMEC/blob/494ea119158480606001896aafb1dccc3256b49c/src/initialize_radial.f90#L103). A stage's first rollback therefore silently discards the interpolated seed; the fine stage re-solves from a cold start.
- PARVMEC: backup moved after the interpolation, tagged `!SPH 012417: move this AFTER interpolation call` at [initialize_radial.f#L146-L148](https://github.com/ORNL-Fusion/PARVMEC/blob/385ab341436a9d3050a5876b941b35af449b1d71/Sources/Initialization_Cleanup/initialize_radial.f#L146-L148) (interpolation at [L137-L139](https://github.com/ORNL-Fusion/PARVMEC/blob/385ab341436a9d3050a5876b941b35af449b1d71/Sources/Initialization_Cleanup/initialize_radial.f#L137-L139)).
- VMEC++: this PR, `Vmec::InitializeRadial` in `src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc` (the `RestartIteration(NO_RESTART)` loop now follows `InterpolateToNextMultigridStep`, with a provenance comment). Measured effect on this branch: the multigrid ladder finally outperforms a cold start at the final resolution (w7x to ns=199: 1.9x wall time; identical converged physics).

### 2. lgiveup / fgiveup early abort (M. Drevlak, 2013-01-14) -- identified, deliberately NOT adopted

- Absent in 8.52. PARVMEC: optional INDATA inputs (`lgiveup`, `fgiveup` default 30) added at [readin.f#L385](https://github.com/ORNL-Fusion/PARVMEC/blob/385ab341436a9d3050a5876b941b35af449b1d71/Sources/Input_Output/readin.f#L385) (tag `! M Drevlak 20130114`; also [vmec_params.f#L141](https://github.com/ORNL-Fusion/PARVMEC/blob/385ab341436a9d3050a5876b941b35af449b1d71/Sources/General/vmec_params.f#L141)); the check aborts the multigrid sequence when a stage ends with any residual above `fgiveup*ftol`, at [runvmec.f#L355-L366](https://github.com/ORNL-Fusion/PARVMEC/blob/385ab341436a9d3050a5876b941b35af449b1d71/Sources/TimeStep/runvmec.f#L355-L366).
- VMEC++: not implemented (`TODO` marker at `vmec.cc:361`). It is pure opt-in input surface with no effect on defaults; we prefer not to grow the INDATA surface for it now. This is the only other flow-control change datable to before 2017-01-24.

(For completeness: `max_main_iterations` from the same Drevlak/Geiger namelist line is *driver-level* -- it re-runs the final stage from the standalone `vmec.f` driver at [vmec.f#L350](https://github.com/ORNL-Fusion/PARVMEC/blob/385ab341436a9d3050a5876b941b35af449b1d71/Sources/TimeStep/vmec.f#L350) -- covered in VMEC++ by the Python API / hot restart, not solver flow control.)

## Changes dated AFTER 2017-01-24 (not adopted; the `SPH:042117` bundle)

### 3. Time-step control moved pre-step into evolve, with only-verified-good stores

- 8.52: `evolve` computes forces *and advances* `xc`; store/restore runs afterwards in `eqsolve` ([eqsolve.f90#L145-L176](https://github.com/jonathanschilling/educational_VMEC/blob/494ea119158480606001896aafb1dccc3256b49c/src/eqsolve.f90#L145-L176)). The stored state is the post-step `xc` whose residuals were never evaluated.
- PARVMEC: `CALL TimeStepControl` moved inside `evolve` between the force evaluation and the position update, tagged `!SPH:042117: MOVE TIME STEP CONTROL HERE (FROM END OF EQSOLVE) TO AVOID STORING A POSSIBLE irst=2 STATE` at [evolve.f#L161-L163](https://github.com/ORNL-Fusion/PARVMEC/blob/385ab341436a9d3050a5876b941b35af449b1d71/Sources/TimeStep/evolve.f#L161-L163); subroutine at [evolve.f#L243-L302](https://github.com/ORNL-Fusion/PARVMEC/blob/385ab341436a9d3050a5876b941b35af449b1d71/Sources/TimeStep/evolve.f#L243-L302).
- VMEC++: absent (8.52 placement in `SolveEquilibriumLoop`/`Evolve`). Main missing companion of item 4.

### 4. Dual residual minima (res0 + res1) and rewritten store/restore criteria

- 8.52 (`eqsolve.f90`): only the preconditioned minimum `res0`; store requires >10 quiet iterations ([L153-L156](https://github.com/jonathanschilling/educational_VMEC/blob/494ea119158480606001896aafb1dccc3256b49c/src/eqsolve.f90#L153-L156)); growth beyond `100*res0` punished ([L157-L159](https://github.com/jonathanschilling/educational_VMEC/blob/494ea119158480606001896aafb1dccc3256b49c/src/eqsolve.f90#L157-L159)); `fsqr+fsqz > 1e-2` stuck-check ([L160-L171](https://github.com/jonathanschilling/educational_VMEC/blob/494ea119158480606001896aafb1dccc3256b49c/src/eqsolve.f90#L160-L171)).
- PARVMEC (`TimeStepControl`, i.e. part of the 042117 rewrite): also tracks the minimum `res1` of the un-preconditioned residual ([evolve.f#L262-L269](https://github.com/ORNL-Fusion/PARVMEC/blob/385ab341436a9d3050a5876b941b35af449b1d71/Sources/TimeStep/evolve.f#L262-L269)); stores only when *both* minima improve, without the 10-iteration delay ([L273](https://github.com/ORNL-Fusion/PARVMEC/blob/385ab341436a9d3050a5876b941b35af449b1d71/Sources/TimeStep/evolve.f#L273)); growth threshold becomes `1e4` on either metric and is downgraded to a mild restore ([L283](https://github.com/ORNL-Fusion/PARVMEC/blob/385ab341436a9d3050a5876b941b35af449b1d71/Sources/TimeStep/evolve.f#L283)); the stuck-check is gone.
- VMEC++: available as the pre-existing `iteration_style = "parvmec"` opt-in (`vmec_indata.h#L50-L56`, criteria at `vmec.cc#L1005-L1054`); default remains `vmec_8_52`. **Caution**: the opt-in transplants these criteria *without* items 3 and 5 -- a combination that never existed upstream. Measured: with it, a plain w7x cold start at ns=51 freezes and aborts with `JACOBIAN_75_TIMES_BAD`, with or without this PR's backup fix. Do not default it before implementing the companions.

### 5. Rollbacks consume iterations

- 8.52: on the restore branch `iter2` is *not* incremented and `iter1` is reset to `iter2` ([eqsolve.f90#L178-L201](https://github.com/jonathanschilling/educational_VMEC/blob/494ea119158480606001896aafb1dccc3256b49c/src/eqsolve.f90#L178-L201)), so the residual minima and damping window re-seed after every rollback.
- PARVMEC: `iter2` increments unconditionally every force evaluation ([eqsolve.f#L185](https://github.com/ORNL-Fusion/PARVMEC/blob/385ab341436a9d3050a5876b941b35af449b1d71/Sources/TimeStep/eqsolve.f#L185)); minima persist across rollbacks. Undated tag-wise, but structurally part of the 042117 restructure (the restore branch left `eqsolve` with it).
- VMEC++: 8.52 behavior.

## Undated differences (kept at 8.52 behavior, deliberately)

### 6. Time-step re-arm at ijacob = 25 / 50

- 8.52: after the 25th (50th) Jacobian failure, `delt0r` is re-armed at `0.98*delt` (`0.96*delt`) of the user's original value and the stage restarts ([eqsolve.f90#L110-L125](https://github.com/jonathanschilling/educational_VMEC/blob/494ea119158480606001896aafb1dccc3256b49c/src/eqsolve.f90#L110-L125)).
- PARVMEC: the re-arm assignments are commented out (`!changed in restart` -- the change never materialized in `restart_iter`), the stage still restarts via `GOTO 1000`: [eqsolve.f#L136-L151](https://github.com/ORNL-Fusion/PARVMEC/blob/385ab341436a9d3050a5876b941b35af449b1d71/Sources/TimeStep/eqsolve.f#L136-L151) (label 1000 at [L53](https://github.com/ORNL-Fusion/PARVMEC/blob/385ab341436a9d3050a5876b941b35af449b1d71/Sources/TimeStep/eqsolve.f#L53)). So delt keeps its cumulative 0.9^n shrinkage, usually riding to the `ijacob >= 75` abort.
- VMEC++: 8.52 behavior, kept -- the re-arm gives a run a second chance at a useful step size; the PARVMEC state looks like an accidental regression.

### 7. Verified identical (no action)

`restart_iter` proper (store/restore, `xcdot = 0`, delt factors 0.9 and 1/1.03), the evolve damping/step formulas (`otau` window, `dtau` clamp 0.15, `b1`/`fac`, velocity update), the huge-initial-forces check, the bad-Jacobian axis-guess retry, the free-boundary vacuum soft start, adaptive `nvacskip`, and the `jacob_off`/ns=3 retry loop are functionally identical in 8.52 and PARVMEC; VMEC++ matches both. (`more_iter_flag` external-resume semantics pre-date 8.52 and have no VMEC++ counterpart; none is needed.)

## VMEC++ code map

| Item | VMEC++ location |
|---|---|
| 1 (this PR) | `vmec.cc` `Vmec::InitializeRadial`, backup loop after `InterpolateToNextMultigridStep` |
| 2 | `vmec.cc:361` (`TODO(jons): insert lgiveup/fgiveup logic here`) |
| 3, 4 | `vmec.cc:1005-1054` (`iteration_style` branches in `SolveEquilibriumLoop`), enum in `common/vmec_indata/vmec_indata.h:50-56` |
| 5 | `vmec.cc` `RestartIteration` at `:1151` + `iter1_` handling in `SolveEquilibriumLoop` |
| 6 | `vmec.cc` ijacob 25/50 branches in `SolveEquilibrium` |

Documentation updated in this PR: `README.md` (8.52-compatibility statement now carries this one deliberate exception) and `src/vmecpp/cpp/vmecpp/vmec/vmec/AGENTS.md` (restart-logic section).
