### PR TITLE
return_outputs_even_if_not_converged now works for more kinds of errors to aid debugging

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -429,9 +429,15 @@ class VmecInput(BaseModelWithNumpy):
     """Hack: directly compute innermost flux surface geometry from radial force balance"""
 
     return_outputs_even_if_not_converged: bool = False
-    """If true, return the outputs even if VMEC++ did not converge.
+    """If true, return a wout even if VMEC++ did not converge, instead of raising a
+    RuntimeError.
 
-    Otherwise a RuntimeError will be raised.
+    This is intended for debugging purposes (e.g. inspecting how far the geometry
+    got, or where the force residuals blew up) since the returned quantities are
+    computed from whatever internal state the solver was in when it gave up, and
+    can be arbitrarily unphysical. Always check `wout.ier_flag` / the accompanying
+    log warning to see why the run did not converge before interpreting any
+    physical quantity in the output.
     """
 
     raxis_c: jt.Float[np.ndarray, "ntor_plus_1"] = pydantic.Field(

--- a/src/vmecpp/cpp/vmecpp/common/util/util.cc
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.cc
@@ -32,6 +32,11 @@ std::string VmecStatusAsString(const VmecStatus vmec_status) {
              "self-intersecting. This "
              "can mean that your prescribed boundary is too shaped for VMEC to "
              "resolve ";
+    case VmecStatus::UNRECOVERABLE_ERROR:
+      return "UNRECOVERABLE_ERROR: a physical inconsistency was detected "
+             "in the MHD model (e.g. a degenerate flux-surface geometry or "
+             "a free-boundary current mismatch) that the solver could not "
+             "recover from";
     case VmecStatus::SUCCESSFUL_TERMINATION:
       return "SUCCESSFUL_TERMINATION";
   }

--- a/src/vmecpp/cpp/vmecpp/common/util/util.h
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.h
@@ -150,6 +150,10 @@ enum class VmecStatus : std::uint8_t {
   NORMAL_TERMINATION = 0,
   BAD_JACOBIAN = 1,
   JACOBIAN_75_TIMES_BAD = 4,
+  // A physical inconsistency was detected deep in the MHD model (e.g. a
+  // degenerate flux-surface geometry or a free-boundary current mismatch)
+  // that the solver has no retry strategy for.
+  UNRECOVERABLE_ERROR = 5,
   // everything went well, VMEC++ converged
   SUCCESSFUL_TERMINATION = 11
 };

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
@@ -219,8 +219,10 @@ class VmecINDATA {
   // based on)
   IterationStyle iteration_style;
 
-  // If true, return the outputs even if VMEC++ did not converge.
-  // Otherwise (default = false), an absl::InternalError will be returned.
+  // If true, return a wout even if VMEC++ did not converge.
+  // Intended for debugging convergence issues only: the
+  // returned quantities are computed from whatever internal state the solver
+  // was in when it gave up, and can be arbitrarily unphysical.
   bool return_outputs_even_if_not_converged;
 
   // ---------------------------------

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -753,12 +753,16 @@ absl::StatusOr<bool> IdealMhdModel::update(
       }
 
       if (m_h_.rBtor * m_h_.bSubVVac < 0.0) {
-        return absl::InternalError(
+        // A physical inconsistency, not a code bug: kFailedPrecondition (as
+        // opposed to kInternal) marks this as a condition that
+        // indata.return_outputs_even_if_not_converged can recover from by
+        // returning best-effort output instead of hard-erroring.
+        return absl::FailedPreconditionError(
             "IdealMHDModel::update: rbtor and bsubvvac must have the same "
             "sign - maybe flip the sign of phiedge or the sign of the coil "
             "currents");
       } else if (fabs((m_h_.cTor - m_h_.bSubUVac) / m_h_.rBtor) > 0.01) {
-        return absl::InternalError(
+        return absl::FailedPreconditionError(
             "IdealMHDModel::update: VAC-VMEC I_TOR MISMATCH : BOUNDARY MAY "
             "ENCLOSE EXT. COIL");
       }
@@ -2093,10 +2097,15 @@ absl::Status IdealMhdModel::constraintForceMultiplier() {
     }
 
     if (arNorm == 0.0) {
-      return absl::InternalError("arNorm should never be 0.0.");
+      // A degenerate (e.g. self-intersecting) flux surface, not a code bug:
+      // kFailedPrecondition (as opposed to kInternal) marks this as a
+      // condition that indata.return_outputs_even_if_not_converged can
+      // recover from by returning best-effort output instead of
+      // hard-erroring.
+      return absl::FailedPreconditionError("arNorm should never be 0.0.");
     }
     if (azNorm == 0.0) {
-      return absl::InternalError("azNorm should never be 0.0.");
+      return absl::FailedPreconditionError("azNorm should never be 0.0.");
     }
 
     double tcon_base =

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -260,6 +260,14 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
   fc_.ns_old = 0;
   fc_.delt0r = indata_.delt;
 
+  // Set when the solver gives up on a fundamentally broken equilibrium (e.g.
+  // persistently bad Jacobian) while
+  // indata_.return_outputs_even_if_not_converged is set: breaks out of both
+  // multigrid loops below so we fall through to ComputeOutputQuantities() with
+  // best-effort (likely unphysical) state, instead of hard-erroring, for
+  // debugging purposes.
+  bool giving_up = false;
+
   // retry with ns=3 if immediately fails at lowest radial resolution
   for (jacob_off_ = 0; jacob_off_ < 2; ++jacob_off_) {
     // jacob_off=1 indicates that an initial run with ns=3 shall be inserted
@@ -353,12 +361,25 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
       // not reach convergence
       if (status_ != VmecStatus::NORMAL_TERMINATION &&
           status_ != VmecStatus::SUCCESSFUL_TERMINATION) {
-        const auto msg = absl::StrFormat(
-            "FATAL ERROR in SolveEquilibrium: %s\n"
-            "VmecINDATA had these contents:\n%s",
-            VmecStatusAsString(status_), *indata_.ToJson());
+        if (!indata_.return_outputs_even_if_not_converged) {
+          const auto msg = absl::StrFormat(
+              "FATAL ERROR in SolveEquilibrium: %s\n"
+              "VmecINDATA had these contents:\n%s",
+              VmecStatusAsString(status_), *indata_.ToJson());
 
-        return absl::InternalError(msg);
+          return absl::InternalError(msg);
+        }
+
+        if (verbose_) {
+          std::cout << absl::StrFormat(
+              "WARNING: FATAL ERROR in SolveEquilibrium: %s\n"
+              "return_outputs_even_if_not_converged is set, so returning "
+              "best-effort (likely unphysical) output for debugging "
+              "purposes.\n",
+              VmecStatusAsString(status_));
+        }
+        giving_up = true;
+        break;
       }
 
       // TODO(jons): insert lgiveup/fgiveup logic here
@@ -366,6 +387,10 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
       // If this point is reached, the current multi-grid step should have
       // properly converged.
     }  // igrid
+
+    if (giving_up) {
+      break;
+    }
 
     // if did not converge only because jacobian was bad
     // and the intermediate ns=3 run was not performed yet (jacob_off is still
@@ -748,6 +773,12 @@ absl::StatusOr<bool> Vmec::SolveEquilibrium(
 
   absl::Status status_of_all_threads = absl::OkStatus();
   bool any_checkpoint_reached = false;
+  // Whether every thread that reported an error reported a kFailedPrecondition
+  // (a physical inconsistency that indata_.return_outputs_even_if_not_converged
+  // can recover from), as opposed to e.g. kInternal (a genuine code bug).
+  // Tracked independently of status_of_all_threads, which always collapses to
+  // kInternal once aggregated (see UpdateStatusForThread).
+  bool all_errors_are_recoverable = true;
 
   // Shared communication variable for all threads. Used to signal an early exit
   // of the main iteration loop.
@@ -801,6 +832,8 @@ absl::StatusOr<bool> Vmec::SolveEquilibrium(
       if (s.ok()) {
         any_checkpoint_reached |= (*s == SolveEqLoopStatus::CHECKPOINT_REACHED);
       } else {
+        all_errors_are_recoverable &=
+            (s.status().code() == absl::StatusCode::kFailedPrecondition);
         UpdateStatusForThread(status_of_all_threads, thread_id, s.status());
       }
     }
@@ -811,6 +844,25 @@ absl::StatusOr<bool> Vmec::SolveEquilibrium(
   }
 
   if (!status_of_all_threads.ok()) {
+    if (indata_.return_outputs_even_if_not_converged &&
+        all_errors_are_recoverable) {
+      // A physical inconsistency (not a code bug) was detected deep in the
+      // MHD model, with no retry strategy available. Since outputs were
+      // requested even if not converged, don't hard-error here: record it as
+      // an unrecoverable status and let run() fall through to
+      // ComputeOutputQuantities() with best-effort (likely unphysical)
+      // state, for debugging purposes.
+      if (verbose_) {
+        std::cout << absl::StrFormat(
+            "WARNING: %s\n"
+            "return_outputs_even_if_not_converged is set, so returning "
+            "best-effort (likely unphysical) output for debugging "
+            "purposes.\n",
+            status_of_all_threads.message());
+      }
+      status_ = VmecStatus::UNRECOVERABLE_ERROR;
+      return false;
+    }
     return status_of_all_threads;
   }
 
@@ -930,12 +982,21 @@ absl::StatusOr<Vmec::SolveEqLoopStatus> Vmec::SolveEquilibriumLoop(
                status_ != VmecStatus::SUCCESSFUL_TERMINATION) {
       // if something went totally wrong even in this initial steps, do not
       // continue at all
-      const auto msg = absl::StrFormat(
-          "FATAL ERROR in thread=%d. The solver failed during the first "
-          "iterations. This may happen if the initial boundary is poorly "
-          "shaped or if it isn't spectrally condensed enough.",
-          thread_id);
-      return absl::UnknownError(msg);
+      if (!indata_.return_outputs_even_if_not_converged) {
+        const auto msg = absl::StrFormat(
+            "FATAL ERROR in thread=%d. The solver failed during the first "
+            "iterations. This may happen if the initial boundary is poorly "
+            "shaped or if it isn't spectrally condensed enough.",
+            thread_id);
+        return absl::UnknownError(msg);
+      }
+
+      // return_outputs_even_if_not_converged: stop iterating on this thread
+      // instead of hard-erroring, so run() falls through to
+      // ComputeOutputQuantities() with best-effort (likely unphysical)
+      // state, for debugging purposes. status_ still reflects the failure
+      // (e.g. BAD_JACOBIAN), so run() will still surface a warning about it.
+      return SolveEqLoopStatus::NORMAL_TERMINATION;
     }
 
     if (checkpoint == VmecCheckpoint::EVOLVE &&


### PR DESCRIPTION
Pending more validation, I'm not happy about the increase in flow control complexity yet.