### PR TITLE
tests: compare the QUASR free-vs-fixed magnetic axis as a curve, not coefficient-wise

### DIFF
--- a/tests/test_free_boundary_quasr.py
+++ b/tests/test_free_boundary_quasr.py
@@ -665,7 +665,39 @@ def test_free_boundary_quasr(
         assert wout.ctor == pytest.approx(prescribed_curtor, rel=0.1)
 
 
-@pytest.mark.parametrize("config_id", QUASR_IDS)
+# Configurations whose free- and fixed-boundary magnetic axes have never agreed to
+# the tolerance asserted below: they fail identically in the very first CI run of
+# this test (2026-07-21) and are unaffected by later solver work. The comparison is
+# coefficient-wise with a *relative* tolerance, so the high-n coefficients -- which
+# are O(1e-5) of the axis major radius -- have to agree to ~1e-7 in absolute
+# position, while the two equilibria genuinely differ (the free-boundary LCFS is set
+# by the coil field rather than imposed). The assertion should probably compare the
+# axis curve R_axis(phi) -- a 1% agreement there is both meaningful and met -- but
+# until that is decided these are marked xfail rather than left red. The mark is
+# non-strict, so a configuration that starts agreeing surfaces as an xpass.
+AXIS_COMPARISON_XFAIL_IDS = (954, 9914, 19940, 29346, 65579)
+
+
+def _axis_comparison_params() -> list:
+    """QUASR_IDS as pytest params, with the known-failing axis comparisons xfailed."""
+    return [
+        pytest.param(
+            config_id,
+            marks=pytest.mark.xfail(
+                reason=(
+                    "free-vs-fixed magnetic axis has never matched the "
+                    "coefficient-wise rtol=0.01 assertion for this configuration"
+                ),
+                strict=False,
+            ),
+        )
+        if config_id in AXIS_COMPARISON_XFAIL_IDS
+        else pytest.param(config_id)
+        for config_id in QUASR_IDS
+    ]
+
+
+@pytest.mark.parametrize("config_id", _axis_comparison_params())
 def test_free_boundary_matches_fixed_boundary(
     config_id: int,
     quasr_configs: dict[int, QuasrConfig],

--- a/tests/test_free_boundary_quasr.py
+++ b/tests/test_free_boundary_quasr.py
@@ -373,6 +373,15 @@ def _magnetic_axis_major_radius(wout) -> float:
     return float(np.sum(wout.raxis_cc))
 
 
+def _magnetic_axis_curve(wout, n_phi: int = 64) -> np.ndarray:
+    """The magnetic axis R_axis(phi) = sum_n raxis_cc[n] cos(n * nfp * phi), sampled
+    over one field period."""
+    raxis_cc = np.asarray(wout.raxis_cc)
+    n = np.arange(len(raxis_cc))
+    phi = np.linspace(0.0, 2.0 * np.pi / wout.nfp, n_phi, endpoint=False)
+    return raxis_cc @ np.cos(np.outer(n * wout.nfp, phi))
+
+
 def _enclosed_volume(surface_rz) -> float:
     """Absolute plasma volume enclosed by a SIMSOPT SurfaceRZFourier.
 
@@ -665,39 +674,7 @@ def test_free_boundary_quasr(
         assert wout.ctor == pytest.approx(prescribed_curtor, rel=0.1)
 
 
-# Configurations whose free- and fixed-boundary magnetic axes have never agreed to
-# the tolerance asserted below: they fail identically in the very first CI run of
-# this test (2026-07-21) and are unaffected by later solver work. The comparison is
-# coefficient-wise with a *relative* tolerance, so the high-n coefficients -- which
-# are O(1e-5) of the axis major radius -- have to agree to ~1e-7 in absolute
-# position, while the two equilibria genuinely differ (the free-boundary LCFS is set
-# by the coil field rather than imposed). The assertion should probably compare the
-# axis curve R_axis(phi) -- a 1% agreement there is both meaningful and met -- but
-# until that is decided these are marked xfail rather than left red. The mark is
-# non-strict, so a configuration that starts agreeing surfaces as an xpass.
-AXIS_COMPARISON_XFAIL_IDS = (954, 9914, 19940, 29346, 65579)
-
-
-def _axis_comparison_params() -> list:
-    """QUASR_IDS as pytest params, with the known-failing axis comparisons xfailed."""
-    return [
-        pytest.param(
-            config_id,
-            marks=pytest.mark.xfail(
-                reason=(
-                    "free-vs-fixed magnetic axis has never matched the "
-                    "coefficient-wise rtol=0.01 assertion for this configuration"
-                ),
-                strict=False,
-            ),
-        )
-        if config_id in AXIS_COMPARISON_XFAIL_IDS
-        else pytest.param(config_id)
-        for config_id in QUASR_IDS
-    ]
-
-
-@pytest.mark.parametrize("config_id", _axis_comparison_params())
+@pytest.mark.parametrize("config_id", QUASR_IDS)
 def test_free_boundary_matches_fixed_boundary(
     config_id: int,
     quasr_configs: dict[int, QuasrConfig],
@@ -725,12 +702,17 @@ def test_free_boundary_matches_fixed_boundary(
         pytest.xfail(f"fixed-boundary reference did not converge: {_first_line(exc)}")
 
     # Same profiles and (nearly) the same boundary -> the interior equilibria
-    # should agree. The magnetic axis is well-determined and matches tightly; the
-    # volume can differ slightly because the free-boundary LCFS is set by the coil
-    # field rather than imposed exactly.
+    # should agree. Both the axis position and the volume can differ slightly
+    # because the free-boundary LCFS is set by the coil field rather than imposed
+    # exactly. The axis is compared as the curve R_axis(phi) rather than coefficient
+    # by coefficient: the coefficients span five orders of magnitude, so a relative
+    # tolerance on the smallest ones says nothing about the axis position.
 
     np.testing.assert_allclose(
-        free.wout.raxis_cc, fixed.wout.raxis_cc, rtol=0.01, atol=0.0
+        _magnetic_axis_curve(free.wout),
+        _magnetic_axis_curve(fixed.wout),
+        rtol=0.02,
+        atol=0.0,
     )
     assert abs(free.wout.volume) == pytest.approx(abs(fixed.wout.volume), rel=0.05)
 


### PR DESCRIPTION
`test_free_boundary_matches_fixed_boundary` has been failing for five QUASR configurations (954, 9914, 19940, 29346, 65579) ever since it was merged — the same five fail in the [first CI run of the test](https://github.com/proximafusion/vmecpp/actions/runs/29827851698/job/88625244491) (2026-07-21: 5 failed, 17 passed, 14 xfailed).

## It is not a regression

- Bit-identical with the pre-lasym build (parent of #538): free-boundary `raxis_cc` agrees to ~1e-12 across that commit.
- `VmecInput` and the mgrid response table are bit-identical under pydantic 2.12.3 and 2.13.4, and the test fails under both, so widening the pydantic pin is not involved.
- numpy and simsopt in the environment predate the test's merge.
- Results reproduce to ~11 digits between 1 and 8 threads, so it is not thread nondeterminism.

## Root cause

The assertion compared `raxis_cc` coefficient by coefficient with `rtol=0.01, atol=0.0`. Those coefficients span five orders of magnitude, so a relative tolerance on the smallest ones demands an absolute agreement (~1e-7 in axis position) far below the level at which the two equilibria genuinely agree: the free-boundary LCFS is set by the coil field rather than imposed exactly.

Raising the tolerance a little does not work — the worst coefficients are off by 27x and 34x, so passing coefficient-wise would need `rtol ~ 35`, which asserts nothing. The *physical* axis, however, agrees well:

| config | max coefficient rel. err | max ΔR_axis / R0 |
|---|---|---|
| 954 | 3.2% | 0.28% |
| 9914 | 8.8% | 0.02% |
| 19940 | 2710% | 0.52% |
| 29346 | 132% | 0.24% |
| 65579 | 3450% | 0.76% |

## Change

Compare the axis curve `R_axis(phi) = sum_n raxis_cc[n] cos(n * nfp * phi)`, sampled over one field period, at `rtol=0.02` — a parametrisation-independent statement about where the axis actually is, with ~2.6x margin on the worst configuration. The volume check is unchanged.

Local run of the affected test: **5 passed, 7 xfailed, 0 failed** (before: 5 failed, 7 xfailed; the 7 xfails are the usual non-convergence ones).