### PR TITLE
4-point Lagrange multigrid transfer (cubic / cubic_rho)

### DIFF
--- a/src/vmecpp/_iteration.py
+++ b/src/vmecpp/_iteration.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import enum
 import logging
 import math
+import typing
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
@@ -521,6 +522,7 @@ def solve_multigrid(
     vmec_input,
     *,
     iteration_style: str | None = None,
+    interpolation: typing.Literal["linear", "cubic", "cubic_rho"] | None = None,
     verbose: bool = False,
     callback: Callable[[IterationState], None] | None = None,
 ):
@@ -532,10 +534,15 @@ def solve_multigrid(
     is solved to its ``ftol_array`` / ``niter_array`` tolerance with
     :func:`solve_equilibrium`, and the converged geometry is interpolated onto
     the next stage's radial grid with ``VmecModel.refine_to`` (the C++
-    ``InterpolateToNextMultigridStep``). A stage that exhausts its iteration
-    budget without converging proceeds to the next stage, exactly as the C++
-    run does; a stage that hard-fails (unrecoverable bad Jacobian, the
-    ijacob >= 75 give-up) stops the ramp.
+    ``InterpolateToNextMultigridStep``). ``interpolation`` selects the radial
+    interpolant for those transfers: ``"linear"`` (2-point, VMEC 8.52
+    behavior), ``"cubic"`` (4-point Lagrange in s) or ``"cubic_rho"`` (4-point
+    Lagrange in rho = sqrt(s)); the higher-order interpolants reduce the
+    interpolation-added error of the stage seed down to the coarse grid's own
+    discretization error. ``None`` (default) keeps the linear scheme. A stage
+    that exhausts its iteration budget without converging proceeds to the next
+    stage, exactly as the C++ run does; a stage that hard-fails (unrecoverable
+    bad Jacobian, the ijacob >= 75 give-up) stops the ramp.
 
     ``ftol_array`` / ``niter_array`` entries are matched to ``ns_array``
     entries by ns value (``VmecModel.create`` / ``refine_to`` semantics);
@@ -550,6 +557,19 @@ def solve_multigrid(
         cpp_indata.iteration_style = getattr(
             _vmecpp.IterationStyle, iteration_style.upper()
         )
+
+    interpolation_scheme = None
+    if interpolation is not None:
+        try:
+            interpolation_scheme = getattr(
+                _vmecpp.MultigridInterpolationScheme, interpolation.upper()
+            )
+        except AttributeError:
+            msg = (
+                "solve_multigrid: unknown interpolation scheme "
+                f"'{interpolation}' (expected 'linear', 'cubic' or 'cubic_rho')"
+            )
+            raise ValueError(msg) from None
 
     ns_array = [int(ns) for ns in np.asarray(cpp_indata.ns_array)]
     if len(set(ns_array)) != len(ns_array):
@@ -570,7 +590,7 @@ def solve_multigrid(
         if model is None:
             model = _vmecpp.VmecModel.create(cpp_indata, ns)
         else:
-            model.refine_to(ns)
+            model.refine_to(ns, interpolation=interpolation_scheme)
         result = solve_equilibrium(
             model, style=iteration_style, verbose=verbose, callback=callback
         )

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -345,7 +345,8 @@ class VmecModel {
   // multi-grid sequencing; call this between solve_equilibrium calls to drive
   // the coarse->fine ramp from Python. `new_ns` must be finer than the current
   // ns (multi-grid only refines).
-  void RefineTo(int new_ns) {
+  void RefineTo(int new_ns, std::optional<vmecpp::MultigridInterpolationScheme>
+                                interpolation = std::nullopt) {
     vmecpp::Vmec &v = *vmec_;
     if (new_ns <= v.fc_.ns) {
       throw std::runtime_error("VmecModel.refine_to: new_ns (" +
@@ -383,7 +384,7 @@ class VmecModel {
     // InitializeRadial (rmsPhiP accumulates in evalRadialProfiles).
     v.constants_.reset();
     v.InitializeRadial(vmecpp::VmecCheckpoint::NONE, INT_MAX, new_ns, ns_old,
-                       delt0, std::nullopt);
+                       delt0, std::nullopt, interpolation);
     last_preconditioner_update_ = 0;
     last_full_update_nestor_ = 0;
   }
@@ -671,6 +672,14 @@ PYBIND11_MODULE(_vmecpp, m) {
   py::native_enum<vmecpp::IterationStyle>(m, "IterationStyle", "enum.Enum")
       .value("VMEC_8_52", vmecpp::IterationStyle::VMEC_8_52)
       .value("PARVMEC", vmecpp::IterationStyle::PARVMEC)
+      .export_values()
+      .finalize();
+
+  py::native_enum<vmecpp::MultigridInterpolationScheme>(
+      m, "MultigridInterpolationScheme", "enum.Enum")
+      .value("LINEAR", vmecpp::MultigridInterpolationScheme::kLinear)
+      .value("CUBIC", vmecpp::MultigridInterpolationScheme::kCubic)
+      .value("CUBIC_RHO", vmecpp::MultigridInterpolationScheme::kCubicRho)
       .export_values()
       .finalize();
 
@@ -1278,7 +1287,8 @@ PYBIND11_MODULE(_vmecpp, m) {
       .def("reset_to_initial_guess", &VmecModel::ResetToInitialGuess)
       .def("recompute_axis", &VmecModel::RecomputeAxis)
       .def("reinitialize", &VmecModel::Reinitialize)
-      .def("refine_to", &VmecModel::RefineTo, py::arg("new_ns"))
+      .def("refine_to", &VmecModel::RefineTo, py::arg("new_ns"),
+           py::arg("interpolation") = py::none())
       .def("solve", &VmecModel::Solve)
       .def("get_state", &VmecModel::GetState)
       .def("set_state", &VmecModel::SetState, py::arg("state"))

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -5,6 +5,8 @@
 #include "vmecpp/vmec/vmec/vmec.h"
 
 #include <algorithm>
+#include <array>
+#include <cmath>
 #include <cstdio>
 #include <iostream>
 #include <memory>
@@ -34,6 +36,7 @@
 #include "vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.h"
 
 namespace {
+
 void UpdateStatusForThread(absl::Status& m_status_of_all_threads, int thread_id,
                            const absl::Status& thread_status) {
   CHECK(!thread_status.ok()) << "UpdateStatusForThread expects an error status";
@@ -477,7 +480,8 @@ void Vmec::SetupVacuumSolvers() {
 bool Vmec::InitializeRadial(
     VmecCheckpoint checkpoint, int iterations_before_checkpointing, int nsval,
     int ns_old, double& m_delt0,
-    const std::optional<HotRestartState>& initial_state) {
+    const std::optional<HotRestartState>& initial_state,
+    std::optional<MultigridInterpolationScheme> interpolation_scheme) {
   // Stage info output is now handled by logger_.BeginStage() in run().
 
   // Set timestep control parameters
@@ -685,7 +689,8 @@ bool Vmec::InitializeRadial(
     // INTERPOLATE FROM COARSE (ns_old) TO NEXT FINER (ns) RADIAL GRID
     if (linterp) {
       InterpolateToNextMultigridStep(fc_.ns, fc_.ns_old, p_, r_, old_r_,
-                                     decomposed_x_, old_xc_scaled_);
+                                     decomposed_x_, old_xc_scaled_,
+                                     interpolation_scheme);
 
       // TODO(jons): check for max_multigrid_steps
       // TODO(jons): maybe need `&& iter2_ >= maximum_iterations) {` ?
@@ -1714,7 +1719,8 @@ void Vmec::InterpolateToNextMultigridStep(
     const std::vector<std::unique_ptr<RadialPartitioning>>& r_new,
     const std::vector<std::unique_ptr<RadialPartitioning>>& r_old,
     std::vector<std::unique_ptr<FourierGeometry>>& m_x_new,
-    std::vector<std::unique_ptr<FourierGeometry>>& m_x_old) {
+    std::vector<std::unique_ptr<FourierGeometry>>& m_x_old,
+    std::optional<MultigridInterpolationScheme> interpolation_scheme) {
   // INTERPOLATE R,Z AND LAMBDA ON FULL GRID
   // (EXTRAPOLATE M=1 MODES,OVER SQRT(S), TO ORIGIN)
   // ON ENTRY, XOLD = X(COARSE MESH) * SCALXC(COARSE MESH)
@@ -1809,133 +1815,114 @@ void Vmec::InterpolateToNextMultigridStep(
   // ------------------------
   // radial interpolation from old, coarse state vector to new, finer state
   // vector
+  std::vector<std::span<double> FourierGeometry::*> coefficient_members = {
+      &FourierGeometry::rmncc, &FourierGeometry::zmnsc,
+      &FourierGeometry::lmnsc};
+  if (s_.lthreed) {
+    coefficient_members.push_back(&FourierGeometry::rmnss);
+    coefficient_members.push_back(&FourierGeometry::zmncs);
+    coefficient_members.push_back(&FourierGeometry::lmncs);
+  }
+  if (s_.lasym) {
+    coefficient_members.push_back(&FourierGeometry::rmnsc);
+    coefficient_members.push_back(&FourierGeometry::zmncc);
+    coefficient_members.push_back(&FourierGeometry::lmncc);
+    if (s_.lthreed) {
+      coefficient_members.push_back(&FourierGeometry::rmncs);
+      coefficient_members.push_back(&FourierGeometry::zmnss);
+      coefficient_members.push_back(&FourierGeometry::lmnss);
+    }
+  }
 
-  sj.resize(ns_new);
-  js1.resize(ns_new);
-  js2.resize(ns_new);
-  s1.resize(ns_new);
-  xint.resize(ns_new);
+  const MultigridInterpolationScheme scheme =
+      interpolation_scheme.value_or(MultigridInterpolationScheme::kLinear);
 
   for (int thread_id = 0; thread_id < num_threads_new; ++thread_id) {
     for (int jNew = r_new[thread_id]->nsMinF1; jNew < r_new[thread_id]->nsMaxF1;
          ++jNew) {
-      sj[jNew] = jNew / (ns_new - 1.0);
+      const double sj = jNew / (ns_new - 1.0);
 
-      // entries around radial position of jNew on old grid
-      js1[jNew] = (jNew * (ns_old - 1)) / (ns_new - 1);
-      js2[jNew] = std::min(js1[jNew] + 1, ns_old - 1);
+      // old-grid interval [js1, js2] around the new radial position
+      const int js1 = (jNew * (ns_old - 1)) / (ns_new - 1);
+      const int js2 = std::min(js1 + 1, ns_old - 1);
 
-      s1[jNew] = js1[jNew] * hs_old;
+      // interpolation stencil on the old radial grid and its weights
+      std::array<int, 4> stencil{};
+      std::array<double, 4> weight{};
+      int stencil_size = 0;
 
-      // interpolation weight
-      xint[jNew] = (sj[jNew] - s1[jNew]) / hs_old;
-      xint[jNew] = std::min(1.0, xint[jNew]);
-      xint[jNew] = std::max(0.0, xint[jNew]);
-
-      // now need to figure out source threads, which have js1 and js2
-      // and the target thread that has jNew
-      int thread_with_js1 = 0;
-      int thread_with_js2 = 0;
-      for (int old_thread_id = 0; old_thread_id < num_threads_old;
-           ++old_thread_id) {
-        const int nsMinF1 = r_old[old_thread_id]->nsMinF1;
-        const int nsMaxF1 = r_old[old_thread_id]->nsMaxF1;
-        if (nsMinF1 <= js1[jNew] && js1[jNew] < nsMaxF1) {
-          thread_with_js1 = old_thread_id;
+      if (scheme == MultigridInterpolationScheme::kLinear || ns_old < 4) {
+        double xint = (sj - js1 * hs_old) / hs_old;
+        xint = std::min(1.0, std::max(0.0, xint));
+        stencil = {js1, js2, 0, 0};
+        weight = {1.0 - xint, xint, 0.0, 0.0};
+        stencil_size = 2;
+      } else {
+        // 4-point Lagrange stencil around [js1, js2], shifted inward at the
+        // radial-domain ends; reproduces old-grid values exactly when the new
+        // position coincides with an old grid point (e.g. at the LCFS).
+        const int base = std::min(std::max(js1 - 1, 0), ns_old - 4);
+        std::array<double, 4> node{};
+        double target = sj;
+        for (int k = 0; k < 4; ++k) {
+          stencil[k] = base + k;
+          node[k] = stencil[k] * hs_old;
         }
-        if (nsMinF1 <= js2[jNew] && js2[jNew] < nsMaxF1) {
-          thread_with_js2 = old_thread_id;
+        if (scheme == MultigridInterpolationScheme::kCubicRho) {
+          target = std::sqrt(sj);
+          for (int k = 0; k < 4; ++k) {
+            node[k] = std::sqrt(node[k]);
+          }
         }
-      }  // old_thread_id
+        for (int k = 0; k < 4; ++k) {
+          double w = 1.0;
+          for (int l = 0; l < 4; ++l) {
+            if (l != k) {
+              w *= (target - node[l]) / (node[k] - node[l]);
+            }
+          }
+          weight[k] = w;
+        }
+        stencil_size = 4;
+      }
+
+      // owning old-partitioning thread for every stencil point
+      std::array<int, 4> source_thread{};
+      for (int k = 0; k < stencil_size; ++k) {
+        for (int old_thread_id = 0; old_thread_id < num_threads_old;
+             ++old_thread_id) {
+          if (r_old[old_thread_id]->nsMinF1 <= stencil[k] &&
+              stencil[k] < r_old[old_thread_id]->nsMaxF1) {
+            source_thread[k] = old_thread_id;
+          }
+        }  // old_thread_id
+      }  // k
 
       // now can actually perform interpolation
       for (int m = 0; m < s_.mpol; ++m) {
-        for (int n = 0; n < s_.ntor + 1; ++n) {
-          const int m_parity = m % 2;
+        const int m_parity = m % 2;
+        const double scalxc =
+            p[thread_id]
+                ->scalxc[(jNew - r_new[thread_id]->nsMinF1) * 2 + m_parity];
 
-          const int idx_fc_js1 =
-              ((js1[jNew] - m_x_old[thread_with_js1]->nsMin()) * s_.mpol + m) *
-                  (s_.ntor + 1) +
-              n;
-          const int idx_fc_js2 =
-              ((js2[jNew] - m_x_old[thread_with_js2]->nsMin()) * s_.mpol + m) *
-                  (s_.ntor + 1) +
-              n;
+        for (int n = 0; n < s_.ntor + 1; ++n) {
           const int idx_fc_jNew =
               ((jNew - m_x_new[thread_id]->nsMin()) * s_.mpol + m) *
                   (s_.ntor + 1) +
               n;
 
-          const double scalxc =
-              p[thread_id]
-                  ->scalxc[(jNew - r_new[thread_id]->nsMinF1) * 2 + m_parity];
-
-          m_x_new[thread_id]->rmncc[idx_fc_jNew] =
-              ((1.0 - xint[jNew]) *
-                   m_x_old[thread_with_js1]->rmncc[idx_fc_js1] +
-               xint[jNew] * m_x_old[thread_with_js2]->rmncc[idx_fc_js2]) /
-              scalxc;
-          m_x_new[thread_id]->zmnsc[idx_fc_jNew] =
-              ((1.0 - xint[jNew]) *
-                   m_x_old[thread_with_js1]->zmnsc[idx_fc_js1] +
-               xint[jNew] * m_x_old[thread_with_js2]->zmnsc[idx_fc_js2]) /
-              scalxc;
-          m_x_new[thread_id]->lmnsc[idx_fc_jNew] =
-              ((1.0 - xint[jNew]) *
-                   m_x_old[thread_with_js1]->lmnsc[idx_fc_js1] +
-               xint[jNew] * m_x_old[thread_with_js2]->lmnsc[idx_fc_js2]) /
-              scalxc;
-          if (s_.lthreed) {
-            m_x_new[thread_id]->rmnss[idx_fc_jNew] =
-                ((1.0 - xint[jNew]) *
-                     m_x_old[thread_with_js1]->rmnss[idx_fc_js1] +
-                 xint[jNew] * m_x_old[thread_with_js2]->rmnss[idx_fc_js2]) /
-                scalxc;
-            m_x_new[thread_id]->zmncs[idx_fc_jNew] =
-                ((1.0 - xint[jNew]) *
-                     m_x_old[thread_with_js1]->zmncs[idx_fc_js1] +
-                 xint[jNew] * m_x_old[thread_with_js2]->zmncs[idx_fc_js2]) /
-                scalxc;
-            m_x_new[thread_id]->lmncs[idx_fc_jNew] =
-                ((1.0 - xint[jNew]) *
-                     m_x_old[thread_with_js1]->lmncs[idx_fc_js1] +
-                 xint[jNew] * m_x_old[thread_with_js2]->lmncs[idx_fc_js2]) /
-                scalxc;
-          }
-          if (s_.lasym) {
-            m_x_new[thread_id]->rmnsc[idx_fc_jNew] =
-                ((1.0 - xint[jNew]) *
-                     m_x_old[thread_with_js1]->rmnsc[idx_fc_js1] +
-                 xint[jNew] * m_x_old[thread_with_js2]->rmnsc[idx_fc_js2]) /
-                scalxc;
-            m_x_new[thread_id]->zmncc[idx_fc_jNew] =
-                ((1.0 - xint[jNew]) *
-                     m_x_old[thread_with_js1]->zmncc[idx_fc_js1] +
-                 xint[jNew] * m_x_old[thread_with_js2]->zmncc[idx_fc_js2]) /
-                scalxc;
-            m_x_new[thread_id]->lmncc[idx_fc_jNew] =
-                ((1.0 - xint[jNew]) *
-                     m_x_old[thread_with_js1]->lmncc[idx_fc_js1] +
-                 xint[jNew] * m_x_old[thread_with_js2]->lmncc[idx_fc_js2]) /
-                scalxc;
-            if (s_.lthreed) {
-              m_x_new[thread_id]->rmncs[idx_fc_jNew] =
-                  ((1.0 - xint[jNew]) *
-                       m_x_old[thread_with_js1]->rmncs[idx_fc_js1] +
-                   xint[jNew] * m_x_old[thread_with_js2]->rmncs[idx_fc_js2]) /
-                  scalxc;
-              m_x_new[thread_id]->zmnss[idx_fc_jNew] =
-                  ((1.0 - xint[jNew]) *
-                       m_x_old[thread_with_js1]->zmnss[idx_fc_js1] +
-                   xint[jNew] * m_x_old[thread_with_js2]->zmnss[idx_fc_js2]) /
-                  scalxc;
-              m_x_new[thread_id]->lmnss[idx_fc_jNew] =
-                  ((1.0 - xint[jNew]) *
-                       m_x_old[thread_with_js1]->lmnss[idx_fc_js1] +
-                   xint[jNew] * m_x_old[thread_with_js2]->lmnss[idx_fc_js2]) /
-                  scalxc;
-            }
-          }
+          for (const auto member : coefficient_members) {
+            double value = 0.0;
+            for (int k = 0; k < stencil_size; ++k) {
+              const FourierGeometry& source = *m_x_old[source_thread[k]];
+              const int idx_fc_k =
+                  ((stencil[k] - source.nsMin()) * s_.mpol + m) *
+                      (s_.ntor + 1) +
+                  n;
+              value += weight[k] * (source.*member)[idx_fc_k];
+            }  // k
+            ((*m_x_new[thread_id]).*member)[idx_fc_jNew] = value / scalxc;
+          }  // member
         }  // n
       }  // m
     }  // jNew

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
@@ -9,7 +9,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
-#include <utility>  // std::move
+#include <utility>
 #include <vector>
 
 #include "vmecpp/common/makegrid_lib/makegrid_lib.h"
@@ -32,6 +32,16 @@
 #include "vmecpp/vmec/vmec_constants/vmec_constants.h"
 
 namespace vmecpp {
+
+enum class MultigridInterpolationScheme : std::uint8_t {
+  // 2-point linear interpolation in s (VMEC 8.52 behavior)
+  kLinear,
+  // 4-point Lagrange interpolation in s
+  kCubic,
+  // 4-point Lagrange interpolation in rho = sqrt(s), the natural radial
+  // variable near the magnetic axis
+  kCubicRho,
+};
 
 // The state we need to hot-restart a VMEC++ run.
 struct HotRestartState {
@@ -126,7 +136,9 @@ class Vmec {
   bool InitializeRadial(
       VmecCheckpoint checkpoint, int maximum_iterations, int nsval, int ns_old,
       double& m_delt0,
-      const std::optional<HotRestartState>& initial_state = std::nullopt);
+      const std::optional<HotRestartState>& initial_state = std::nullopt,
+      std::optional<MultigridInterpolationScheme> interpolation_scheme =
+          std::nullopt);
   absl::StatusOr<bool> SolveEquilibrium(VmecCheckpoint checkpoint,
                                         int maximum_iterations);
   void RestartIteration(double& m_delt0r, int thread_id);
@@ -144,7 +156,9 @@ class Vmec {
       const std::vector<std::unique_ptr<RadialPartitioning>>& r_new,
       const std::vector<std::unique_ptr<RadialPartitioning>>& r_old,
       std::vector<std::unique_ptr<FourierGeometry>>& m_x_new,
-      std::vector<std::unique_ptr<FourierGeometry>>& m_x_old);
+      std::vector<std::unique_ptr<FourierGeometry>>& m_x_old,
+      std::optional<MultigridInterpolationScheme> interpolation_scheme =
+          std::nullopt);
   // -------------------
 
   bool updateFwdModel(IdealMhdModel& m_m, FourierGeometry& m_decomposed_x,
@@ -206,11 +220,6 @@ class Vmec {
   std::vector<std::unique_ptr<FourierForces>> physical_f_;
   std::vector<std::unique_ptr<FourierVelocity>> decomposed_v_;
 
-  Eigen::VectorXd sj;
-  Eigen::VectorXi js1;
-  Eigen::VectorXi js2;
-  Eigen::VectorXd s1;
-  Eigen::VectorXd xint;
   std::vector<std::unique_ptr<FourierGeometry>> old_xc_scaled_;
   std::vector<std::unique_ptr<RadialPartitioning>> old_r_;
 

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/vmec/vmec_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/vmec/vmec_test.cc
@@ -34,7 +34,6 @@ using file_io::ReadFile;
 using testing::IsCloseRelAbs;
 
 using ::testing::DoubleNear;
-using ::testing::ElementsAreArray;
 using ::testing::Pointwise;
 using ::testing::TestWithParam;
 using ::testing::Values;
@@ -425,12 +424,6 @@ TEST_P(InterpTest, CheckInterp) {
   ASSERT_TRUE(ifs_interp.is_open())
       << "failed to open reference file: " << filename;
   json interp = json::parse(ifs_interp);
-
-  EXPECT_THAT(vmec.sj, ElementsAreArray(interp["sj"]));
-  EXPECT_THAT(vmec.js1, ElementsAreArray(interp["js1"]));
-  EXPECT_THAT(vmec.js2, ElementsAreArray(interp["js2"]));
-  EXPECT_THAT(vmec.s1, ElementsAreArray(interp["s1"]));
-  EXPECT_THAT(vmec.xint, ElementsAreArray(interp["xint"]));
 
   // test previous xc
   std::size_t num_threads_old = vmec.old_xc_scaled_.size();

--- a/tests/test_iteration.py
+++ b/tests/test_iteration.py
@@ -208,6 +208,33 @@ def test_alternative_styles_converge_cma():
     assert results["parvmec"].restarts == 0
 
 
+def test_multigrid_interpolation_scheme_improves_seed():
+    """The cubic multigrid interpolant reduces the interpolated-seed force residual of a
+    continuation stage (down to the coarse solution's own truncation error)."""
+    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA / "cth_like_fixed_bdy.json")
+    vmec_input.ns_array = np.array([13, 25])
+    vmec_input.ftol_array = np.array([1.0e-9, 1.0e-16])
+    # stage 2 only needs its first force evaluation (the seed quality)
+    vmec_input.niter_array = np.array([3000, 1])
+
+    entry = {}
+    for interpolation in ("linear", "cubic", "cubic_rho"):
+        history: list[vmecpp.IterationState] = []
+        vmecpp.solve_multigrid(
+            vmec_input, interpolation=interpolation, callback=history.append
+        )
+        it = [s.iteration for s in history]
+        stage2_start = next(i for i in range(1, len(it)) if it[i] < it[i - 1])
+        entry[interpolation] = history[stage2_start].fsq_invariant
+
+    # the 4-point interpolants must clearly beat the 2-point one
+    assert entry["cubic"] < entry["linear"] / 3
+    assert entry["cubic_rho"] < entry["linear"] / 3
+
+    with pytest.raises(ValueError, match="unknown interpolation scheme"):
+        vmecpp.solve_multigrid(vmec_input, interpolation="quintic")  # type: ignore[arg-type]
+
+
 def test_native_parvmec_matches_python_parvmec():
     """The native C++ PARVMEC control reproduces the ported Python PARVMEC control.
 


### PR DESCRIPTION
Add an optional MultigridInterpolationScheme enum (linear, cubic, cubic_rho) for Vmec::InterpolateToNextMultigridStep and rewrite the transfer loop:

- linear keeps the VMEC 8.52 2-point scheme (default, and forced when the coarse grid has fewer than 4 surfaces); cubic uses a 4-point Lagrange stencil in s; cubic_rho interpolates in rho = sqrt(s), the natural radial variable near the magnetic axis. The 4-point stencil is shifted inward at the radial-domain ends and reproduces old-grid values exactly on coinciding grid points.
- The higher-order interpolants reduce the interpolated-seed force residual of a continuation stage down to the coarse solution's own truncation error