### PR TITLE
Remove py3.14 constraint after simsopt update

### DIFF
--- a/.github/constraints.txt
+++ b/.github/constraints.txt
@@ -1,3 +1,2 @@
-# Block simsopt 1.11.0 wheels with unsupported AVX-512 instructions. Python 3.14
-# has no wheel and must use the corrected 1.11.0 source distribution.
-simsopt!=1.11.0; python_version != "3.14"
+# Block simsopt 1.11.0 wheels with unsupported AVX-512 instructions.
+simsopt!=1.11.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,6 @@ version_file = "src/vmecpp/__about__.py"
 [tool.cibuildwheel]
 archs = ["native"]
 skip = ["*-musllinux*"]
-test-skip = ["cp314-*", "cp314t-*"] # Skip tests on Python 3.14 until all our dependencies start supporting it. The wheels are still valid, and become installable the moment simsopt releases 3.14 support.
 build-frontend = "build[uv]" # More modern package manager than pip, with faster builds
 test-requires = "pytest"
 test-command = "pytest {package}/tests/test_simsopt_compat.py {package}/tests/test_free_boundary.py"


### PR DESCRIPTION
Remove py3.14 constraint after simsopt update