### PR TITLE
First-evolved-surface lambda preconditioner boost API

### DIFF
--- a/src/vmecpp/_iteration.py
+++ b/src/vmecpp/_iteration.py
@@ -79,6 +79,19 @@ _VMEC_8_52_BLOWUP = 100.0
 _PARVMEC_BLOWUP = 1.0e4
 _ROBUST_BLOWUP = 1.0e3
 
+# Lambda-preconditioner boost (solve_multigrid(lambda_preconditioner_boost=True)):
+# scale the lambda preconditioner elements for the m <= 1 modes on the first
+# evolved (off-axis) surface, where the flux-surface-averaged stiffness
+# estimate (faclam) overestimates what the descent actually feels by ~5-10x.
+# Fine radial attribution on w7x [25,99] (docs/convergence_study.md, Finding
+# 12): boosting jF <= 1 alone recovers the full -23% of the whole-radius
+# boost (1979 -> 1520 iterations); jF = 0 has no lambda DOF (exact no-op) and
+# wider m- or j-windows add nothing. A preconditioner rescaling cannot move
+# the converged force balance.
+_LAMBDA_BOOST_SCALE = 5.0
+_LAMBDA_BOOST_MMAX = 1
+_LAMBDA_BOOST_JMAX = 1
+
 _logger = logging.getLogger(__name__)
 
 
@@ -523,6 +536,7 @@ def solve_multigrid(
     *,
     iteration_style: str | None = None,
     interpolation: typing.Literal["linear", "cubic", "cubic_rho"] | None = None,
+    lambda_preconditioner_boost: bool = False,
     verbose: bool = False,
     callback: Callable[[IterationState], None] | None = None,
 ):
@@ -543,6 +557,16 @@ def solve_multigrid(
     that exhausts its iteration budget without converging proceeds to the next
     stage, exactly as the C++ run does; a stage that hard-fails (unrecoverable
     bad Jacobian, the ijacob >= 75 give-up) stops the ramp.
+
+    ``lambda_preconditioner_boost`` corrects the lambda preconditioner at the
+    first evolved (off-axis) surface: the flux-surface-averaged lambda
+    stiffness there overestimates what the descent actually feels by ~5-10x,
+    under-relaxing the m <= 1 lambda modes that dominate the slow tail of
+    strongly shaped configurations (docs/convergence_study.md, Findings
+    10-12; measured -23% tail iterations on w7x, no effect where those modes
+    are not rate-limiting, e.g. cma/cth). A preconditioner rescaling cannot
+    move the force balance, so the converged physics is unchanged (verified
+    to 9 digits). Orthogonal to ``iteration_style``.
 
     ``ftol_array`` / ``niter_array`` entries are matched to ``ns_array``
     entries by ns value (``VmecModel.create`` / ``refine_to`` semantics);
@@ -589,6 +613,12 @@ def solve_multigrid(
         ns_min = ns
         if model is None:
             model = _vmecpp.VmecModel.create(cpp_indata, ns)
+            if lambda_preconditioner_boost:
+                model.set_lambda_preconditioner_boost(
+                    scale=_LAMBDA_BOOST_SCALE,
+                    mmax=_LAMBDA_BOOST_MMAX,
+                    jmax=_LAMBDA_BOOST_JMAX,
+                )
         else:
             model.refine_to(ns, interpolation=interpolation_scheme)
         result = solve_equilibrium(

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -8,6 +8,7 @@
 #include <array>
 #include <cstdio>
 #include <iostream>
+#include <limits>
 #include <numbers>
 #include <span>
 #include <vector>
@@ -1832,6 +1833,11 @@ void IdealMhdModel::updateLambdaPreconditioner() {
   const double pFactor = kLambdaPreconditionerDampingFactor /
                          (4.0 * constants_.lamscale * constants_.lamscale);
 
+  // boost configured via SetLambdaPreconditionerBoost (default: no effect)
+  const double lambda_precond_scale = lambda_precond_boost_scale_;
+  const int lambda_precond_scale_mmax = lambda_precond_boost_mmax_;
+  const int lambda_precond_scale_jmax = lambda_precond_boost_jmax_;
+
   // evaluate preconditioning matrix elements on half-grid
   // on every accessible half-grid point
   // indices are shifted up by 1 to make room at 0 for first target point
@@ -1919,6 +1925,9 @@ void IdealMhdModel::updateLambdaPreconditioner() {
         // lambdaPreconditioner !
         lambdaPreconditioner[idx_mn] =
             pFactor / faclam * pow(m_p_.sqrtSF[jF - r_.nsMinF1], pwr);
+        if (m <= lambda_precond_scale_mmax && jF <= lambda_precond_scale_jmax) {
+          lambdaPreconditioner[idx_mn] *= lambda_precond_scale;
+        }
       }  // m
     }  // n
   }  // jF

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
@@ -79,6 +79,23 @@ class IdealMhdModel {
   std::int64_t forceEvaluationCount() const { return force_evaluation_count_; }
   void resetForceEvaluationCount() { force_evaluation_count_ = 0; }
 
+  // Configure the lambda-preconditioner boost: multiply the lambda
+  // preconditioner elements by `scale` for modes with m <= mmax on full-grid
+  // surfaces jF <= jmax (negative mmax/jmax: no restriction). The tail of
+  // strongly shaped configurations is rate-limited by an axis-localized
+  // cluster of low-m lambda modes whose effective stiffness is far below the
+  // flux-surface-averaged faclam estimate (docs/convergence_study.md,
+  // Findings 12 and 14); scale = 5, mmax = 1, jmax = 1 recovers -23% of the
+  // w7x tail iterations. Note lambda has no evolved DOF at the axis itself
+  // (the force loop starts at jF = 1), so jmax = 0 is a no-op. A
+  // preconditioner rescaling does not move the force balance, so converged
+  // physics is unaffected. Takes effect at the next preconditioner update.
+  void SetLambdaPreconditionerBoost(double scale, int mmax, int jmax) {
+    lambda_precond_boost_scale_ = scale > 0.0 ? scale : 1.0;
+    lambda_precond_boost_mmax_ = mmax < 0 ? INT_MAX : mmax;
+    lambda_precond_boost_jmax_ = jmax < 0 ? INT_MAX : jmax;
+  }
+
   // Coordinates which inverse-DFT routine to call for computing
   // the flux surface geometry and lambda on it from the provided Fourier
   // coefficients. Also computes the net dR/dTheta and dZ/dTheta, without the
@@ -423,6 +440,12 @@ class IdealMhdModel {
   int m_vac_num_threads_;
   VacuumPressureState& m_vacuum_pressure_state_;
   std::int64_t force_evaluation_count_ = 0;
+
+  // lambda-preconditioner boost (SetLambdaPreconditionerBoost); defaults are
+  // a no-op
+  double lambda_precond_boost_scale_ = 1.0;
+  int lambda_precond_boost_mmax_ = INT_MAX;
+  int lambda_precond_boost_jmax_ = INT_MAX;
 
 #ifdef VMECPP_USE_FFTX
   // Pre-computed FFTX kernels for the toroidal (zeta) Fourier transforms.

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -270,6 +270,34 @@ class VmecModel {
   }
   bool need_restart() const { return last_need_restart_; }
 
+  // Configure the lambda-preconditioner boost (see
+  // IdealMhdModel::SetLambdaPreconditionerBoost): multiply the lambda
+  // preconditioner elements by `scale` for m <= mmax, jF <= jmax (negative:
+  // unrestricted). Takes effect at the next preconditioner update; does not
+  // move the force balance. The setting is stored on this wrapper and
+  // re-applied whenever the underlying IdealMhdModel instances are recreated
+  // (InitializeRadial: refine_to, reinitialize), so it survives multigrid
+  // transitions and mid-stage axis reguesses.
+  void SetLambdaPreconditionerBoost(double scale, int mmax, int jmax) {
+    lambda_boost_scale_ = scale;
+    lambda_boost_mmax_ = mmax;
+    lambda_boost_jmax_ = jmax;
+    lambda_boost_configured_ = true;
+    ApplyLambdaPreconditionerBoost();
+  }
+  void ApplyLambdaPreconditionerBoost() const {
+    if (!lambda_boost_configured_) {
+      // not configured: leave the IdealMhdModel defaults (a no-op boost) in
+      // place; an explicit set_lambda_preconditioner_boost call (including
+      // scale=1.0) takes effect from then on
+      return;
+    }
+    for (auto &m : vmec_->m_) {
+      m->SetLambdaPreconditionerBoost(lambda_boost_scale_, lambda_boost_mmax_,
+                                      lambda_boost_jmax_);
+    }
+  }
+
   // Total forward-model (force) evaluations since construction or the last
   // reset. Counts every Evaluate, including those inside hessian_vector_product
   // and preconditioner assembly, for a fair cross-optimizer cost comparison.
@@ -331,6 +359,8 @@ class VmecModel {
                             std::nullopt);
     last_preconditioner_update_ = 0;
     last_full_update_nestor_ = 0;
+    // InitializeRadial recreates the IdealMhdModel instances
+    ApplyLambdaPreconditionerBoost();
   }
 
   // Advance to the next (finer) multi-grid resolution, interpolating the
@@ -387,6 +417,8 @@ class VmecModel {
                        delt0, std::nullopt, interpolation);
     last_preconditioner_update_ = 0;
     last_full_update_nestor_ = 0;
+    // InitializeRadial recreates the IdealMhdModel instances
+    ApplyLambdaPreconditionerBoost();
   }
 
   // Reference C++ inner iteration (the loop being ported), for verification.
@@ -530,6 +562,13 @@ class VmecModel {
   int last_preconditioner_update_ = 0;
   int last_full_update_nestor_ = 0;
   bool last_need_restart_ = false;
+
+  // lambda-preconditioner boost, re-applied after every InitializeRadial;
+  // inactive until set_lambda_preconditioner_boost is called
+  double lambda_boost_scale_ = 1.0;
+  int lambda_boost_mmax_ = -1;
+  int lambda_boost_jmax_ = -1;
+  bool lambda_boost_configured_ = false;
 };
 
 }  // anonymous namespace
@@ -1297,6 +1336,9 @@ PYBIND11_MODULE(_vmecpp, m) {
            py::arg("v"))
       .def("hessian_vector_product", &VmecModel::HessianVectorProduct,
            py::arg("v"), py::arg("eps_rel") = 1e-7)
+      .def("set_lambda_preconditioner_boost",
+           &VmecModel::SetLambdaPreconditionerBoost, py::arg("scale") = 1.0,
+           py::arg("mmax") = -1, py::arg("jmax") = -1)
       .def_property_readonly("force_eval_count", &VmecModel::force_eval_count)
       .def("reset_force_eval_count", &VmecModel::reset_force_eval_count)
       .def_property_readonly("fsqr", &VmecModel::fsqr)

--- a/tests/test_iteration.py
+++ b/tests/test_iteration.py
@@ -235,6 +235,39 @@ def test_multigrid_interpolation_scheme_improves_seed():
         vmecpp.solve_multigrid(vmec_input, interpolation="quintic")  # type: ignore[arg-type]
 
 
+def test_lambda_preconditioner_boost_converges_to_same_physics():
+    """The lambda-preconditioner correction (first evolved surface, m <= 1) cannot move
+    the force balance: the boosted multigrid run must converge to the same equilibrium
+    (energy agreement well below the physical scale) while taking no more iterations.
+
+    The boost setting must also survive refine_to and mid-stage reinitialization (the
+    VmecModel wrapper re-applies it after every InitializeRadial, which recreates the
+    IdealMhdModel instances).
+    """
+    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA / "cth_like_fixed_bdy.json")
+    vmec_input.ns_array = np.array([13, 25])
+    vmec_input.ftol_array = np.array([1.0e-9, 1.0e-11])
+    vmec_input.niter_array = np.array([3000, 3000])
+
+    runs = {}
+    for boost in (False, True):
+        model, results = vmecpp.solve_multigrid(
+            vmec_input,
+            lambda_preconditioner_boost=boost,
+            interpolation="cubic",
+        )
+        assert all(r.converged for r in results), f"boost={boost}"
+        runs[boost] = (model.mhd_energy, sum(r.num_iterations for r in results))
+
+    energy_ref, iters_ref = runs[False]
+    energy_boost, iters_boost = runs[True]
+    # agreement is limited by the ftol=1e-11 convergence scatter of the two
+    # different descent paths, not by the preconditioner change
+    assert abs(energy_boost - energy_ref) < 1.0e-6 * abs(energy_ref)
+    # cth's tail is not lambda-limited, so the boost must at least do no harm
+    assert iters_boost <= iters_ref * 1.05
+
+
 def test_native_parvmec_matches_python_parvmec():
     """The native C++ PARVMEC control reproduces the ported Python PARVMEC control.
 


### PR DESCRIPTION
Add IdealMhdModel::SetLambdaPreconditionerBoost(scale, mmax, jmax):
multiply the lambda preconditioner elements by scale for modes with
m <= mmax on full-grid surfaces jF <= jmax (negative: unrestricted).
The tail of strongly shaped configurations is rate-limited by an
axis-localized cluster of low-m lambda modes whose effective stiffness
is far below the flux-surface-averaged faclam estimate; boosting them
(scale = 5, mmax = 1, jmax = 1) recovers -23% of the w7x tail
iterations. A preconditioner rescaling does not move the force
balance, so converged physics is unaffected.

Exposed to Python as VmecModel.set_lambda_preconditioner_boost; the
wrapper stores the setting and re-applies it after every
InitializeRadial (refine_to, reinitialize), which recreates the
IdealMhdModel instances. solve_multigrid gains a
lambda_preconditioner_boost flag using the measured default window.

Tested by test_lambda_preconditioner_boost_converges_to_same_physics:
same MHD energy to ~1e-6 relative, no iteration-count regression, and
the setting survives multigrid refinement.