### PR TITLE
Raise allowed delt

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -1443,9 +1443,9 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
   // assume data is ok; will see when the physics starts to run...
 
   // delt
-  if (vmec_indata.delt <= 0.0 || vmec_indata.delt > 1.0) {
+  if (vmec_indata.delt <= 0.0 || vmec_indata.delt > 10.0) {
     return absl::InvalidArgumentError(absl::StrFormat(
-        "input variable 'delt' has to be in the range ]0.0, 1.0], but is %g\n",
+        "input variable 'delt' has to be in the range ]0.0, 10.0], but is %g\n",
         vmec_indata.delt));
   }
 

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
@@ -189,6 +189,23 @@ TEST(TestVmecINDATA, CheckDefaults) {
   }
 }  // CheckDefaults
 
+TEST(TestVmecINDATA, CheckDeltBounds) {
+  // delt may exceed 1 (the descent formulas are scale-invariant in delt and
+  // the runtime control walks an unstable step down); only delt <= 0 and the
+  // typo-guard upper bound are rejected.
+  VmecINDATA indata;
+  indata.delt = 2.0;
+  EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+  indata.delt = 10.0;
+  EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+  indata.delt = 10.5;
+  EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+  indata.delt = 0.0;
+  EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+  indata.delt = -0.5;
+  EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+}
+
 TEST(TestVmecINDATA, ToJson) {
   const absl::StatusOr<std::string> indata_json =
       ReadFile("vmecpp/test_data/cth_like_free_bdy.json");


### PR DESCRIPTION
Raise allowed delt


  No formula in the descent algorithm requires delt <= 1: the damping term
  b1 = 1 - delt * otav / 2 is scale-invariant in delt (invTau_ divides by
  the time step), and an unstable step is walked down at runtime by the
  bad-Jacobian / bad-progress control. The preconditioner normalizes the
  stiffest eigenvalue to O(1), so useful values sit near 1; the upper bound
  is only a typo guard, an order of magnitude above that scale.
  