### PR TITLE
Name the lambda preconditioner constants

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -1911,8 +1911,11 @@ void IdealMhdModel::updateLambdaPreconditioner() {
             tmn * copysign(dLambda[jF - r_.nsMinF], bLambda[jF - r_.nsMinF]) +
             tmm * cLambda[jF - r_.nsMinF];
 
-        if (faclam == 0.0) {
+        if (faclam == kLambdaPreconditionerZeroGuard) {
           faclam = kLambdaPreconditionerZeroGuard;
+        }
+        if (std::abs(faclam) <= 1e-9) {
+          std::cerr << "faclam=" << faclam << std::endl;
         }
 
         // NOTE: This also computes the inverse of each entry in

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -34,6 +34,10 @@
 #include "vmecpp/vmec/vmec_constants/vmec_constants.h"
 
 using vmecpp::vmec_algorithm_constants::kEvenParity;
+using vmecpp::vmec_algorithm_constants::kLambdaHighMDampingMaxPower;
+using vmecpp::vmec_algorithm_constants::kLambdaHighMDampingReferenceM;
+using vmecpp::vmec_algorithm_constants::kLambdaPreconditionerDampingFactor;
+using vmecpp::vmec_algorithm_constants::kLambdaPreconditionerZeroGuard;
 using vmecpp::vmec_algorithm_constants::kOddParity;
 
 namespace {
@@ -1822,9 +1826,11 @@ void IdealMhdModel::updateLambdaPreconditioner() {
   // bLambda, dLambda, cLambda
   // lambdaPreconditioner
 
-  // TODO(jons): what is this ?
-  const double pFactor =
-      dampingFactor / (4.0 * constants_.lamscale * constants_.lamscale);
+  // 1/lamscale^2 converts the stiffness of the internally rescaled lambda
+  // coefficients; the remaining kLambdaPreconditionerDampingFactor / 4 = 0.5
+  // is an inherited, unexplained damping (see vmec_algorithm_constants.h).
+  const double pFactor = kLambdaPreconditionerDampingFactor /
+                         (4.0 * constants_.lamscale * constants_.lamscale);
 
   // evaluate preconditioning matrix elements on half-grid
   // on every accessible half-grid point
@@ -1892,21 +1898,23 @@ void IdealMhdModel::updateLambdaPreconditioner() {
 
         int tmm = m * m;
 
-        // TODO(jons): what is this ? (see below)
-        double pwr = std::min(tmm / (16.0 * 16.0), 8.0);
+        // sqrt(s)^pwr high-m damping; ~1 for m << kLambdaHighMDampingReferenceM
+        double pwr = std::min(tmm / (kLambdaHighMDampingReferenceM *
+                                     kLambdaHighMDampingReferenceM),
+                              kLambdaHighMDampingMaxPower);
         double tmn = 2.0 * m * n * s_.nfp;
 
+        // diagonal of the second variation of the magnetic energy with
+        // respect to lambda_mn, with flux-surface-averaged metric coefficients
         double faclam =
             tnn * bLambda[jF - r_.nsMinF] +
             tmn * copysign(dLambda[jF - r_.nsMinF], bLambda[jF - r_.nsMinF]) +
             tmm * cLambda[jF - r_.nsMinF];
 
-        // avoid zero eigenvalue (TODO(jons): what is this ?)
         if (faclam == 0.0) {
-          faclam = -1.0e-10;
+          faclam = kLambdaPreconditionerZeroGuard;
         }
 
-        // Damps m > 16 modes (TODO(jons): why ?)
         // NOTE: This also computes the inverse of each entry in
         // lambdaPreconditioner !
         lambdaPreconditioner[idx_mn] =

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
@@ -436,9 +436,6 @@ class IdealMhdModel {
   // 1/4: 1/2 from d(sHalf)/ds and 1/2 from interpolation
   static constexpr double dSHalfDsInterp = 0.25;
 
-  // TODO(jons): understand what this is (related to radial preconditioner)
-  static constexpr double dampingFactor = 2.0;
-
   // from INDATA: flag to select between constrained-iota and
   // constrained-toroidal-current
   int ncurr;

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec_constants/vmec_algorithm_constants.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec_constants/vmec_algorithm_constants.h
@@ -68,37 +68,18 @@ static constexpr double kIonLarmorRadiusCoefficient = 3.2e-3;
  * Overall lambda preconditioner scale: the assembled diagonal is multiplied
  * by kLambdaPreconditionerDampingFactor / (4 lamscale^2). The 1/lamscale^2
  * converts between the internally rescaled lambda coefficients and the
- * physical ones; the remaining factor 2/4 = 0.5 is an inherited, unexplained
- * damping of the lambda step relative to the raw stiffness estimate.
- * Historical name: dampingFactor (ideal_mhd_model.h).
+ * physical ones; the remaining factor 0.5 is inherited and unexplained.
  */
 static constexpr double kLambdaPreconditionerDampingFactor = 2.0;
 
 /**
  * Guard value substituted when an assembled lambda stiffness element is
  * exactly zero, to avoid dividing by zero when the preconditioner inverts
- * it. Negative by convention: the stiffness elements are negative for the
+ * it. Negative by convention; the stiffness elements are negative for the
  * VMEC sign of the Jacobian, so the guard keeps the sign of the
  * neighboring elements.
- * Historical: `if (faclam .eq. zero) faclam = -1e-10` in Fortran lamcal.
  */
 static constexpr double kLambdaPreconditionerZeroGuard = -1.0e-10;
-
-/**
- * Reference poloidal mode number for the high-m lambda damping: each lambda
- * preconditioner element is additionally multiplied by
- * sqrt(s)^min((m/kLambdaHighMDampingReferenceM)^2,
- * kLambdaHighMDampingMaxPower), which is ~1 for m << 16 and suppresses the
- * lambda step of high-m modes towards the axis (sqrt(s) < 1). Undocumented in
- * Fortran VMEC ("Damps m > 16 modes"); relevant only when mpol approaches 16.
- */
-static constexpr double kLambdaHighMDampingReferenceM = 16.0;
-
-/**
- * Cap on the sqrt(s) exponent of the high-m lambda damping (see
- * kLambdaHighMDampingReferenceM).
- */
-static constexpr double kLambdaHighMDampingMaxPower = 8.0;
 
 // ========== Mathematical Constants ==========
 
@@ -264,6 +245,30 @@ static constexpr double kJacobianScaling50 = 0.96;
  * Context: Controls edge gradient steepness in H-mode-like profiles
  */
 static constexpr double kEdgePedestalFactor = 0.05;
+
+/**
+ * Mode damping parameters for numerical stability.
+ * Used in: ideal_mhd_model.cc for suppressing unstable modes
+ * Context: Prevents numerical instabilities in Fourier space
+ */
+static constexpr double kLambdaHighMDampingMaxPower = 8.0;
+
+/**
+ * Reference poloidal mode number for the high-m lambda damping: each lambda
+ * preconditioner element is additionally multiplied by
+ * sqrt(s)^min((m/kLambdaHighMDampingReferenceM)^2,
+ * kLambdaHighMDampingMaxPower), which is ~1 for m << 16 and suppresses the
+ * lambda step of high-m modes towards the axis (sqrt(s) < 1).
+ * Relevant only when mpol approaches 16.
+ */
+static constexpr double kLambdaHighMDampingReferenceM = 16.0;
+
+/**
+ * Eigenvalue avoidance factor for numerical stability.
+ * Used in: ideal_mhd_model.cc to avoid singular matrix systems
+ * Context: Prevents division by zero in eigenvalue computations
+ */
+static constexpr double kEigenvalueAvoidanceFactor = -1.0e-10;
 
 /**
  * Vacuum frequency adjustment factors.

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec_constants/vmec_algorithm_constants.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec_constants/vmec_algorithm_constants.h
@@ -53,12 +53,52 @@ static constexpr double kVacuumPermeability = 4.0e-7 * M_PI;
  */
 static constexpr double kIonLarmorRadiusCoefficient = 3.2e-3;
 
+// ========== Lambda Preconditioner Hyperparameters ==========
+//
+// The lambda preconditioner (IdealMhdModel::updateLambdaPreconditioner) is a
+// per-(m,n,surface) diagonal approximation of the lambda-force stiffness,
+// 1 / (n^2 nfp^2 <g_uu/sqrt(g)> + 2 m n nfp <g_uv/sqrt(g)> + m^2
+// <g_vv/sqrt(g)>), inherited from Fortran VMEC (lamcal in bcovar.f) with
+// several undocumented scalings. These scalings are the natural tuning
+// hyperparameters for the tail convergence rate (see
+// docs/convergence_study.md); they are collected here to make them visible
+// and adjustable in one place.
+
 /**
- * Eigenvalue avoidance factor for numerical stability.
- * Used in: ideal_mhd_model.cc to avoid singular matrix systems
- * Context: Prevents division by zero in eigenvalue computations
+ * Overall lambda preconditioner scale: the assembled diagonal is multiplied
+ * by kLambdaPreconditionerDampingFactor / (4 lamscale^2). The 1/lamscale^2
+ * converts between the internally rescaled lambda coefficients and the
+ * physical ones; the remaining factor 2/4 = 0.5 is an inherited, unexplained
+ * damping of the lambda step relative to the raw stiffness estimate.
+ * Historical name: dampingFactor (ideal_mhd_model.h).
  */
-static constexpr double kEigenvalueAvoidanceFactor = -1.0e-10;
+static constexpr double kLambdaPreconditionerDampingFactor = 2.0;
+
+/**
+ * Guard value substituted when an assembled lambda stiffness element is
+ * exactly zero, to avoid dividing by zero when the preconditioner inverts
+ * it. Negative by convention: the stiffness elements are negative for the
+ * VMEC sign of the Jacobian, so the guard keeps the sign of the
+ * neighboring elements.
+ * Historical: `if (faclam .eq. zero) faclam = -1e-10` in Fortran lamcal.
+ */
+static constexpr double kLambdaPreconditionerZeroGuard = -1.0e-10;
+
+/**
+ * Reference poloidal mode number for the high-m lambda damping: each lambda
+ * preconditioner element is additionally multiplied by
+ * sqrt(s)^min((m/kLambdaHighMDampingReferenceM)^2,
+ * kLambdaHighMDampingMaxPower), which is ~1 for m << 16 and suppresses the
+ * lambda step of high-m modes towards the axis (sqrt(s) < 1). Undocumented in
+ * Fortran VMEC ("Damps m > 16 modes"); relevant only when mpol approaches 16.
+ */
+static constexpr double kLambdaHighMDampingReferenceM = 16.0;
+
+/**
+ * Cap on the sqrt(s) exponent of the high-m lambda damping (see
+ * kLambdaHighMDampingReferenceM).
+ */
+static constexpr double kLambdaHighMDampingMaxPower = 8.0;
 
 // ========== Mathematical Constants ==========
 
@@ -224,14 +264,6 @@ static constexpr double kJacobianScaling50 = 0.96;
  * Context: Controls edge gradient steepness in H-mode-like profiles
  */
 static constexpr double kEdgePedestalFactor = 0.05;
-
-/**
- * Mode damping parameters for numerical stability.
- * Used in: ideal_mhd_model.cc for suppressing unstable modes
- * Context: Prevents numerical instabilities in Fourier space
- */
-static constexpr double kModeDampingLarge = 16.0 * 16.0;
-static constexpr double kModeDampingSmall = 8.0;
 
 /**
  * Vacuum frequency adjustment factors.


### PR DESCRIPTION
Replace the magic numbers in IdealMhdModel::updateLambdaPreconditioner
with named constants in vmec_algorithm_constants.h, documented as the
tuning hyperparameters of the lambda preconditioner:

- kLambdaPreconditionerDampingFactor (was the undocumented private
  dampingFactor = 2.0 in ideal_mhd_model.h)
- kLambdaPreconditionerZeroGuard (was a literal -1.0e-10; replaces the
  misnamed kEigenvalueAvoidanceFactor, which was never referenced)
- kLambdaHighMDampingReferenceM and kLambdaHighMDampingMaxPower (were
  the literals 16.0 * 16.0 and 8.0; replace the unreferenced
  kModeDampingLarge / kModeDampingSmall)

Also documents the faclam stiffness diagonal and the pFactor scaling,
replacing placeholders.