### PR TITLE
Widen supported pydantic versions after bugfix landed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
   "netCDF4",
   "numpy",
   "pydantic>=2.11", # Introduced support for by_alias validation
-  "pydantic<2.13", # Breaking change currently under investigation
+  "pydantic!=2.13.0", # Breaking validation https://github.com/proximafusion/vmecpp/issues/481
+  "pydantic!=2.13.1", # Breaking validation https://github.com/proximafusion/vmecpp/issues/481
   "jaxtyping>=0.2.6",
   "jax!=0.5.2", # To prevent a circular import bug in jax on arch Linux
   "jax!=0.5.1", # To prevent a circular import bug in jax on arch Linux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,6 @@ dependencies = [
   "netCDF4",
   "numpy",
   "pydantic>=2.11", # Introduced support for by_alias validation
-  "pydantic!=2.13.0", # Breaking validation https://github.com/proximafusion/vmecpp/issues/481
-  "pydantic!=2.13.1", # Breaking validation https://github.com/proximafusion/vmecpp/issues/481
   "jaxtyping>=0.2.6",
   "jax!=0.5.2", # To prevent a circular import bug in jax on arch Linux
   "jax!=0.5.1", # To prevent a circular import bug in jax on arch Linux

--- a/src/vmecpp/_pydantic_numpy.py
+++ b/src/vmecpp/_pydantic_numpy.py
@@ -10,67 +10,80 @@ import jaxtyping as jt
 import numpy as np
 import pydantic
 
+try:
+    import dapper
+except ImportError:
+    dapper = None
 
-class BaseModelWithNumpy(pydantic.BaseModel):
-    """A minimal layer on top of pydantic to help with serialization and de-
-    serialization of classes with numpy arrays, annotated with jaxtyping.
+if dapper is not None:
+    # BaseModelWithNumpy is a small subset of an internal Proxima library, dapper.
+    # Use it directly when available instead of redefining the same behavior.
+    BaseModelWithNumpy = dapper.DapperData
+else:
 
-    Does checks on the shape and type of arrays, may do casting if needed.
-    """
+    class BaseModelWithNumpy(pydantic.BaseModel):
+        """A minimal layer on top of pydantic to help with serialization and de-
+        serialization of classes with numpy arrays, annotated with jaxtyping.
 
-    model_config = pydantic.ConfigDict(
-        arbitrary_types_allowed=True,
-        # Serialize NaN and infinite floats as strings in JSON output.
-        # Due to a bug in Pydantic, this setting is ignored by model_dump(mode="json"),
-        # so we override it below to also convert values to string there.
-        ser_json_inf_nan="strings",
-    )
+        Does checks on the shape and type of arrays, may do casting if needed.
+        """
 
-    @pydantic.field_serializer("*", mode="wrap", when_used="json")
-    def _serialize_field(
-        self,
-        value: typing.Any,
-        default_handler: pydantic.SerializerFunctionWrapHandler,
-        info: pydantic.FieldSerializationInfo,
-        # Note: Do NOT annotate return type with "-> Any" here, since that removes types
-        # from the JSON schema of all fields (in serialization mode).
-    ):
-        value = serialize_special_field(type(self), info.field_name, value)
-        return default_handler(value)
+        model_config = pydantic.ConfigDict(
+            arbitrary_types_allowed=True,
+            # Serialize NaN and infinite floats as strings in JSON output.
+            # Due to a bug in Pydantic, this setting is ignored by
+            # model_dump(mode="json"), so we override it below to also convert values
+            # to string there.
+            ser_json_inf_nan="strings",
+        )
 
-    @pydantic.field_validator("*", mode="wrap")
-    @classmethod
-    def _validate_field(
-        cls,
-        value: typing.Any,
-        default_handler: pydantic.ValidatorFunctionWrapHandler,
-        info: pydantic.ValidationInfo,
-    ) -> typing.Any:
-        assert info.field_name is not None
-        # We consciously *ignore* info.mode_is_json() here to allow validating from
-        # JSON-like dicts without having to go through strings. This is consistent with
-        # Pydantic's default behavior: while serializers retain Python objects in
-        # model_dump, but convert them to JSON values in model_dump_json, validators
-        # are lenient and accept JSON values in both modes.
-        value = deserialize_special_field(cls, info.field_name, value)
-        return default_handler(value)
+        @pydantic.field_serializer("*", mode="wrap", when_used="json")
+        def _serialize_field(
+            self,
+            value: typing.Any,
+            default_handler: pydantic.SerializerFunctionWrapHandler,
+            info: pydantic.FieldSerializationInfo,
+            # Note: Do NOT annotate return type with "-> Any" here, since that removes
+            # types from the JSON schema of all fields (in serialization mode).
+        ):
+            value = serialize_special_field(type(self), info.field_name, value)
+            return default_handler(value)
 
-    # This override is necessary to make also `model_dump(mode="json")` respect the
-    # ser_json_inf_nan="strings" setting in model_config. Without this fix, Pydantic
-    # would keep returning NaN/Inf as Python floats from this function, which leads to
-    # invalid JSON, e.g. when the output is used with `json.dumps`.
-    # This bug will probably only be fixed in Pydantic V3, since they consider it a
-    # breaking change.
-    # See: https://github.com/pydantic/pydantic/issues/10037#issuecomment-2314751795
-    # Hide the override from the type system to "pass through" docstring and parameter
-    # types and defaults.
-    if not typing.TYPE_CHECKING:
+        @pydantic.field_validator("*", mode="wrap")
+        @classmethod
+        def _validate_field(
+            cls,
+            value: typing.Any,
+            default_handler: pydantic.ValidatorFunctionWrapHandler,
+            info: pydantic.ValidationInfo,
+        ) -> typing.Any:
+            assert info.field_name is not None
+            # We consciously *ignore* info.mode_is_json() here to allow validating from
+            # JSON-like dicts without having to go through strings. This is consistent
+            # with Pydantic's default behavior: while serializers retain Python objects
+            # in model_dump, but convert them to JSON values in model_dump_json,
+            # validators are lenient and accept JSON values in both modes.
+            value = deserialize_special_field(cls, info.field_name, value)
+            return default_handler(value)
 
-        def model_dump(self, *, mode: str = "python", **kwargs: Any) -> dict[str, Any]:
-            output_dict = super().model_dump(mode=mode, **kwargs)
-            if mode == "json":
-                sanitize_floats_in_container(output_dict)
-            return output_dict
+        # This override is necessary to make also `model_dump(mode="json")` respect the
+        # ser_json_inf_nan="strings" setting in model_config. Without this fix, Pydantic
+        # would keep returning NaN/Inf as Python floats from this function, which leads
+        # to invalid JSON, e.g. when the output is used with `json.dumps`.
+        # This bug will probably only be fixed in Pydantic V3, since they consider it a
+        # breaking change.
+        # See: https://github.com/pydantic/pydantic/issues/10037#issuecomment-2314751795
+        # Hide the override from the type system to "pass through" docstring and
+        # parameter types and defaults.
+        if not typing.TYPE_CHECKING:
+
+            def model_dump(
+                self, *, mode: str = "python", **kwargs: Any
+            ) -> dict[str, Any]:
+                output_dict = super().model_dump(mode=mode, **kwargs)
+                if mode == "json":
+                    sanitize_floats_in_container(output_dict)
+                return output_dict
 
 
 """This module handles special cases for serialization of BaseModelWithNumpy types.

--- a/src/vmecpp/_pydantic_numpy.py
+++ b/src/vmecpp/_pydantic_numpy.py
@@ -11,7 +11,7 @@ import numpy as np
 import pydantic
 
 try:
-    import dapper
+    import dapper  # pyright: ignore[reportMissingImports]
 except ImportError:
     dapper = None
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -20,7 +20,6 @@ from pathlib import Path
 
 import netCDF4
 import numpy as np
-import pydantic
 import pytest
 
 import vmecpp
@@ -821,40 +820,3 @@ except KeyboardInterrupt:
         f"Expected KeyboardInterrupt but got:\noutput: {output}"
     )
     assert "RUN_COMPLETED" not in output
-
-
-def test_subclass_outer_wrap_serializer_not_overridden(cma_output: vmecpp.VmecOutput):
-    """Subclass wrap serializers that operate on the arrays must not be overridden by
-    VmecWOut's inner serializers.
-
-    This ensures that VmecWOut's field-level serializers (e.g. a PlainSerializer on
-    extcur) pass through values that are not numpy arrays, so an outer framework can
-    replace arrays with custom representations during serialization.
-    """
-
-    class OuterSerializer(pydantic.BaseModel):
-        model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
-
-        @pydantic.field_serializer("*", mode="wrap", when_used="always")
-        def _outer_encode(
-            self,
-            value: object,
-            handler: pydantic.SerializerFunctionWrapHandler,
-            _: pydantic.FieldSerializationInfo,
-        ) -> object:
-            if isinstance(value, np.ndarray):
-                return {"__custom_encoded__": True}
-            return handler(value)
-
-    class CustomWOut(OuterSerializer, vmecpp.VmecWOut):
-        pass
-
-    custom = CustomWOut.model_validate(cma_output.wout.model_dump())
-    dumped = custom.model_dump(mode="json")
-
-    # Plain array field — goes through _serialize_field wrap serializer.
-    assert dumped["rmnc"].get("__custom_encoded__")
-    # SerializeIntAsFloat field — has its own PlainSerializer/WrapSerializer.
-    assert dumped["xm"].get("__custom_encoded__")
-    # extcur field — has its own PlainSerializer/WrapSerializer.
-    assert dumped["extcur"].get("__custom_encoded__")


### PR DESCRIPTION
BaseModelWithNumpy is a small subset of an internal Proxima library, dapper.
Use it directly when available instead of redefining the same behavior. We no longer need to block pydantic versions due to the regression introduced between 2.13 and 2.13.3