### PR TITLE
Hotfix CI job to unblock release

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -73,7 +73,7 @@ jobs:
             "ubuntu:22.04",
             "archlinux/archlinux",
             "debian:12",
-            "debian:testing-20250224",
+            # "debian:testing-20250224", # TODO(jurasic): re-enable when 3.14 support unblocked
             "fedora:41",
           ]
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The Debian testing version started defaulting to Python 3.14 which is still unsupported (simsopt as a blocking dependency).
Since Debian support is still covered in CI by debian:12, disabling it temporarily seems an acceptable hotfix.