### PR TITLE
ci: demonstrate ccache cache reuse (stacked on #712)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
+# Demo commit: no C++ sources touched here, so the ccache cache key below is
+# unchanged from the parent commit and every matrix leg should get an exact
+# ccache hit, restoring the cache this branch's previous run saved.
+
 # CI-only dependency workaround, see .github/constraints.txt
 env:
   PIP_CONSTRAINT: ${{ github.workspace }}/.github/constraints.txt


### PR DESCRIPTION
Stacked on #712 -- do not merge into `main` directly; this is a demonstration
that the ccache cache from #712's run gets restored and reused.

This commit touches only `.github/workflows/tests.yaml` (a comment), leaving
`CMakeLists.txt`/`src/vmecpp/cpp/**` untouched. Since the cache key is a hash
of exactly those paths, every matrix leg should get an exact ccache hit
restoring the cache #712's run saved on this same branch (GitHub Actions
cache is branch-scoped, so same-branch restore works without needing to
merge to `main` first).

Expect `Install package` to drop from ~6-9 min (cold, see #712) to well under
a minute once ccache is warm.