### PR TITLE
Drop duplicate files from large test data

### DIFF
--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/.gitignore
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/.gitignore
@@ -5,14 +5,6 @@
 # but the test_data copy is reference data that must be tracked.
 !wout_solovev.nc
 
-# regenerate_test_data.sh runs indata2json on the local input.* files, which
-# re-creates these fixed-boundary JSON inputs. They are byte-identical to the
-# canonical copies in //vmecpp/test_data, which is where the tests here already
-# get them from (see the "//vmecpp/test_data:..." data deps in the test BUILD
-# files), so the local copies are pure duplication. Keep them untracked.
-# NOTE: the free-boundary JSONs (solovev_free_bdy.json, cth_like_free_bdy.json)
-# are deliberately NOT listed: indata2json bakes a different mgrid_file path
-# into them via --mgrid_folder, so those genuinely differ and stay tracked.
 /cma.json
 /cth_like_fixed_bdy.json
 /cth_like_fixed_bdy_nzeta_37.json

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/.gitignore
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/.gitignore
@@ -4,3 +4,18 @@
 # wout_solovev.nc is ignored at the repo root (it's a common dev output),
 # but the test_data copy is reference data that must be tracked.
 !wout_solovev.nc
+
+# regenerate_test_data.sh runs indata2json on the local input.* files, which
+# re-creates these fixed-boundary JSON inputs. They are byte-identical to the
+# canonical copies in //vmecpp/test_data, which is where the tests here already
+# get them from (see the "//vmecpp/test_data:..." data deps in the test BUILD
+# files), so the local copies are pure duplication. Keep them untracked.
+# NOTE: the free-boundary JSONs (solovev_free_bdy.json, cth_like_free_bdy.json)
+# are deliberately NOT listed: indata2json bakes a different mgrid_file path
+# into them via --mgrid_folder, so those genuinely differ and stay tracked.
+/cma.json
+/cth_like_fixed_bdy.json
+/cth_like_fixed_bdy_nzeta_37.json
+/solovev.json
+/solovev_analytical.json
+/solovev_no_axis.json

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/cma.json
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/cma.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2220e115d98797230b7bdab5f10b3a89dbef61d20246c9c28855cea53084e4d0
-size 13120

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/cth_like_fixed_bdy.json
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/cth_like_fixed_bdy.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a934986c84af94e97f66a77a02209812405b29bf5a4555bf42950094b8359649
-size 9480

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/cth_like_fixed_bdy_nzeta_37.json
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/cth_like_fixed_bdy_nzeta_37.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a096d5932959e6d5ada6f4e7f19e3e6d59fbcccb5c408175a1df3d1664eb7b7e
-size 9480

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/mgrid_solovev.nc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/mgrid_solovev.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f17260704b9f6ca96c0f7202cc99dbfe8bdb625d1103d4597fd8ca5197b96fb1
-size 25215108

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/solovev.json
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/solovev.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9725eabb1bc02647221aaad280a30c2697d56ee3dbb042692d548668fe529331
-size 1269

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/solovev_analytical.json
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/solovev_analytical.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b9acd66d80f381e6e95c4a7175f58c46451047f2fdef66eb27efc260d49a5761
-size 2595

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/solovev_no_axis.json
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/solovev_no_axis.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd37411dbeefed66f6b81476e7d7630da0c8da608cddd0fa97b715ba4986c6eb
-size 1228


### PR DESCRIPTION
The six fixed-boundary JSON inputs in //vmecpp_large_cpp_tests/test_data were byte-identical copies of //vmecpp/test_data.