### PR TITLE
Remove vendored LAPACK dependency: replace dgetrf_/dgetrs_ with Eigen::PartialPivLU

### DIFF
--- a/.github/actions/run-benchmarks/action.yml
+++ b/.github/actions/run-benchmarks/action.yml
@@ -31,7 +31,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential cmake libnetcdf-dev liblapack-dev libomp-dev libhdf5-dev
+        sudo apt-get install -y build-essential cmake libnetcdf-dev libomp-dev libhdf5-dev
 
     - name: Mount bazel cache
       uses: actions/cache@v4

--- a/.github/workflows/clang_tidy.yaml
+++ b/.github/workflows/clang_tidy.yaml
@@ -28,7 +28,7 @@ jobs:
         id: review
         with:
           config_file: ".clang-tidy"
-          apt_packages: libhdf5-dev, liblapack-dev, libnetcdf-dev, gfortran, python3-dev, libomp-dev
+          apt_packages: libhdf5-dev, libnetcdf-dev, gfortran, python3-dev, libomp-dev
           build_dir: build
           cmake_command: cmake -B build && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS:STRING=ON build
           # bazel-built test and benchmark files have no cmake compile_commands

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -43,7 +43,6 @@ jobs:
                       build-essential \
                       cmake \
                       libnetcdf-dev \
-                      liblapack-dev \
                       libomp-dev \
                       libhdf5-dev \
                       python3-dev

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Build docs
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake libnetcdf-dev liblapack-dev libomp-dev libhdf5-dev
+          sudo apt-get install -y build-essential cmake libnetcdf-dev libomp-dev libhdf5-dev
           # must actually install the package otherwise sphinx can't autogenerate the API reference
           python -m pip install -v .[docs]
           sphinx-apidoc --module-first --no-toc --force --separate -o docs/api src/vmecpp/ && sphinx-build docs html_docs

--- a/.github/workflows/full_validation.yaml
+++ b/.github/workflows/full_validation.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Install required system packages for Ubuntu
         run: |
           sudo apt-get update && sudo apt-get install -y \
-            build-essential cmake libnetcdf-dev liblapack-dev liblapacke-dev libopenmpi-dev \
+            build-essential cmake libnetcdf-dev libopenmpi-dev \
             libomp-dev libeigen3-dev nlohmann-json3-dev libhdf5-dev
 
       - name: Install vmecpp-validation's Python requirements
@@ -104,7 +104,7 @@ jobs:
       - name: Install required packages for Ubuntu
         run: |
           sudo apt-get update && sudo apt-get install -y \
-            build-essential cmake libnetcdf-dev liblapack-dev liblapacke-dev libopenmpi-dev \
+            build-essential cmake libnetcdf-dev libopenmpi-dev \
             libomp-dev libeigen3-dev nlohmann-json3-dev libhdf5-dev
       - name: Install package
         run: python -m pip install -v .[test]

--- a/.github/workflows/pyright.yaml
+++ b/.github/workflows/pyright.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential cmake libnetcdf-dev liblapack-dev python3-dev
+          sudo apt-get install build-essential cmake libnetcdf-dev python3-dev
       # Parse the dependencies from the pyproject.toml file and install them,
       # without installing and building the entire vmecpp project
       - run: |

--- a/.github/workflows/test_bazel.yaml
+++ b/.github/workflows/test_bazel.yaml
@@ -25,7 +25,7 @@ jobs:
           lfs: true  # for the mgrid test data
       - name: Install required system packages for Ubuntu
         run: |
-          sudo apt-get update && sudo apt-get install -y build-essential cmake liblapack-dev libomp-dev python3-dev python3-pip python-is-python3
+          sudo apt-get update && sudo apt-get install -y build-essential cmake libomp-dev python3-dev python3-pip python-is-python3
       - name: Mount bazel cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,12 +49,14 @@ jobs:
       - name: Install required packages for MacOS
         if: ${{ contains(matrix.os, 'macos') }}
         run: |
-          brew install ninja libomp netcdf-cxx eigen lapack git
+          brew install ninja libomp netcdf-cxx eigen git
       - name: Install required packages for Ubuntu
         if: ${{ contains(matrix.os, 'ubuntu') }}
         run: |
-          # install VMEC++ deps as well as VMEC2000 deps (we need to import VMEC2000 in a test)
-          sudo apt-get update && sudo apt-get install -y build-essential cmake libnetcdf-dev liblapack-dev libomp-dev
+          # install VMEC++ deps as well as VMEC2000 deps (we need to import VMEC2000 in a test).
+          # VMEC2000 itself gets libopenblas-dev/libscalapack-mpi-dev below, which cover its
+          # LAPACK needs; VMEC++ no longer links LAPACK at all.
+          sudo apt-get update && sudo apt-get install -y build-essential cmake libnetcdf-dev libomp-dev
       - name: Cache the VMEC2000 wheel
         if: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version == '3.10' }}
         uses: actions/cache@v4
@@ -116,7 +118,7 @@ jobs:
           cache: 'pip'
       - name: Install required packages for Ubuntu
         run: |
-          sudo apt-get update && sudo apt-get install -y build-essential cmake libnetcdf-dev liblapack-dev libomp-dev
+          sudo apt-get update && sudo apt-get install -y build-essential cmake libnetcdf-dev libomp-dev
       - name: Install package
         run: python -m pip install .[test]
       - name: Test example scripts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,12 +70,14 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(eigen)
 include_directories(${eigen_SOURCE_DIR})
+# The only dense linear solve in this project (LaplaceSolver::DecomposeMatrix/
+# SolveForPotential) uses Eigen::PartialPivLU, which is pure C++ with no
+# external LAPACK/BLAS dependency as long as EIGEN_USE_LAPACKE/EIGEN_USE_BLAS/
+# EIGEN_USE_MKL are never defined. Do not define those macros without
+# reintroducing an explicit LAPACK/BLAS dependency here.
 
 FetchContent_Declare(nlohmann_json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
 FetchContent_MakeAvailable(nlohmann_json)
-
-find_package(LAPACK REQUIRED)
-
 
 FetchContent_Declare(
   abseil-cpp
@@ -140,7 +142,6 @@ function(vmecpp_add_core target)
   target_link_libraries(${target} PUBLIC ${HDF5_CXX_LIBRARIES} ${HDF5_LIBRARIES})
   target_link_libraries(${target} PUBLIC ${netCDF_LIBRARIES})
   target_link_libraries(${target} PUBLIC nlohmann_json::nlohmann_json)
-  target_link_libraries(${target} PUBLIC LAPACK::LAPACK)
   target_link_libraries(${target} PUBLIC absl::algorithm absl::base
     absl::synchronization absl::strings absl::str_format absl::log
     absl::string_view absl::check absl::status absl::statusor)

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Ubuntu 22.04 and 24.04, as well as Debian 12 are officially supported.
 
 1. Install required system packages:
 ```shell
-sudo apt-get install -y build-essential cmake gfortran libnetcdf-dev liblapack-dev libomp-dev libhdf5-dev python3-dev
+sudo apt-get install -y build-essential cmake gfortran libnetcdf-dev libomp-dev libhdf5-dev python3-dev
 ```
 
 2. Install VMEC++ as a Python package (possibly after creating a dedicated virtual environment):
@@ -172,7 +172,7 @@ Otherwise the Ubuntu package `python-is-python3` provides the `python` alias.
 1. Install required system packages:
 
 ```shell
-pacman -Sy --noconfirm python-pip gcc gcc-fortran openmp hdf5 netcdf lapack
+pacman -Sy --noconfirm python-pip gcc gcc-fortran openmp hdf5 netcdf
 ```
 
 2. Install VMEC++ as a Python package (possibly after creating a virtual environment):
@@ -188,7 +188,7 @@ python -m pip install git+https://github.com/proximafusion/vmecpp
 1. Install required system packages:
 
 ```shell
-dnf install -y python3.10-devel cmake g++ gfortran libomp-devel hdf5-devel netcdf-devel lapack-devel
+dnf install -y python3.10-devel cmake g++ gfortran libomp-devel hdf5-devel netcdf-devel
 ```
 
 2. Install VMEC++ as a Python package (possibly after creating a virtual environment):
@@ -232,7 +232,7 @@ python -m pip install -e .[test]
 ```
 
 The shell provides Python 3.13 together with the native build dependencies needed
-to build and test VMEC++, including CMake, GCC, GFortran, HDF5, NetCDF, LAPACK,
+to build and test VMEC++, including CMake, GCC, GFortran, HDF5, NetCDF,
 OpenMPI, and Git LFS.
 
 ### As part of a conda environment

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get -q update && \
     build-essential \
     cmake \
     libnetcdf-dev \
-    liblapack-dev \
     libomp-dev \
     libhdf5-dev \
     python3-pip \

--- a/environment.yml
+++ b/environment.yml
@@ -50,7 +50,6 @@ dependencies:
   - libgomp=14.2.0=h77fa898_1
   - libiconv=1.17=hd590300_2
   - libjpeg-turbo=3.0.0=hd590300_1
-  - liblapack=3.9.0=6_ha36c22a_netlib
   - liblzma=5.6.3=hb9d3cd8_1
   - libnetcdf=4.9.2=nompi_h00e09a9_116
   - libnghttp2=1.64.0=h161d5f1_0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,10 +111,10 @@ test-requires = "pytest"
 test-command = "pytest {package}/tests/test_simsopt_compat.py {package}/tests/test_free_boundary.py"
 
 [tool.cibuildwheel.linux]
-before-build = "yum install -y lapack-devel netcdf-devel hdf5-devel"
+before-build = "yum install -y netcdf-devel hdf5-devel"
 
 [tool.cibuildwheel.macos]
-before-build = "brew install gcc lapack netcdf hdf5 libomp"
+before-build = "brew install gcc netcdf hdf5 libomp"
 
 [tool.coverage.run]
 source_pkgs = ["vmecpp", "tests"]

--- a/src/vmecpp/cpp/docker/tsan/Dockerfile
+++ b/src/vmecpp/cpp/docker/tsan/Dockerfile
@@ -41,8 +41,7 @@ RUN apt-get install -y curl && curl -L "https://github.com/bazelbuild/bazelisk/r
 
 # Install packages required for building VMEC++.
 RUN apt-get install -y \
-    libnetcdf-dev \
-    liblapacke-dev
+    libnetcdf-dev
 
 # Install packages for in-docker development
 RUN apt-get install -y vim

--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/BUILD.bazel
@@ -13,9 +13,6 @@ cc_library(
         "//vmecpp/common/fourier_basis_fast_toroidal",
         "//vmecpp/free_boundary/tangential_partitioning:tangential_partitioning",
     ],
-    linkopts = [
-        "-llapack",
-    ],
 )
 
 cc_test(
@@ -41,5 +38,4 @@ cc_binary(
         "//vmecpp/free_boundary/tangential_partitioning:tangential_partitioning",
         "@google_benchmark//:benchmark_main",
     ],
-    linkopts = ["-llapack"],
 )

--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.cc
@@ -5,33 +5,26 @@
 #include "vmecpp/free_boundary/laplace_solver/laplace_solver.h"
 
 #include <cmath>
-#include <iostream>
 #include <vector>
 
 #include "absl/algorithm/container.h"
 #include "absl/log/check.h"
 
-///  LU factorization of a general M-by-N matrix A
-extern "C" void dgetrf_(int* m, int* n, double* a, int* lda, int* ipiv,
-                        int* info);
-///  Solves a system of linear equations using the LU factorization.
-extern "C" void dgetrs_(char* transpose, int* num_rows, int* num_columns,
-                        double* matrix, int* leading_dim, int* pivot, double* y,
-                        int* y_leading_dim, int* info);
-
 namespace vmecpp {
 
-LaplaceSolver::LaplaceSolver(const Sizes* s, const FourierBasisFastToroidal* fb,
-                             const TangentialPartitioning* tp, int nf, int mf,
-                             std::span<double> matrixShare, std::span<int> iPiv,
-                             std::span<double> bvecShare)
+LaplaceSolver::LaplaceSolver(
+    const Sizes* s, const FourierBasisFastToroidal* fb,
+    const TangentialPartitioning* tp, int nf, int mf,
+    std::span<double> matrixShare,
+    Eigen::PartialPivLU<Eigen::MatrixXd>* lu_decomposition,
+    std::span<double> bvecShare)
     : s_(*s),
       fb_(*fb),
       tp_(*tp),
       nf(nf),
       mf(mf),
       matrixShare(matrixShare),
-      iPiv(iPiv),
+      lu_decomposition_(lu_decomposition),
       bvecShare(bvecShare) {
   // thread-local tangential grid point range
   numLocal = tp_.ztMax - tp_.ztMin;
@@ -578,28 +571,17 @@ void LaplaceSolver::BuildMatrix() {
 
 void LaplaceSolver::DecomposeMatrix() {
   const int mnpd = (mf + 1) * (2 * nf + 1);
-  int mnpd_dim = s_.lasym ? 2 * mnpd : mnpd;
-
-  // NOTE:
-  // As soon as LAPACK starts working on `matrixShare`,
-  // it is not consistent with the value on entry anymore
-  // and thus cannot be used for testing anymore.
+  const int mnpd_dim = s_.lasym ? 2 * mnpd : mnpd;
 
   // perform LU factorization of the matrix
   // (only needed when matrix is updated --> every nvacskip iterations)
-  int info;
-  dgetrf_(&mnpd_dim, &mnpd_dim, matrixShare.data(), &mnpd_dim, iPiv.data(),
-          &info);
+  Eigen::Map<const Eigen::MatrixXd> matrix_map(matrixShare.data(), mnpd_dim,
+                                               mnpd_dim);
+  lu_decomposition_->compute(matrix_map);
 
-  if (info < 0) {
-    std::cout << -info << "-th argument to dgetrf is wrong\n";
-  } else if (info > 0) {
-    std::cout << absl::StrFormat(
-        "U(%d,%d) is exactly zero in dgetrf --> singular matrix!\n", info,
-        info);
-  }
-
-  CHECK_EQ(info, 0) << "dgetrf error";
+  // A zero diagonal entry in the U factor means an exactly singular matrix.
+  CHECK((lu_decomposition_->matrixLU().diagonal().array() != 0.0).all())
+      << "singular matrix in LaplaceSolver::DecomposeMatrix";
 }  // DecomposeMatrix
 
 void LaplaceSolver::SolveForPotential(
@@ -653,19 +635,13 @@ void LaplaceSolver::SolveForPotential(
       }
     }
 
-    // solve for given RHS
-    int one = 1;
-    int info;
-    char no_transpose = 'N';
-    int n = mnpd_dim;
-    dgetrs_(&no_transpose, &n, &one, matrixShare.data(), &n, iPiv.data(),
-            bvecShare.data(), &n, &info);
-
-    if (info < 0) {
-      std::cout << -info << "-th argument to dgetrs wrong\n";
-    }
-
-    CHECK_EQ(info, 0) << "dgetrs error";
+    // solve for given RHS using the factorization computed in
+    // DecomposeMatrix(). Use a temporary for the result: bvecShare is both
+    // the right-hand side and the destination, and aliasing it directly
+    // against the input of PartialPivLU::solve() is not guaranteed safe.
+    Eigen::Map<const Eigen::VectorXd> rhs(bvecShare.data(), mnpd_dim);
+    const Eigen::VectorXd solution = lu_decomposition_->solve(rhs);
+    Eigen::Map<Eigen::VectorXd>(bvecShare.data(), mnpd_dim) = solution;
   }
 #ifdef _OPENMP
 #pragma omp barrier

--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.h
@@ -17,9 +17,18 @@ namespace vmecpp {
 
 class LaplaceSolver {
  public:
+  // lu_decomposition is a non-owning pointer to a LU decomposition object
+  // that is shared across all per-thread LaplaceSolver instances of a given
+  // vacuum solve, exactly like matrixShare/bvecShare are spans into shared
+  // backing storage: DecomposeMatrix() (called by exactly one thread, guarded
+  // by an outer `#pragma omp single`) may run on a different LaplaceSolver
+  // object than the one whose SolveForPotential() (also single-threaded
+  // internally) later reads the factorization, so the decomposition itself
+  // must live outside any individual LaplaceSolver instance.
   LaplaceSolver(const Sizes* s, const FourierBasisFastToroidal* fb,
                 const TangentialPartitioning* tp, int nf, int mf,
-                std::span<double> matrixShare, std::span<int> iPiv,
+                std::span<double> matrixShare,
+                Eigen::PartialPivLU<Eigen::MatrixXd>* lu_decomposition,
                 std::span<double> bvecShare);
 
   void TransformGreensFunctionDerivative(const Eigen::VectorXd& greenp);
@@ -96,10 +105,13 @@ class LaplaceSolver {
   int nf;
   int mf;
 
-  // needed for LAPACK's dgetrf
+  // needed for the dense linear solve (BuildMatrix/DecomposeMatrix/
+  // SolveForPotential)
   // non-owning pointers
   std::span<double> matrixShare;
-  std::span<int> iPiv;
+  // Shared LU decomposition object; see the constructor comment for why this
+  // cannot be a plain member of LaplaceSolver.
+  Eigen::PartialPivLU<Eigen::MatrixXd>* lu_decomposition_;
   std::span<double> bvecShare;
 
   // ----------------

--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver_bench.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver_bench.cc
@@ -7,8 +7,8 @@
 //
 // The dense linear system assembled and factorized here is the dominant
 // free-boundary cost when NESTOR performs a full update: an
-// mnpd x mnpd  (mnpd = (mf+1)*(2*nf+1))  matrix is built, LU-factorized via
-// LAPACK dgetrf, and back-substituted via dgetrs.  We benchmark:
+// mnpd x mnpd  (mnpd = (mf+1)*(2*nf+1))  matrix is built, LU-factorized, and
+// back-substituted via Eigen::PartialPivLU.  We benchmark:
 //
 //   * TransformGreensFunctionDerivative -- the largest of the Fourier
 //     transforms feeding the source term (uses the manufactured single-mode
@@ -53,8 +53,8 @@ constexpr ResParams kResolutions[] = {
 
 // ----------------------------------------------------------------------------
 // Fixture matching laplace_solver_test.cc's minimal single-threaded setup:
-// a non-mocked LaplaceSolver with flat matrixShare / iPiv / bvecShare backing
-// storage.
+// a non-mocked LaplaceSolver with flat matrixShare / bvecShare backing
+// storage and a shared LU decomposition object.
 // ----------------------------------------------------------------------------
 struct BenchFixture {
   Sizes s;
@@ -66,8 +66,8 @@ struct BenchFixture {
   int mnpd;
 
   std::vector<double> matrixShare;
-  std::vector<int> iPiv;
   std::vector<double> bvecShare;
+  Eigen::PartialPivLU<Eigen::MatrixXd> lu_decomposition;
 
   std::unique_ptr<LaplaceSolver> ls;
 
@@ -87,16 +87,16 @@ struct BenchFixture {
         mf(mpol + 1),
         mnpd((mf + 1) * (2 * nf + 1)),
         matrixShare(mnpd * mnpd, 0.0),
-        iPiv(mnpd, 0),
         bvecShare(mnpd, 0.0) {
     ls = std::make_unique<LaplaceSolver>(
-        &s, &fb, &tp, nf, mf, std::span<double>(matrixShare),
-        std::span<int>(iPiv), std::span<double>(bvecShare));
+        &s, &fb, &tp, nf, mf, std::span<double>(matrixShare), &lu_decomposition,
+        std::span<double>(bvecShare));
 
     std::mt19937 rng(42);
     std::uniform_real_distribution<double> dist(-1.0, 1.0);
 
-    // Diagonally-dominant matrix so dgetrf never hits a singular pivot.
+    // Diagonally-dominant matrix so the LU factorization never hits a
+    // singular pivot.
     amat_seed.resize(mnpd * mnpd);
     for (int col = 0; col < mnpd; ++col) {
       for (int row = 0; row < mnpd; ++row) {
@@ -129,9 +129,8 @@ struct BenchFixture {
     }
   }
 
-  // Re-seed the LaplaceSolver's system state to the well-conditioned baseline.
-  // dgetrf destroys matrixShare in place, so this must run before each
-  // decompose+solve iteration.
+  // Re-seed the LaplaceSolver's system state to the well-conditioned
+  // baseline before each decompose+solve iteration.
   void ResetSystem() {
     ls->amat_sin_sin = amat_seed;
     ls->bvec_sin = Eigen::VectorXd::Zero(mnpd);
@@ -156,7 +155,7 @@ void BM_LaplaceSolve(benchmark::State& state) {
   state.SetLabel(kResolutions[kIdx].label);
 }
 
-// Just the LU factorization (dgetrf), the O(mnpd^3) hotspot.
+// Just the LU factorization, the O(mnpd^3) hotspot.
 template <int kIdx>
 void BM_LaplaceDecompose(benchmark::State& state) {
   static BenchFixture fx(kResolutions[kIdx].nfp, kResolutions[kIdx].mpol,

--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver_test.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver_test.cc
@@ -58,11 +58,11 @@ TEST_P(TransformGreensFunctionDerivativeTest, SingleModeRoundTrip) {
 
   // Dummy shared arrays (single-threaded, no cross-thread accumulation needed)
   std::vector<double> matrixShare(mnpd * mnpd, 0.0);
-  std::vector<int> iPiv(mnpd, 0);
   std::vector<double> bvecShare(mnpd, 0.0);
+  Eigen::PartialPivLU<Eigen::MatrixXd> lu_decomposition;
 
   LaplaceSolver ls(&s, &fb, &tp, nf, mf, std::span<double>(matrixShare),
-                   std::span<int>(iPiv), std::span<double>(bvecShare));
+                   &lu_decomposition, std::span<double>(bvecShare));
 
   // Build greenp[klpRel * nThetaEven * nZeta + l * nZeta + k].
   // For each klp, inject exactly one mode:
@@ -219,11 +219,11 @@ TEST(LaplaceSolverTest, ZeroKernelSolveGivesHalfInverse) {
   const int numLocal = tp.ztMax - tp.ztMin;
 
   std::vector<double> matrixShare(mnpd * mnpd, 0.0);
-  std::vector<int> iPiv(mnpd, 0);
   std::vector<double> bvecShare(mnpd, 0.0);
+  Eigen::PartialPivLU<Eigen::MatrixXd> lu_decomposition;
 
   LaplaceSolver ls(&s, &fb, &tp, nf, mf, std::span<double>(matrixShare),
-                   std::span<int>(iPiv), std::span<double>(bvecShare));
+                   &lu_decomposition, std::span<double>(bvecShare));
 
   // Zero greenp: no double-layer kernel contribution.
   Eigen::VectorXd greenp =

--- a/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.cc
@@ -11,7 +11,8 @@ namespace vmecpp {
 Nestor::Nestor(const Sizes* s, const TangentialPartitioning* tp,
                const MGridProvider* mgrid, std::span<double> matrixShare,
                std::span<double> bvecShare, std::span<double> bSqVacShare,
-               std::span<int> iPiv, std::span<double> vacuum_b_r_share,
+               Eigen::PartialPivLU<Eigen::MatrixXd>* lu_decomposition,
+               std::span<double> vacuum_b_r_share,
                std::span<double> vacuum_b_phi_share,
                std::span<double> vacuum_b_z_share)
     : FreeBoundaryBase(s, tp, mgrid, bSqVacShare, vacuum_b_r_share,
@@ -20,7 +21,7 @@ Nestor::Nestor(const Sizes* s, const TangentialPartitioning* tp,
       mf(s_.mpol + 1),
       si_(s, &fb_, tp, &sg_, nf, mf),
       ri_(s, tp, &sg_),
-      ls_(s, &fb_, tp, nf, mf, matrixShare, iPiv, bvecShare),
+      ls_(s, &fb_, tp, nf, mf, matrixShare, lu_decomposition, bvecShare),
       bvecShare(bvecShare) {
   int numLocal = tp_.ztMax - tp_.ztMin;
 

--- a/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.h
@@ -26,7 +26,8 @@ class Nestor : public FreeBoundaryBase {
   Nestor(const Sizes* s, const TangentialPartitioning* tp,
          const MGridProvider* mgrid, std::span<double> matrixShare,
          std::span<double> bvecShare, std::span<double> bSqVacShare,
-         std::span<int> iPiv, std::span<double> vacuum_b_r_share,
+         Eigen::PartialPivLU<Eigen::MatrixXd>* lu_decomposition,
+         std::span<double> vacuum_b_r_share,
          std::span<double> vacuum_b_phi_share,
          std::span<double> vacuum_b_z_share);
 

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -202,7 +202,6 @@ Vmec::Vmec(const VmecINDATA& indata, std::optional<int> max_threads,
     // mnpd2 = 2 * mnpd (analog of mnpd2 in the Fortran vacmod / scalpot).
     int mnpd_dim = s_.lasym ? 2 * mnpd : mnpd;
     matrixShare.setZero(mnpd_dim * mnpd_dim);
-    iPiv.setZero(mnpd_dim);
     bvecShare.setZero(mnpd_dim);
 
     h_.vacuum_magnetic_pressure.setZero(s_.nZnT);
@@ -485,7 +484,7 @@ void Vmec::SetupVacuumSolvers() {
           std::span<double>(bvecShare.data(), bvecShare.size()),
           std::span<double>(h_.vacuum_magnetic_pressure.data(),
                             h_.vacuum_magnetic_pressure.size()),
-          std::span<int>(iPiv.data(), iPiv.size()),
+          &lu_decomposition,
           std::span<double>(h_.vacuum_b_r.data(), h_.vacuum_b_r.size()),
           std::span<double>(h_.vacuum_b_phi.data(), h_.vacuum_b_phi.size()),
           std::span<double>(h_.vacuum_b_z.data(), h_.vacuum_b_z.size()));

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
@@ -224,7 +224,11 @@ class Vmec {
   std::vector<std::unique_ptr<RadialPartitioning>> old_r_;
 
   Eigen::VectorXd matrixShare;
-  Eigen::VectorXi iPiv;
+  // LU decomposition of matrixShare, shared across all vac_num_threads_
+  // Nestor/LaplaceSolver instances (mirroring how matrixShare/bvecShare are
+  // spans into shared backing storage). See LaplaceSolver's constructor for
+  // why this must be a single object rather than a per-thread member.
+  Eigen::PartialPivLU<Eigen::MatrixXd> lu_decomposition;
   Eigen::VectorXd bvecShare;
 
  private:


### PR DESCRIPTION
vmecpp's calls exactly two LAPACK routines, dgetrf_ and dgetrs_ in LaplaceSolver. Because of that, we bundle a full LAPACK library with the wheel.

This PR replaces both calls with Eigen::PartialPivLUEigen::MatrixXd, removing one more dependency.

Benchmarks continue to report similar numbers.