### PR TITLE
Fix typos in Python docstrings and messages

### DIFF
--- a/src/vmecpp/__main__.py
+++ b/src/vmecpp/__main__.py
@@ -43,7 +43,7 @@ def parse_arguments(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument(
         "-t",
         "--max-threads",
-        help="Maximum number of threads that VMEC++ should spawn. The actual number might still be lower that this in case there are too few flux surfaces to keep these many threads busy.",
+        help="Maximum number of threads that VMEC++ should spawn. The actual number might still be lower than this in case there are too few flux surfaces to keep these many threads busy.",
         type=int,
     )
     p.add_argument(

--- a/src/vmecpp/_free_boundary.py
+++ b/src/vmecpp/_free_boundary.py
@@ -125,8 +125,8 @@ class MagneticFieldResponseTable(BaseModelWithNumpy):
         """Convert the Pydantic object to a C++ MagneticFieldResponseTable object,
         avoiding a copy if possible."""
         # If vmecpp.MagneticFieldResponseTable was created from a C++ object, the
-        # arrays be views to the memory of the C++ object. We don't need to create
-        # a new object and just return the underling one.
+        # arrays are views to the memory of the C++ object. We don't need to create
+        # a new object and just return the underlying one.
         underlying = self.b_r.base
         if (
             isinstance(underlying, _vmecpp.MagneticFieldResponseTable)

--- a/src/vmecpp/_pydantic_numpy.py
+++ b/src/vmecpp/_pydantic_numpy.py
@@ -133,8 +133,7 @@ For example, you can declare `value: jt.Float[np.ndarray, ...]` instead of
 The mechanism for serialization is to convert "special" fields to JSON-serializable
 values and then let Pydantic take care of the rest.
 In practice:
-- If the field is "special", (e.g. `np.ndarray`) it is converted to either a primitive
-  list.
+- If the field is "special", (e.g. `np.ndarray`) it is converted to a primitive list.
 - If the field is a generic/composed type such as a list, an optional or a union,
   recurse and do the same for the inner types.
 - Otherwise just return the field as is.

--- a/src/vmecpp/_util.py
+++ b/src/vmecpp/_util.py
@@ -32,16 +32,16 @@ def distribution_root() -> Path:
     package_root, but doesn't have to be.
 
     The two differ in editable installations, where package_root() will point to the
-    source files, and distribution will point the /site-packages/vmecpp folder of your
-    python environment. It is the correct path to use for accessing shared libraries and
-    executables that come with vmecpp.
+    source files, and distribution will point to the /site-packages/vmecpp folder of
+    your python environment. It is the correct path to use for accessing shared
+    libraries and executables that come with vmecpp.
     """
     return Path(importlib.metadata.distribution("vmecpp").locate_file("vmecpp"))  # type: ignore
 
 
 @contextlib.contextmanager
 def change_working_directory_to(path: Path) -> Generator[None, None, None]:
-    """Changes the working director within a context manager.
+    """Changes the working directory within a context manager.
 
     Args:
         path: The path to change the working directory to.
@@ -170,7 +170,7 @@ def indata_to_json(
 # adapted from https://github.com/jonathanschilling/indata2json/blob/4274976/json2indata
 def vmecpp_json_to_indata(vmecpp_json: dict[str, Any]) -> str:
     """Convert a dictionary with the contents of a VMEC++ JSON input file to the
-    corresponding conents of a VMEC2000 INDATA file."""
+    corresponding contents of a VMEC2000 INDATA file."""
 
     indata: str = "&INDATA\n"
 


### PR DESCRIPTION
Typo fixes in `_util.py`, `_free_boundary.py`, `_pydantic_numpy.py` and the `--max-threads` help text: misspellings (director, conents, underling), a missing verb and preposition, a stray "either", and "lower that" -> "lower than".