### PR TITLE
ci: run pypi wheel build on PRs, skip publish stage

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -4,6 +4,8 @@ on:
   # allows running workflows manually
   workflow_dispatch:
 
+  pull_request:
+
   release:
     types: [published]
 


### PR DESCRIPTION
Adds `pull_request` as a trigger to `.github/workflows/pypi_publish.yml` so the wheel build (all OS matrix), sdist build, and cross-distro install tests run on every PR.

The final `pypi-publish` job is unaffected — it already has `if: github.event_name == 'release'`, so it continues to run only on published releases, never on PRs.