### PR TITLE
ci: cache ccache across CI jobs; fix ccache not reaching HDF5/netCDF builds

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,14 +49,25 @@ jobs:
       - name: Install required packages for MacOS
         if: ${{ contains(matrix.os, 'macos') }}
         run: |
-          brew install ninja libomp eigen git
+          brew install ninja libomp eigen git ccache
       - name: Install required packages for Ubuntu
         if: ${{ contains(matrix.os, 'ubuntu') }}
         run: |
           # install VMEC++ deps as well as VMEC2000 deps (we need to import VMEC2000 in a test).
           # VMEC2000 itself gets libopenblas-dev/libscalapack-mpi-dev below, which cover its
           # LAPACK needs; VMEC++ no longer links LAPACK at all.
-          sudo apt-get update && sudo apt-get install -y build-essential cmake zlib1g-dev libomp-dev
+          sudo apt-get update && sudo apt-get install -y build-essential cmake zlib1g-dev libomp-dev ccache
+      - name: Cache ccache directory
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.ccache
+          # Keyed on the C++ sources: unchanged sources -> exact hit for every
+          # matrix leg (they all share this one key, so only the leg that
+          # misses ends up saving). restore-keys falls back to the closest
+          # prior cache when sources did change, for partial ccache hits.
+          key: ccache-${{ matrix.os }}-${{ hashFiles('CMakeLists.txt', 'src/vmecpp/cpp/**') }}
+          restore-keys: |
+            ccache-${{ matrix.os }}-
       - name: Cache the VMEC2000 wheel
         if: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version == '3.10' }}
         uses: actions/cache@v4
@@ -85,6 +96,8 @@ jobs:
           # fail loudly here if the binding is still broken, not in the test step
           python -c "import vmec; print('VMEC2000 import OK')"
       - name: Install package
+        env:
+          CCACHE_DIR: ${{ github.workspace }}/.ccache
         run: |
           # on Ubuntu we would not need this, but on MacOS we need to point CMake to gfortran-14 and gcc-14
           export FC=$(which gfortran-14 || which gfortran)
@@ -97,6 +110,7 @@ jobs:
           else
             python -m pip install -v .[test]
           fi
+          ccache -s
       - name: Test package
         run: python -m pytest tests/
       - name: Test docstring examples
@@ -118,8 +132,17 @@ jobs:
           cache: 'pip'
       - name: Install required packages for Ubuntu
         run: |
-          sudo apt-get update && sudo apt-get install -y build-essential cmake zlib1g-dev libomp-dev
+          sudo apt-get update && sudo apt-get install -y build-essential cmake zlib1g-dev libomp-dev ccache
+      - name: Cache ccache directory
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-ubuntu-22.04-${{ hashFiles('CMakeLists.txt', 'src/vmecpp/cpp/**') }}
+          restore-keys: |
+            ccache-ubuntu-22.04-
       - name: Install package
+        env:
+          CCACHE_DIR: ${{ github.workspace }}/.ccache
         run: python -m pip install .[test]
       - name: Test example scripts
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ add_compile_definitions(EIGEN_MAX_ALIGN_BYTES=32 EIGEN_MAX_STATIC_ALIGN_BYTES=32
 find_program(CCACHE_COMMAND NAMES ccache ccache-swig)
 if(EXISTS ${CCACHE_COMMAND})
   message(STATUS "Found ccache: ${CCACHE_COMMAND}")
+  set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_COMMAND})
   set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_COMMAND})
 else()
   message(STATUS "Could NOT find ccache")
@@ -64,6 +65,16 @@ set(_native_deps_cmake_args
   -DBUILD_SHARED_LIBS=OFF
   -DCMAKE_POSITION_INDEPENDENT_CODE=ON
   -DBUILD_TESTING=OFF)
+
+if(EXISTS ${CCACHE_COMMAND})
+  # ExternalProject_Add runs its own separate CMake configure, so it does not
+  # inherit the top-level CMAKE_CXX_COMPILER_LAUNCHER set above; without this,
+  # HDF5 and netCDF (the most expensive part of a from-source build) never
+  # touch ccache at all.
+  list(APPEND _native_deps_cmake_args
+    -DCMAKE_C_COMPILER_LAUNCHER=${CCACHE_COMMAND}
+    -DCMAKE_CXX_COMPILER_LAUNCHER=${CCACHE_COMMAND})
+endif()
 
 if(APPLE)
   # CC=brew's gcc-14 (set by some CI jobs) chokes on Apple's SDK math.h for


### PR DESCRIPTION
## Problem

Every leg of the test matrix (2 OS x 2 editable x 5 Python = 20 jobs) does a
fully cold C++ build: Eigen, abseil, HDF5, and netCDF are all recompiled from
scratch, with no caching whatsoever between jobs or runs. On the linked run,
`Install package` alone took ~6 min per job:
https://github.com/proximafusion/vmecpp/actions/runs/33166608919/job/98833491538

## Root cause (also present locally)

`CMakeLists.txt` detects `ccache` and sets `CMAKE_CXX_COMPILER_LAUNCHER` for
the main project, but HDF5 and netCDF are built via `ExternalProject_Add`,
which runs its own independent CMake configure and does **not** inherit that
setting. Verified locally: the generated `build.ninja` for the top-level
project references `ccache`, but the ones for `hdf5_native-build` and
`netcdf_native-build` have zero references to it. Since #704 made HDF5/netCDF
build from source, this means the single most expensive part of the build
never benefited from ccache, even for local incremental rebuilds.

## Changes

- `CMakeLists.txt`: pass `CMAKE_C_COMPILER_LAUNCHER`/
  `CMAKE_CXX_COMPILER_LAUNCHER=ccache` explicitly into the native-deps
  `ExternalProject_Add` CMake args.
- `.github/workflows/tests.yaml`: install `ccache` and cache its directory
  (`actions/cache`) in both the `tests` and `examples` jobs, keyed on a hash
  of `CMakeLists.txt`/`src/vmecpp/cpp/**`. Unchanged C++ sources -> every
  matrix leg shares the same key -> exact cache hit, no save races.

## Demonstration plan

This PR's own CI run is expected to be cold (nothing cached yet) -- it primes
the cache for this branch, and merging it primes the cache scoped to `main`.
A follow-up PR that doesn't touch C++ sources will restore that cache and
should show a large speedup in the `Install package` step.