### PR TITLE
Seed the vacuum state across free-boundary multigrid transitions

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -496,6 +496,24 @@ bool Vmec::InitializeRadial(
   fc_.res1 = -1;
   m_delt0 = indata_.delt;
 
+  // On a free-boundary multigrid continuation stage, the vacuum solution of
+  // the converged coarser stage is still exactly valid, because the radial
+  // interpolation changes neither the angular grid nor the LCFS geometry.
+  // Re-marking the vacuum state as kInitialized here (mirroring the
+  // hot-restart path in run()) makes the first iteration of the new stage
+  // run the free-boundary block, so the LCFS force enters balanced by the
+  // vacuum magnetic pressure. Otherwise iteration 1 skips the vacuum update
+  // (the `iter2 > 1` gate in IdealMhdModel::update) and applies the edge
+  // force with rBSq = 0 -- the raw, unbalanced plasma pressure -- which
+  // kicks the boundary in a single step and costs a long NESTOR ring-down
+  // afterwards (stage-entry FSQR ~ 9 instead of the interpolation-error
+  // level, W_MHD -12 percent in one step, DELBSQ ~ 400x its converged
+  // value).
+  if (fc_.lfreeb && ns_old != 0 && ns_old < nsval &&
+      vacuum_pressure_state_ == VacuumPressureState::kActive) {
+    vacuum_pressure_state_ = VacuumPressureState::kInitialized;
+  }
+
   // INITIALIZE MESH-DEPENDENT SCALARS
 
   // *THIS* actually sets the global ns value for the main physics algorithm

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
@@ -194,6 +194,8 @@ TEST(TestVmec, MultiGridFreeBoundary) {
   ASSERT_TRUE(output.ok());
 
   // Regression guard for issue #330/#640 and other changes to the multigrid
-  // convergence path
-  EXPECT_EQ(output->wout.niter, 344);
+  // convergence path. 344 with the historical unbalanced stage entry; 321
+  // since the vacuum state is seeded across multigrid transitions (the
+  // second stage enters force-balanced instead of kicking the boundary).
+  EXPECT_EQ(output->wout.niter, 321);
 }  // MultiGridFreeBoundary


### PR DESCRIPTION
The first iteration of a free-boundary continuation stage skips the whole vacuum block (the iter2 > 1 gate in IdealMhdModel::update, inherited from Fortran VMEC funct3d) while assembleTotalForces still applies the edge term with the freshly zeroed rBSq. The LCFS row therefore takes one step using the unbalanced plasma pressure, inflating the LCFS unphyisically, before the outside vacuum pressure is turned back on the next iteration.

The vacuum solution of the converged coarser stage is still exactly valid at stage entry: the radial interpolation changes neither the angular grid nor the LCFS geometry. A continuation stage is like our "hot restart" in this
respect, and the hot-restart path already sets vacuum_pressure_state_ = kInitialized for exactly this purpose.

Measured (identical converged physics to all printed digits):
- cth_like_free_bdy_multigrid [15,25]: second stage 343 -> 320 iterations (niter regression guard updated 344 -> 321)
- solovev_free_bdy [16,32]: second stage 828 -> 630 iterations (-24%)