### PR TITLE
Make the vacuum-grid overrun an error instead of a stderr warning

### DIFF
--- a/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/BUILD.bazel
@@ -14,5 +14,6 @@ cc_library(
         "//vmecpp/free_boundary/tangential_partitioning:tangential_partitioning",
         "@abscab_cpp//abscab:abscab",
         "@abseil-cpp//absl/algorithm:container",
+        "@abseil-cpp//absl/status:status",
     ],
 )

--- a/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.cc
@@ -47,15 +47,22 @@ ExternalMagneticField::ExternalMagneticField(const Sizes* s,
 }
 
 // rAxis, zAxis are provided over a single module
-void ExternalMagneticField::update(const std::span<const double> rAxis,
-                                   const std::span<const double> zAxis,
-                                   double netToroidalCurrent) {
+absl::Status ExternalMagneticField::update(const std::span<const double> rAxis,
+                                           const std::span<const double> zAxis,
+                                           double netToroidalCurrent) {
 #ifdef _OPENMP
 #pragma omp barrier
 #endif  // _OPENMP
 
-  mgrid_.interpolate(tp_.ztMin, tp_.ztMax, s_.nZeta, sg_.r1b, sg_.z1b, interpBr,
-                     interpBp, interpBz);
+  // An out-of-grid boundary is reported rather than returned here: the barriers
+  // below are collective over the vacuum team, and only the threads whose own
+  // tangential slice left the grid would see the error, so returning early
+  // would leave the rest of the team waiting forever. The interpolated field is
+  // clamped and therefore finite, so the remainder of this function is safe to
+  // run on it; the caller discards the result once it observes the status.
+  absl::Status interpolation_status =
+      mgrid_.interpolate(tp_.ztMin, tp_.ztMax, s_.nZeta, s_.nZnT, sg_.r1b,
+                         sg_.z1b, interpBr, interpBp, interpBz);
 
 #ifdef _OPENMP
 #pragma omp barrier
@@ -76,6 +83,8 @@ void ExternalMagneticField::update(const std::span<const double> rAxis,
 #ifdef _OPENMP
 #pragma omp barrier
 #endif  // _OPENMP
+
+  return interpolation_status;
 }
 
 // add in contribution from net toroidal current along magnetic axis

--- a/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.cc
@@ -54,12 +54,7 @@ absl::Status ExternalMagneticField::update(const std::span<const double> rAxis,
 #pragma omp barrier
 #endif  // _OPENMP
 
-  // An out-of-grid boundary is reported rather than returned here: the barriers
-  // below are collective over the vacuum team, and only the threads whose own
-  // tangential slice left the grid would see the error, so returning early
-  // would leave the rest of the team waiting forever. The interpolated field is
-  // clamped and therefore finite, so the remainder of this function is safe to
-  // run on it; the caller discards the result once it observes the status.
+  // Not returned here: the barriers below are collective over the team.
   absl::Status interpolation_status =
       mgrid_.interpolate(tp_.ztMin, tp_.ztMax, s_.nZeta, s_.nZnT, sg_.r1b,
                          sg_.z1b, interpBr, interpBp, interpBz);

--- a/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.h
@@ -22,11 +22,7 @@ class ExternalMagneticField {
   ExternalMagneticField(const Sizes* s, const TangentialPartitioning* tp,
                         const SurfaceGeometry* sg, const MGridProvider* mgrid);
 
-  // Returns a kFailedPrecondition status if the plasma boundary left the
-  // vacuum field grid on this thread's tangential slice. The outputs are still
-  // computed in that case, on a field clamped to the grid edge, so that the
-  // collective barriers inside stay uniform across the vacuum team; the caller
-  // must reduce the status across the team before acting on it.
+  // Returns kFailedPrecondition if this thread's slice left the vacuum grid.
   [[nodiscard]] absl::Status update(const std::span<const double> rAxis,
                                     const std::span<const double> zAxis,
                                     double netToroidalCurrent);

--- a/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/external_magnetic_field/external_magnetic_field.h
@@ -8,6 +8,7 @@
 #include <Eigen/Dense>
 #include <span>
 
+#include "absl/status/status.h"
 #include "vmecpp/common/sizes/sizes.h"
 #include "vmecpp/common/util/util.h"
 #include "vmecpp/free_boundary/mgrid_provider/mgrid_provider.h"
@@ -21,8 +22,14 @@ class ExternalMagneticField {
   ExternalMagneticField(const Sizes* s, const TangentialPartitioning* tp,
                         const SurfaceGeometry* sg, const MGridProvider* mgrid);
 
-  void update(const std::span<const double> rAxis,
-              const std::span<const double> zAxis, double netToroidalCurrent);
+  // Returns a kFailedPrecondition status if the plasma boundary left the
+  // vacuum field grid on this thread's tangential slice. The outputs are still
+  // computed in that case, on a field clamped to the grid edge, so that the
+  // collective barriers inside stay uniform across the vacuum team; the caller
+  // must reduce the status across the team before acting on it.
+  [[nodiscard]] absl::Status update(const std::span<const double> rAxis,
+                                    const std::span<const double> zAxis,
+                                    double netToroidalCurrent);
 
   // axis geometry around whole machine
   Eigen::VectorXd axisXYZ;

--- a/src/vmecpp/cpp/vmecpp/free_boundary/free_boundary_base/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/free_boundary_base/BUILD.bazel
@@ -6,6 +6,7 @@ cc_library(
     hdrs = ["free_boundary_base.h"],
     visibility = ["//visibility:public"],
     deps = [
+        "@abseil-cpp//absl/status:statusor",
         "//vmecpp/common/fourier_basis_fast_toroidal:fourier_basis_fast_toroidal",
         "//vmecpp/common/sizes:sizes",
         "//vmecpp/common/util:util",

--- a/src/vmecpp/cpp/vmecpp/free_boundary/free_boundary_base/free_boundary_base.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/free_boundary_base/free_boundary_base.h
@@ -37,14 +37,7 @@ class FreeBoundaryBase {
         vacuum_b_phi_share_(vacuum_b_phi_share),
         vacuum_b_z_share_(vacuum_b_z_share) {}
 
-  // Returns true if the solve stopped early at the requested debug checkpoint.
-  //
-  // Returns an error status if the vacuum solve cannot produce a meaningful
-  // field for this boundary, for example because the boundary left the domain
-  // of the vacuum field grid. Implementations run inside the nested vacuum
-  // OpenMP team and must therefore reach every collective barrier before
-  // returning such a status, which means carrying it to the end of the call
-  // rather than returning at the point of detection.
+  // True at the debug checkpoint; error status if the vacuum solve failed.
   virtual absl::StatusOr<bool> update(
       const std::span<const double> rCC, const std::span<const double> rSS,
       const std::span<const double> rSC, const std::span<const double> rCS,

--- a/src/vmecpp/cpp/vmecpp/free_boundary/free_boundary_base/free_boundary_base.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/free_boundary_base/free_boundary_base.h
@@ -8,6 +8,7 @@
 #include <span>
 #include <vector>
 
+#include "absl/status/statusor.h"
 #include "vmecpp/common/fourier_basis_fast_toroidal/fourier_basis_fast_toroidal.h"
 #include "vmecpp/common/sizes/sizes.h"
 #include "vmecpp/common/util/util.h"
@@ -36,7 +37,15 @@ class FreeBoundaryBase {
         vacuum_b_phi_share_(vacuum_b_phi_share),
         vacuum_b_z_share_(vacuum_b_z_share) {}
 
-  virtual bool update(
+  // Returns true if the solve stopped early at the requested debug checkpoint.
+  //
+  // Returns an error status if the vacuum solve cannot produce a meaningful
+  // field for this boundary, for example because the boundary left the domain
+  // of the vacuum field grid. Implementations run inside the nested vacuum
+  // OpenMP team and must therefore reach every collective barrier before
+  // returning such a status, which means carrying it to the end of the call
+  // rather than returning at the point of detection.
+  virtual absl::StatusOr<bool> update(
       const std::span<const double> rCC, const std::span<const double> rSS,
       const std::span<const double> rSC, const std::span<const double> rCS,
       const std::span<const double> zSC, const std::span<const double> zCS,

--- a/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/BUILD.bazel
@@ -8,6 +8,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@abseil-cpp//absl/log:check",
+        "@abseil-cpp//absl/status:status",
         "@abseil-cpp//absl/strings:str_format",
         "//util/netcdf_io:netcdf_io",
         "//vmecpp/common/util:util",

--- a/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
@@ -333,8 +333,7 @@ absl::Status MGridProvider::interpolate(int ztMin, int ztMax, int nZeta,
 
   if (has_fixed_field_) {
     // quick return: just copy into target storage
-    // Every thread of the vacuum team takes this branch together, so skipping
-    // the barrier at the end of this function is uniform across the team.
+    // Uniform across the team, so skipping the barrier below is safe.
 
     for (int kl = ztMin; kl < ztMax; ++kl) {
       m_interpBr[kl - ztMin] = fixed_br_[kl];
@@ -396,25 +395,13 @@ absl::Status MGridProvider::interpolate(int ztMin, int ztMax, int nZeta,
 
   absl::Status status = absl::OkStatus();
   if (exceedGridSizeR || exceedGridSizeZ) {
-    // The field written above is clamped to the grid edge, so it no longer
-    // represents the coils outside the grid. Continuing on it silently biases
-    // the free-boundary force and moves the converged boundary; reporting it
-    // as an error is what keeps that from being mistaken for a physical or a
-    // solver effect.
-    //
+    // The clamped field no longer represents the coils outside the grid.
     // TODO(jons): automatically evaluate B outside of grid based on coil
     // definitions and Biot-Savart
     // --> will only get slower, but more robust (and accurate?)
     // --> would also require to always have coil geometry inside mgrid file for
     // on-the-fly re-evaluation...
-    //
-    // The extents below are taken over the whole boundary rather than over
-    // [ztMin, ztMax): rLCFS and zLCFS are full-surface and hold the same values
-    // on every thread of the vacuum team, so reporting them globally makes the
-    // message independent of which thread's slice left the grid and of which
-    // thread happens to win the reduction. Reporting a single slice instead
-    // would name a minimum that is not the boundary's and would vary from run
-    // to run.
+    // Global, not per-slice, so the message is the same whoever reports.
     double min_r = DBL_MAX;
     double max_r = -DBL_MAX;
     double min_z = DBL_MAX;
@@ -438,9 +425,7 @@ absl::Status MGridProvider::interpolate(int ztMin, int ztMax, int nZeta,
           max_z, minZ, maxZ);
     }
 
-    // A configuration problem, not a code bug: kFailedPrecondition marks this
-    // as a condition that indata.return_outputs_even_if_not_converged can
-    // recover from by returning best-effort output instead of hard-erroring.
+    // kFailedPrecondition so return_outputs_even_if_not_converged recovers.
     status = absl::FailedPreconditionError(absl::StrFormat(
         "MGridProvider::interpolate: the plasma boundary exceeded the vacuum "
         "field grid, so the interpolated field was clamped to the grid edge "
@@ -449,8 +434,7 @@ absl::Status MGridProvider::interpolate(int ztMin, int ztMax, int nZeta,
         exceeded_extents));
   }
 
-  // Unconditional: every thread of the vacuum team must reach this barrier,
-  // including the ones whose slice left the grid, or the team deadlocks.
+  // Unconditional: every thread must reach this barrier or the team deadlocks.
 #ifdef _OPENMP
 #pragma omp barrier
 #endif  // _OPENMP

--- a/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
@@ -10,10 +10,11 @@
 #include <cfloat>  // DBL_MAX
 #include <cstdio>
 #include <fstream>
-#include <iostream>
+#include <string>
 #include <vector>
 
 #include "absl/log/check.h"
+#include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 #include "util/netcdf_io/netcdf_io.h"
 #include "vmecpp/common/makegrid_lib/makegrid_lib.h"
@@ -322,16 +323,18 @@ void MGridProvider::SetFixedMagneticField(const Eigen::VectorXd& fixed_br,
 }  // SetFixedMagneticField
 
 // interpolate mgrid file at current flux surface
-void MGridProvider::interpolate(int ztMin, int ztMax, int nZeta,
-                                const Eigen::VectorXd& rLCFS,
-                                const Eigen::VectorXd& zLCFS,
-                                Eigen::VectorXd& m_interpBr,
-                                Eigen::VectorXd& m_interpBp,
-                                Eigen::VectorXd& m_interpBz) const {
+absl::Status MGridProvider::interpolate(int ztMin, int ztMax, int nZeta,
+                                        int nZnT, const Eigen::VectorXd& rLCFS,
+                                        const Eigen::VectorXd& zLCFS,
+                                        Eigen::VectorXd& m_interpBr,
+                                        Eigen::VectorXd& m_interpBp,
+                                        Eigen::VectorXd& m_interpBz) const {
   CHECK(has_mgrid_loaded_) << "no mgrid loaded";
 
   if (has_fixed_field_) {
     // quick return: just copy into target storage
+    // Every thread of the vacuum team takes this branch together, so skipping
+    // the barrier at the end of this function is uniform across the team.
 
     for (int kl = ztMin; kl < ztMax; ++kl) {
       m_interpBr[kl - ztMin] = fixed_br_[kl];
@@ -339,25 +342,13 @@ void MGridProvider::interpolate(int ztMin, int ztMax, int nZeta,
       m_interpBz[kl - ztMin] = fixed_bz_[kl];
     }  // kl
 
-    return;
+    return absl::OkStatus();
   }
-
-  double min_r = DBL_MAX;
-  double max_r = -DBL_MAX;
-
-  double min_z = DBL_MAX;
-  double max_z = -DBL_MAX;
 
   bool exceedGridSizeR = false;
   bool exceedGridSizeZ = false;
   for (int kl = ztMin; kl < ztMax; ++kl) {
     int k = kl % nZeta;
-
-    min_r = std::min(min_r, rLCFS[kl]);
-    max_r = std::max(max_r, rLCFS[kl]);
-
-    min_z = std::min(min_z, zLCFS[kl]);
-    max_z = std::max(max_z, zLCFS[kl]);
 
     // check if plasma boundary exceeds pre-computed grid
     if (rLCFS[kl] < minR || rLCFS[kl] > maxR) {
@@ -403,30 +394,68 @@ void MGridProvider::interpolate(int ztMin, int ztMax, int nZeta,
         w11 * bZ[kj_i_] + w12 * bZ[kj1i_] + w21 * bZ[kj_i1] + w22 * bZ[kj1i1];
   }  // kl
 
+  absl::Status status = absl::OkStatus();
   if (exceedGridSizeR || exceedGridSizeZ) {
+    // The field written above is clamped to the grid edge, so it no longer
+    // represents the coils outside the grid. Continuing on it silently biases
+    // the free-boundary force and moves the converged boundary; reporting it
+    // as an error is what keeps that from being mistaken for a physical or a
+    // solver effect.
+    //
     // TODO(jons): automatically evaluate B outside of grid based on coil
     // definitions and Biot-Savart
     // --> will only get slower, but more robust (and accurate?)
     // --> would also require to always have coil geometry inside mgrid file for
     // on-the-fly re-evaluation...
-    // NOTE: This is not suppressed by the `verbose` flag (vmec.cc:Vmec), since
-    // it is considered an error message.
-    std::cerr << "WARNING: Plasma Boundary exceeded Vacuum Grid Size\n";
+    //
+    // The extents below are taken over the whole boundary rather than over
+    // [ztMin, ztMax): rLCFS and zLCFS are full-surface and hold the same values
+    // on every thread of the vacuum team, so reporting them globally makes the
+    // message independent of which thread's slice left the grid and of which
+    // thread happens to win the reduction. Reporting a single slice instead
+    // would name a minimum that is not the boundary's and would vary from run
+    // to run.
+    double min_r = DBL_MAX;
+    double max_r = -DBL_MAX;
+    double min_z = DBL_MAX;
+    double max_z = -DBL_MAX;
+    for (int kl = 0; kl < nZnT; ++kl) {
+      min_r = std::min(min_r, rLCFS[kl]);
+      max_r = std::max(max_r, rLCFS[kl]);
+      min_z = std::min(min_z, zLCFS[kl]);
+      max_z = std::max(max_z, zLCFS[kl]);
+    }  // kl
 
+    std::string exceeded_extents;
     if (exceedGridSizeR) {
-      std::cout << absl::StrFormat("  R: min = % .3e  max = % .3e\n", min_r,
-                                   max_r);
+      exceeded_extents += absl::StrFormat(
+          " R: boundary [% .6e, % .6e] against grid [% .6e, % .6e].", min_r,
+          max_r, minR, maxR);
+    }
+    if (exceedGridSizeZ) {
+      exceeded_extents += absl::StrFormat(
+          " Z: boundary [% .6e, % .6e] against grid [% .6e, % .6e].", min_z,
+          max_z, minZ, maxZ);
     }
 
-    if (exceedGridSizeZ) {
-      std::cout << absl::StrFormat("  Z: min = % .3e  max = % .3e\n", min_z,
-                                   max_z);
-    }
+    // A configuration problem, not a code bug: kFailedPrecondition marks this
+    // as a condition that indata.return_outputs_even_if_not_converged can
+    // recover from by returning best-effort output instead of hard-erroring.
+    status = absl::FailedPreconditionError(absl::StrFormat(
+        "MGridProvider::interpolate: the plasma boundary exceeded the vacuum "
+        "field grid, so the interpolated field was clamped to the grid edge "
+        "and is not physically meaningful.%s Enlarge the mgrid domain so that "
+        "it contains the plasma boundary at every iteration.",
+        exceeded_extents));
   }
 
+  // Unconditional: every thread of the vacuum team must reach this barrier,
+  // including the ones whose slice left the grid, or the team deadlocks.
 #ifdef _OPENMP
 #pragma omp barrier
 #endif  // _OPENMP
+
+  return status;
 }
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.h
@@ -31,24 +31,7 @@ class MGridProvider {
                              const Eigen::VectorXd& fixed_bp,
                              const Eigen::VectorXd& fixed_bz);
 
-  // Interpolate the vacuum magnetic field onto the tangential grid points
-  // [ztMin, ztMax) of the plasma boundary. nZnT is the number of tangential
-  // grid points on the whole boundary, of which [ztMin, ztMax) is this
-  // thread's slice.
-  //
-  // Returns a kFailedPrecondition status if the boundary left the domain of
-  // the vacuum field grid. The interpolated field is still written in that
-  // case, clamped to the grid edge, so that the caller sees finite values and
-  // can carry the status to a safe place before acting on it; the clamped
-  // field is not physically meaningful and must not be used to advance the
-  // equilibrium.
-  //
-  // The status describes this thread's tangential slice only. The caller runs
-  // this inside the nested vacuum OpenMP team, so the result has to be reduced
-  // across that team before it is acted upon. The extents named in the error
-  // message, on the other hand, are taken over the whole boundary [0, nZnT),
-  // so that every thread that reports produces the same message no matter
-  // which one wins the reduction.
+  // Interpolate [ztMin, ztMax) of nZnT points; error if outside the grid.
   [[nodiscard]] absl::Status interpolate(int ztMin, int ztMax, int nZeta,
                                          int nZnT, const Eigen::VectorXd& r,
                                          const Eigen::VectorXd& z,

--- a/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.h
@@ -8,6 +8,7 @@
 #include <Eigen/Dense>
 #include <filesystem>
 
+#include "absl/status/status.h"
 #include "vmecpp/common/makegrid_lib/makegrid_lib.h"
 #include "vmecpp/common/sizes/sizes.h"
 
@@ -30,10 +31,30 @@ class MGridProvider {
                              const Eigen::VectorXd& fixed_bp,
                              const Eigen::VectorXd& fixed_bz);
 
-  void interpolate(int ztMin, int ztMax, int nZeta, const Eigen::VectorXd& r,
-                   const Eigen::VectorXd& z, Eigen::VectorXd& m_interpBr,
-                   Eigen::VectorXd& m_interpBp,
-                   Eigen::VectorXd& m_interpBz) const;
+  // Interpolate the vacuum magnetic field onto the tangential grid points
+  // [ztMin, ztMax) of the plasma boundary. nZnT is the number of tangential
+  // grid points on the whole boundary, of which [ztMin, ztMax) is this
+  // thread's slice.
+  //
+  // Returns a kFailedPrecondition status if the boundary left the domain of
+  // the vacuum field grid. The interpolated field is still written in that
+  // case, clamped to the grid edge, so that the caller sees finite values and
+  // can carry the status to a safe place before acting on it; the clamped
+  // field is not physically meaningful and must not be used to advance the
+  // equilibrium.
+  //
+  // The status describes this thread's tangential slice only. The caller runs
+  // this inside the nested vacuum OpenMP team, so the result has to be reduced
+  // across that team before it is acted upon. The extents named in the error
+  // message, on the other hand, are taken over the whole boundary [0, nZnT),
+  // so that every thread that reports produces the same message no matter
+  // which one wins the reduction.
+  [[nodiscard]] absl::Status interpolate(int ztMin, int ztMax, int nZeta,
+                                         int nZnT, const Eigen::VectorXd& r,
+                                         const Eigen::VectorXd& z,
+                                         Eigen::VectorXd& m_interpBr,
+                                         Eigen::VectorXd& m_interpBp,
+                                         Eigen::VectorXd& m_interpBz) const;
 
   // mgrid internals below
 

--- a/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.cc
@@ -32,7 +32,7 @@ Nestor::Nestor(const Sizes* s, const TangentialPartitioning* tp,
   bSubV.setZero(numLocal);
 }
 
-bool Nestor::update(
+absl::StatusOr<bool> Nestor::update(
     const std::span<const double> rCC, const std::span<const double> rSS,
     const std::span<const double> rSC, const std::span<const double> rCS,
     const std::span<const double> zSC, const std::span<const double> zCS,
@@ -55,7 +55,13 @@ bool Nestor::update(
     return true;
   }
 
-  ef_.update(rAxis, zAxis, netToroidalCurrent);
+  // Carried to the end of this function rather than returned here: the vacuum
+  // team runs collective barriers and 'omp single' regions below, and only the
+  // threads whose own tangential slice left the vacuum grid observe the error.
+  // The clamped field is finite, so the remaining stages run harmlessly on it
+  // and their result is discarded by the caller.
+  const absl::Status external_field_status =
+      ef_.update(rAxis, zAxis, netToroidalCurrent);
   if (vmec_checkpoint == VmecCheckpoint::VAC1_BEXTERN &&
       at_checkpoint_iteration) {
     return true;
@@ -260,6 +266,13 @@ bool Nestor::update(
 
   // TODO(jons): could move bSubUVac, bSubVVac collection here to spare on
   // barrier
+
+  // Every collective region above has been executed by the whole vacuum team,
+  // so it is now safe for the threads that saw an out-of-grid boundary to
+  // report it.
+  if (!external_field_status.ok()) {
+    return external_field_status;
+  }
 
   return false;
 }

--- a/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.cc
@@ -55,11 +55,7 @@ absl::StatusOr<bool> Nestor::update(
     return true;
   }
 
-  // Carried to the end of this function rather than returned here: the vacuum
-  // team runs collective barriers and 'omp single' regions below, and only the
-  // threads whose own tangential slice left the vacuum grid observe the error.
-  // The clamped field is finite, so the remaining stages run harmlessly on it
-  // and their result is discarded by the caller.
+  // Carried to the end: collective regions below must be reached by all.
   const absl::Status external_field_status =
       ef_.update(rAxis, zAxis, netToroidalCurrent);
   if (vmec_checkpoint == VmecCheckpoint::VAC1_BEXTERN &&
@@ -267,9 +263,7 @@ absl::StatusOr<bool> Nestor::update(
   // TODO(jons): could move bSubUVac, bSubVVac collection here to spare on
   // barrier
 
-  // Every collective region above has been executed by the whole vacuum team,
-  // so it is now safe for the threads that saw an out-of-grid boundary to
-  // report it.
+  // All collective regions are done, so it is safe to report now.
   if (!external_field_status.ok()) {
     return external_field_status;
   }

--- a/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.h
@@ -31,7 +31,7 @@ class Nestor : public FreeBoundaryBase {
          std::span<double> vacuum_b_phi_share,
          std::span<double> vacuum_b_z_share);
 
-  bool update(
+  absl::StatusOr<bool> update(
       const std::span<const double> rCC, const std::span<const double> rSS,
       const std::span<const double> rSC, const std::span<const double> rCS,
       const std::span<const double> zSC, const std::span<const double> zCS,

--- a/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.cc
@@ -14,7 +14,7 @@ OnlyCoils::OnlyCoils(const Sizes* s, const TangentialPartitioning* tp,
     : FreeBoundaryBase(s, tp, mgrid, bSqVacShare, vacuum_b_r_share,
                        vacuum_b_phi_share, vacuum_b_z_share) {}  // OnlyCoils
 
-bool OnlyCoils::update(
+absl::StatusOr<bool> OnlyCoils::update(
     const std::span<const double> rCC, const std::span<const double> rSS,
     const std::span<const double> rSC, const std::span<const double> rCS,
     const std::span<const double> zSC, const std::span<const double> zCS,
@@ -31,7 +31,10 @@ bool OnlyCoils::update(
 
   // blindly assume netToroidalCurrent == 0.0,
   // since checked for that during initialization
-  ef_.update(rAxis, zAxis, 0.0);
+  // The status is carried to the end of this function for the same reason as
+  // in Nestor::update: the collective regions below must be reached by the
+  // whole vacuum team, not just the threads that saw an out-of-grid boundary.
+  const absl::Status external_field_status = ef_.update(rAxis, zAxis, 0.0);
 
   // compute net covariant magnetic field components on surface
   double local_bsubuvac = 0.0;
@@ -86,6 +89,10 @@ bool OnlyCoils::update(
 
   // TODO(jons): could move bSubUVac, bSubVVac collection here to spare on
   // barrier
+
+  if (!external_field_status.ok()) {
+    return external_field_status;
+  }
 
   return false;
 }  // update

--- a/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.cc
@@ -31,9 +31,7 @@ absl::StatusOr<bool> OnlyCoils::update(
 
   // blindly assume netToroidalCurrent == 0.0,
   // since checked for that during initialization
-  // The status is carried to the end of this function for the same reason as
-  // in Nestor::update: the collective regions below must be reached by the
-  // whole vacuum team, not just the threads that saw an out-of-grid boundary.
+  // Carried to the end for the same reason as in Nestor::update.
   const absl::Status external_field_status = ef_.update(rAxis, zAxis, 0.0);
 
   // compute net covariant magnetic field components on surface

--- a/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.h
@@ -23,7 +23,7 @@ class OnlyCoils : public FreeBoundaryBase {
             std::span<double> vacuum_b_phi_share,
             std::span<double> vacuum_b_z_share);
 
-  bool update(
+  absl::StatusOr<bool> update(
       const std::span<const double> rCC, const std::span<const double> rSS,
       const std::span<const double> rSC, const std::span<const double> rCS,
       const std::span<const double> zSC, const std::span<const double> zCS,

--- a/src/vmecpp/cpp/vmecpp/vmec/handover_storage/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/vmec/handover_storage/BUILD.bazel
@@ -7,6 +7,7 @@ cc_library(
     hdrs = ["handover_storage.h"],
     visibility = ["//visibility:public"],
     deps = [
+        "@abseil-cpp//absl/status:status",
         "//vmecpp/common/util:util",
         "//vmecpp/common/sizes:sizes",
         "//vmecpp/common/flow_control:flow_control",

--- a/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
@@ -10,6 +10,7 @@
 #include <span>
 #include <vector>
 
+#include "absl/status/status.h"
 #include "vmecpp/common/flow_control/flow_control.h"
 #include "vmecpp/common/sizes/sizes.h"
 #include "vmecpp/common/util/util.h"
@@ -183,6 +184,15 @@ class HandoverStorage {
   // reads it after the enclosing 'omp single' barrier). Always false during
   // normal runs (checkpoint == NONE).
   bool vacuum_reached_checkpoint = false;
+
+  // First error reported by any thread of the nested vacuum team during the
+  // current free-boundary update, for example an out-of-grid plasma boundary.
+  // The vacuum threads must reach all of their collective barriers before
+  // returning, so the error cannot propagate out of the nested region on the
+  // call stack; it is reduced into this shared slot instead and read by the
+  // whole radial team after the enclosing 'omp single' barrier. Reset to OK
+  // before each vacuum solve.
+  absl::Status vacuum_status = absl::OkStatus();
 
  private:
   const Sizes& s_;

--- a/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
@@ -185,13 +185,7 @@ class HandoverStorage {
   // normal runs (checkpoint == NONE).
   bool vacuum_reached_checkpoint = false;
 
-  // First error reported by any thread of the nested vacuum team during the
-  // current free-boundary update, for example an out-of-grid plasma boundary.
-  // The vacuum threads must reach all of their collective barriers before
-  // returning, so the error cannot propagate out of the nested region on the
-  // call stack; it is reduced into this shared slot instead and read by the
-  // whole radial team after the enclosing 'omp single' barrier. Reset to OK
-  // before each vacuum solve.
+  // First error from the nested vacuum team; reset to OK before each solve.
   absl::Status vacuum_status = absl::OkStatus();
 
  private:

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -763,9 +763,7 @@ absl::StatusOr<bool> IdealMhdModel::update(
               signOfJacobian, m_h_.rAxis, m_h_.zAxis, &(m_h_.bSubUVac),
               &(m_h_.bSubVVac), netToroidalCurrent, ivacskip, checkpoint,
               at_checkpoint_iteration);
-          // A failure is specific to the tangential slice that saw it, so it is
-          // reduced across the nested team rather than broadcast from thread 0.
-          // The first error wins; they all describe the same boundary.
+          // Reduced across the team; the first error wins.
           if (!rc.ok()) {
 #ifdef _OPENMP
 #pragma omp critical
@@ -783,8 +781,7 @@ absl::StatusOr<bool> IdealMhdModel::update(
           }
         }
       }
-      // The 'omp single' implicit barrier publishes the shared vacuum outputs,
-      // the broadcast flag, and the reduced status to all radial threads.
+      // The 'omp single' barrier publishes the outputs, flag, and status.
       if (!m_h_.vacuum_status.ok()) {
         return m_h_.vacuum_status;
       }

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -782,8 +782,14 @@ absl::StatusOr<bool> IdealMhdModel::update(
         }
       }
       // The 'omp single' barrier publishes the outputs, flag, and status.
-      if (!m_h_.vacuum_status.ok()) {
-        return m_h_.vacuum_status;
+      // Only a warning here: the boundary may leave the grid transiently while
+      // the equilibrium is still moving. Vmec::run turns a still-outside
+      // boundary into an error once the run has converged.
+      if (!m_h_.vacuum_status.ok() && verbose) {
+#ifdef _OPENMP
+#pragma omp single
+#endif  // _OPENMP
+        std::cout << "WARNING: " << m_h_.vacuum_status.message() << "\n";
       }
       if (m_h_.vacuum_reached_checkpoint) {
         return true;

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -741,6 +741,7 @@ absl::StatusOr<bool> IdealMhdModel::update(
 #pragma omp single
 #endif  // _OPENMP
       {
+        m_h_.vacuum_status = absl::OkStatus();
 #ifdef _OPENMP
 #pragma omp parallel num_threads(m_vac_num_threads_)
 #endif  // _OPENMP
@@ -756,21 +757,37 @@ absl::StatusOr<bool> IdealMhdModel::update(
               << "Nested vacuum parallel region was not granted the requested "
                  "number of threads";
 #endif  // _OPENMP
-          const bool rc = (*m_fb_vac_)[vac_thread_id]->update(
+          const absl::StatusOr<bool> rc = (*m_fb_vac_)[vac_thread_id]->update(
               m_h_.rCC_LCFS, m_h_.rSS_LCFS, m_h_.rSC_LCFS, m_h_.rCS_LCFS,
               m_h_.zSC_LCFS, m_h_.zCS_LCFS, m_h_.zCC_LCFS, m_h_.zSS_LCFS,
               signOfJacobian, m_h_.rAxis, m_h_.zAxis, &(m_h_.bSubUVac),
               &(m_h_.bSubVVac), netToroidalCurrent, ivacskip, checkpoint,
               at_checkpoint_iteration);
+          // A failure is specific to the tangential slice that saw it, so it is
+          // reduced across the nested team rather than broadcast from thread 0.
+          // The first error wins; they all describe the same boundary.
+          if (!rc.ok()) {
+#ifdef _OPENMP
+#pragma omp critical
+#endif  // _OPENMP
+            {
+              if (m_h_.vacuum_status.ok()) {
+                m_h_.vacuum_status = rc.status();
+              }
+            }
+          }
           // All nested threads follow identical control flow and compute the
           // same checkpoint result; record it once for the radial team.
           if (vac_thread_id == 0) {
-            m_h_.vacuum_reached_checkpoint = rc;
+            m_h_.vacuum_reached_checkpoint = rc.ok() && *rc;
           }
         }
       }
-      // The 'omp single' implicit barrier publishes the shared vacuum outputs
-      // and the broadcast flag to all radial threads.
+      // The 'omp single' implicit barrier publishes the shared vacuum outputs,
+      // the broadcast flag, and the reduced status to all radial threads.
+      if (!m_h_.vacuum_status.ok()) {
+        return m_h_.vacuum_status;
+      }
       if (m_h_.vacuum_reached_checkpoint) {
         return true;
       }

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -430,13 +430,7 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
     if (!indata_.return_outputs_even_if_not_converged) {
       return h_.vacuum_status;
     }
-    if (verbose_) {
-      std::cout << absl::StrFormat(
-          "WARNING: %s\n"
-          "return_outputs_even_if_not_converged is set, so returning "
-          "best-effort (likely unphysical) output for debugging purposes.\n",
-          h_.vacuum_status.message());
-    }
+    status_ = VmecStatus::UNRECOVERABLE_ERROR;
   }
 
   // compute output file quantities, but do not write them to output file yet

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -41,19 +41,20 @@ void UpdateStatusForThread(absl::Status& m_status_of_all_threads, int thread_id,
                            const absl::Status& thread_status) {
   CHECK(!thread_status.ok()) << "UpdateStatusForThread expects an error status";
 
-  auto thread_msg =
-      absl::StrFormat("Thread %i:\n\t%s", thread_id, thread_status.message());
+  const auto thread_msg =
+      absl::StrFormat("Thread %i:\n\t%s\n", thread_id, thread_status.message());
 
+  // The aggregate deliberately collapses to kInternal; SolveEquilibrium tracks
+  // recoverability separately in all_errors_are_recoverable.
   if (m_status_of_all_threads.ok()) {
-    auto msg =
-        "There was an error in one or more threads during a VMEC++ run:\n" +
-        thread_msg;
-    m_status_of_all_threads = absl::InternalError(std::move(thread_msg));
+    m_status_of_all_threads = absl::InternalError(absl::StrCat(
+        "There was an error in one or more threads during a VMEC++ run:\n",
+        thread_msg));
+    return;
   }
 
-  const auto new_msg =
-      std::string(m_status_of_all_threads.message()) + thread_msg;
-  m_status_of_all_threads = absl::InternalError(new_msg);
+  m_status_of_all_threads = absl::InternalError(
+      absl::StrCat(m_status_of_all_threads.message(), thread_msg));
 }
 
 // Check preconditions on (initial_state, indata) pair passed to Vmec::run

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -44,8 +44,7 @@ void UpdateStatusForThread(absl::Status& m_status_of_all_threads, int thread_id,
   const auto thread_msg =
       absl::StrFormat("Thread %i:\n\t%s\n", thread_id, thread_status.message());
 
-  // The aggregate deliberately collapses to kInternal; SolveEquilibrium tracks
-  // recoverability separately in all_errors_are_recoverable.
+  // Collapses to kInternal; recoverability is tracked separately.
   if (m_status_of_all_threads.ok()) {
     m_status_of_all_threads = absl::InternalError(absl::StrCat(
         "There was an error in one or more threads during a VMEC++ run:\n",

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -423,6 +423,22 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
     return absl::InternalError(msg);
   }
 
+  // A converged free-boundary result must not rest on a vacuum field that was
+  // clamped to the grid edge. h_.vacuum_status holds the last vacuum solve, so
+  // a boundary that only left the grid transiently has already cleared it.
+  if (!h_.vacuum_status.ok()) {
+    if (!indata_.return_outputs_even_if_not_converged) {
+      return h_.vacuum_status;
+    }
+    if (verbose_) {
+      std::cout << absl::StrFormat(
+          "WARNING: %s\n"
+          "return_outputs_even_if_not_converged is set, so returning "
+          "best-effort (likely unphysical) output for debugging purposes.\n",
+          h_.vacuum_status.message());
+    }
+  }
+
   // compute output file quantities, but do not write them to output file yet
   // (for creating the output file, use WriteOutputFile())
   output_quantities_ = vmecpp::ComputeOutputQuantities(

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/mgrid_provider/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/mgrid_provider/BUILD.bazel
@@ -11,9 +11,11 @@ cc_test(
     deps = [
         "//vmecpp/free_boundary/mgrid_provider",
         "@googletest//:gtest_main",
+        "@abseil-cpp//absl/status:status",
         "//util/file_io:file_io",
         "//util/testing:numerical_comparison_lib",
         "//vmecpp/common/magnetic_configuration_lib:magnetic_configuration_lib",
         "//vmecpp/common/magnetic_field_provider:magnetic_field_provider_lib",
+        "//vmecpp/common/vmec_indata:vmec_indata",
     ],
 )

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/mgrid_provider/mgrid_provider_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/mgrid_provider/mgrid_provider_test.cc
@@ -288,8 +288,7 @@ TEST_F(MGridInterpolationTest, BoundaryInsideGridIsAccepted) {
   }
 }
 
-// The bounds check is inclusive, so a boundary that just touches the outermost
-// grid line is still interpolated from real data.
+// The bounds check is inclusive, so the outermost grid line is still inside.
 TEST_F(MGridInterpolationTest, BoundaryExactlyOnGridEdgeIsAccepted) {
   Eigen::VectorXd r;
   Eigen::VectorXd z;
@@ -332,8 +331,7 @@ TEST_F(MGridInterpolationTest, BoundaryOutsideGridInRIsAnError) {
   EXPECT_THAT(message, HasSubstr("R: boundary"));
   EXPECT_THAT(message, Not(HasSubstr("Z: boundary")));
 
-  // The clamped field is still written, so that a thread running inside the
-  // vacuum team can carry the status past its collective barriers.
+  // The clamped field is still written, so the status can be carried.
   for (int index = 0; index < kNumTangentialPoints; ++index) {
     EXPECT_TRUE(std::isfinite(b_r[index]));
     EXPECT_TRUE(std::isfinite(b_p[index]));
@@ -384,9 +382,7 @@ TEST_F(MGridInterpolationTest, ErrorNamesTheBoundaryAndTheGridExtents) {
   EXPECT_THAT(message, HasSubstr(absl::StrFormat("% .6e", mgrid_.minZ)));
 }
 
-// Pins the behaviour the error status describes: the returned field is the one
-// belonging to the nearest point on the grid boundary, not the field of the
-// requested point.
+// The returned field is the grid edge's, not the requested point's.
 TEST_F(MGridInterpolationTest, FieldOutsideGridIsClampedToTheGridEdge) {
   Eigen::VectorXd r;
   Eigen::VectorXd z;
@@ -419,8 +415,7 @@ TEST_F(MGridInterpolationTest, FieldOutsideGridIsClampedToTheGridEdge) {
   }
 }
 
-// Each thread of the vacuum team interpolates one tangential slice, so the
-// status a call returns describes that slice and no other.
+// The status describes the requested slice and no other.
 TEST_F(MGridInterpolationTest, OnlyTheRequestedTangentialSliceIsChecked) {
   const int num_points = 2 * kNumTangentialPoints;
   Eigen::VectorXd r;
@@ -442,18 +437,13 @@ TEST_F(MGridInterpolationTest, OnlyTheRequestedTangentialSliceIsChecked) {
   EXPECT_EQ(second_slice.code(), absl::StatusCode::kFailedPrecondition);
 }
 
-// Which thread of the vacuum team wins the reduction in IdealMhdModel is a
-// race, so the extents named in the message are taken over the whole boundary
-// rather than over the reporting thread's slice. Anything slice-local here
-// would name a minimum that is not the boundary's and would make the error a
-// user sees change from run to run.
+// Which thread wins the reduction is a race, so the extents must be global.
 TEST_F(MGridInterpolationTest, ReportedExtentsDoNotDependOnTheReportingSlice) {
   const int num_points = 2 * kNumTangentialPoints;
   Eigen::VectorXd r;
   Eigen::VectorXd z;
   FillInsideGrid(num_points, r, z);
-  // One point in each half of the boundary leaves the grid, so both slices
-  // report. The boundary's minimum R lies in the second slice only.
+  // Both slices report, but the boundary's minimum R is in the second only.
   r[0] = OutsideR();
   r[num_points - 1] = OutsideR() + 0.01;
 
@@ -478,11 +468,7 @@ TEST_F(MGridInterpolationTest, ReportedExtentsDoNotDependOnTheReportingSlice) {
 }
 
 #ifdef _OPENMP
-// The barrier at the end of interpolate is collective over the vacuum team, so
-// a thread whose own slice left the grid has to reach it along with everyone
-// else. This splits a boundary that leaves the grid at one end only across a
-// team, which is the case that hangs if the barrier is ever made conditional
-// on the slice being inside the grid.
+// Hangs if the barrier is ever made conditional on the slice being in grid.
 TEST_F(MGridInterpolationTest, MixedInAndOutOfGridSlicesDoNotDeadlock) {
   constexpr int kNumThreads = 4;
   const int num_points = kNumThreads * kNumTangentialPoints;
@@ -524,8 +510,7 @@ TEST_F(MGridInterpolationTest, MixedInAndOutOfGridSlicesDoNotDeadlock) {
 }
 #endif  // _OPENMP
 
-// A fixed field is handed over per tangential grid point rather than
-// interpolated, so there is no vacuum field grid to leave.
+// A fixed field is handed over per point, so there is no grid to leave.
 TEST_F(MGridInterpolationTest, FixedFieldIgnoresGridBounds) {
   const Eigen::VectorXd fixed_b_r =
       Eigen::VectorXd::Constant(kNumTangentialPoints, 1.0);

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/mgrid_provider/mgrid_provider_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/mgrid_provider/mgrid_provider_test.cc
@@ -288,183 +288,29 @@ TEST_F(MGridInterpolationTest, BoundaryInsideGridIsAccepted) {
   }
 }
 
-// The bounds check is inclusive, so the outermost grid line is still inside.
-TEST_F(MGridInterpolationTest, BoundaryExactlyOnGridEdgeIsAccepted) {
-  Eigen::VectorXd r;
-  Eigen::VectorXd z;
-  FillInsideGrid(kNumTangentialPoints, r, z);
-  r[0] = mgrid_.minR;
-  r[1] = mgrid_.maxR;
-  z[2] = mgrid_.minZ;
-  z[3] = mgrid_.maxZ;
-
-  Eigen::VectorXd b_r(kNumTangentialPoints);
-  Eigen::VectorXd b_p(kNumTangentialPoints);
-  Eigen::VectorXd b_z(kNumTangentialPoints);
-  const absl::Status status =
-      mgrid_.interpolate(0, kNumTangentialPoints, mgrid_.numPhi,
-                         kNumTangentialPoints, r, z, b_r, b_p, b_z);
-
-  EXPECT_TRUE(status.ok()) << status;
-  for (int index = 0; index < kNumTangentialPoints; ++index) {
-    EXPECT_TRUE(std::isfinite(b_r[index]));
-    EXPECT_TRUE(std::isfinite(b_p[index]));
-    EXPECT_TRUE(std::isfinite(b_z[index]));
-  }
-}
-
-TEST_F(MGridInterpolationTest, BoundaryOutsideGridInRIsAnError) {
-  Eigen::VectorXd r;
-  Eigen::VectorXd z;
-  FillInsideGrid(kNumTangentialPoints, r, z);
-  r[3] = OutsideR();
-
-  Eigen::VectorXd b_r(kNumTangentialPoints);
-  Eigen::VectorXd b_p(kNumTangentialPoints);
-  Eigen::VectorXd b_z(kNumTangentialPoints);
-  const absl::Status status =
-      mgrid_.interpolate(0, kNumTangentialPoints, mgrid_.numPhi,
-                         kNumTangentialPoints, r, z, b_r, b_p, b_z);
-
-  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
-  const std::string message(status.message());
-  EXPECT_THAT(message, HasSubstr("R: boundary"));
-  EXPECT_THAT(message, Not(HasSubstr("Z: boundary")));
-
-  // The clamped field is still written, so the status can be carried.
-  for (int index = 0; index < kNumTangentialPoints; ++index) {
-    EXPECT_TRUE(std::isfinite(b_r[index]));
-    EXPECT_TRUE(std::isfinite(b_p[index]));
-    EXPECT_TRUE(std::isfinite(b_z[index]));
-  }
-}
-
-TEST_F(MGridInterpolationTest, BoundaryOutsideGridInZIsAnError) {
-  Eigen::VectorXd r;
-  Eigen::VectorXd z;
-  FillInsideGrid(kNumTangentialPoints, r, z);
-  z[5] = OutsideZ();
-
-  Eigen::VectorXd b_r(kNumTangentialPoints);
-  Eigen::VectorXd b_p(kNumTangentialPoints);
-  Eigen::VectorXd b_z(kNumTangentialPoints);
-  const absl::Status status =
-      mgrid_.interpolate(0, kNumTangentialPoints, mgrid_.numPhi,
-                         kNumTangentialPoints, r, z, b_r, b_p, b_z);
-
-  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
-  const std::string message(status.message());
-  EXPECT_THAT(message, HasSubstr("Z: boundary"));
-  EXPECT_THAT(message, Not(HasSubstr("R: boundary")));
-}
-
-TEST_F(MGridInterpolationTest, ErrorNamesTheBoundaryAndTheGridExtents) {
-  Eigen::VectorXd r;
-  Eigen::VectorXd z;
-  FillInsideGrid(kNumTangentialPoints, r, z);
-  r[3] = OutsideR();
-  z[5] = OutsideZ();
-
-  Eigen::VectorXd b_r(kNumTangentialPoints);
-  Eigen::VectorXd b_p(kNumTangentialPoints);
-  Eigen::VectorXd b_z(kNumTangentialPoints);
-  const absl::Status status =
-      mgrid_.interpolate(0, kNumTangentialPoints, mgrid_.numPhi,
-                         kNumTangentialPoints, r, z, b_r, b_p, b_z);
-
-  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
-  const std::string message(status.message());
-  EXPECT_THAT(message, HasSubstr("R: boundary"));
-  EXPECT_THAT(message, HasSubstr("Z: boundary"));
-  EXPECT_THAT(message, HasSubstr(absl::StrFormat("% .6e", OutsideR())));
-  EXPECT_THAT(message, HasSubstr(absl::StrFormat("% .6e", mgrid_.maxR)));
-  EXPECT_THAT(message, HasSubstr(absl::StrFormat("% .6e", OutsideZ())));
-  EXPECT_THAT(message, HasSubstr(absl::StrFormat("% .6e", mgrid_.minZ)));
-}
-
-// The returned field is the grid edge's, not the requested point's.
-TEST_F(MGridInterpolationTest, FieldOutsideGridIsClampedToTheGridEdge) {
-  Eigen::VectorXd r;
-  Eigen::VectorXd z;
-  FillInsideGrid(kNumTangentialPoints, r, z);
-
-  Eigen::VectorXd r_on_edge = r;
-  r_on_edge[3] = mgrid_.maxR;
-  r[3] = OutsideR();
-
-  Eigen::VectorXd b_r_outside(kNumTangentialPoints);
-  Eigen::VectorXd b_p_outside(kNumTangentialPoints);
-  Eigen::VectorXd b_z_outside(kNumTangentialPoints);
-  const absl::Status outside = mgrid_.interpolate(
-      0, kNumTangentialPoints, mgrid_.numPhi, kNumTangentialPoints, r, z,
-      b_r_outside, b_p_outside, b_z_outside);
-  EXPECT_EQ(outside.code(), absl::StatusCode::kFailedPrecondition);
-
-  Eigen::VectorXd b_r_on_edge(kNumTangentialPoints);
-  Eigen::VectorXd b_p_on_edge(kNumTangentialPoints);
-  Eigen::VectorXd b_z_on_edge(kNumTangentialPoints);
-  const absl::Status on_edge = mgrid_.interpolate(
-      0, kNumTangentialPoints, mgrid_.numPhi, kNumTangentialPoints, r_on_edge,
-      z, b_r_on_edge, b_p_on_edge, b_z_on_edge);
-  EXPECT_TRUE(on_edge.ok()) << on_edge;
-
-  for (int index = 0; index < kNumTangentialPoints; ++index) {
-    EXPECT_EQ(b_r_outside[index], b_r_on_edge[index]);
-    EXPECT_EQ(b_p_outside[index], b_p_on_edge[index]);
-    EXPECT_EQ(b_z_outside[index], b_z_on_edge[index]);
-  }
-}
-
-// The status describes the requested slice and no other.
-TEST_F(MGridInterpolationTest, OnlyTheRequestedTangentialSliceIsChecked) {
+// The reported extents are the whole boundary's, not the reporting slice's:
+// this call covers the second slice only, which does not contain the minima.
+TEST_F(MGridInterpolationTest, BoundaryOutsideGridIsAnError) {
   const int num_points = 2 * kNumTangentialPoints;
   Eigen::VectorXd r;
   Eigen::VectorXd z;
   FillInsideGrid(num_points, r, z);
   r[num_points - 1] = OutsideR();
+  z[num_points - 2] = OutsideZ();
 
   Eigen::VectorXd b_r(kNumTangentialPoints);
   Eigen::VectorXd b_p(kNumTangentialPoints);
   Eigen::VectorXd b_z(kNumTangentialPoints);
-
-  const absl::Status first_slice = mgrid_.interpolate(
-      0, kNumTangentialPoints, mgrid_.numPhi, num_points, r, z, b_r, b_p, b_z);
-  EXPECT_TRUE(first_slice.ok()) << first_slice;
-
-  const absl::Status second_slice =
-      mgrid_.interpolate(kNumTangentialPoints, num_points, mgrid_.numPhi,
-                         num_points, r, z, b_r, b_p, b_z);
-  EXPECT_EQ(second_slice.code(), absl::StatusCode::kFailedPrecondition);
-}
-
-// Which thread wins the reduction is a race, so the extents must be global.
-TEST_F(MGridInterpolationTest, ReportedExtentsDoNotDependOnTheReportingSlice) {
-  const int num_points = 2 * kNumTangentialPoints;
-  Eigen::VectorXd r;
-  Eigen::VectorXd z;
-  FillInsideGrid(num_points, r, z);
-  // Both slices report, but the boundary's minimum R is in the second only.
-  r[0] = OutsideR();
-  r[num_points - 1] = OutsideR() + 0.01;
-
-  Eigen::VectorXd b_r(kNumTangentialPoints);
-  Eigen::VectorXd b_p(kNumTangentialPoints);
-  Eigen::VectorXd b_z(kNumTangentialPoints);
-
-  const absl::Status first_slice = mgrid_.interpolate(
-      0, kNumTangentialPoints, mgrid_.numPhi, num_points, r, z, b_r, b_p, b_z);
-  const absl::Status second_slice =
+  const absl::Status status =
       mgrid_.interpolate(kNumTangentialPoints, num_points, mgrid_.numPhi,
                          num_points, r, z, b_r, b_p, b_z);
 
-  EXPECT_EQ(first_slice.code(), absl::StatusCode::kFailedPrecondition);
-  EXPECT_EQ(second_slice.code(), absl::StatusCode::kFailedPrecondition);
-  EXPECT_EQ(first_slice.message(), second_slice.message());
-
-  // The extents are the boundary's, not either slice's.
-  const std::string message(first_slice.message());
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  const std::string message(status.message());
   EXPECT_THAT(message, HasSubstr(absl::StrFormat("% .6e", r.minCoeff())));
   EXPECT_THAT(message, HasSubstr(absl::StrFormat("% .6e", r.maxCoeff())));
+  EXPECT_THAT(message, HasSubstr(absl::StrFormat("% .6e", z.minCoeff())));
+  EXPECT_THAT(message, HasSubstr(absl::StrFormat("% .6e", z.maxCoeff())));
 }
 
 #ifdef _OPENMP
@@ -509,35 +355,5 @@ TEST_F(MGridInterpolationTest, MixedInAndOutOfGridSlicesDoNotDeadlock) {
             absl::StatusCode::kFailedPrecondition);
 }
 #endif  // _OPENMP
-
-// A fixed field is handed over per point, so there is no grid to leave.
-TEST_F(MGridInterpolationTest, FixedFieldIgnoresGridBounds) {
-  const Eigen::VectorXd fixed_b_r =
-      Eigen::VectorXd::Constant(kNumTangentialPoints, 1.0);
-  const Eigen::VectorXd fixed_b_p =
-      Eigen::VectorXd::Constant(kNumTangentialPoints, 2.0);
-  const Eigen::VectorXd fixed_b_z =
-      Eigen::VectorXd::Constant(kNumTangentialPoints, 3.0);
-  mgrid_.SetFixedMagneticField(fixed_b_r, fixed_b_p, fixed_b_z);
-
-  const Eigen::VectorXd r =
-      Eigen::VectorXd::Constant(kNumTangentialPoints, OutsideR());
-  const Eigen::VectorXd z =
-      Eigen::VectorXd::Constant(kNumTangentialPoints, OutsideZ());
-
-  Eigen::VectorXd b_r(kNumTangentialPoints);
-  Eigen::VectorXd b_p(kNumTangentialPoints);
-  Eigen::VectorXd b_z(kNumTangentialPoints);
-  const absl::Status status =
-      mgrid_.interpolate(0, kNumTangentialPoints, mgrid_.numPhi,
-                         kNumTangentialPoints, r, z, b_r, b_p, b_z);
-
-  EXPECT_TRUE(status.ok()) << status;
-  for (int index = 0; index < kNumTangentialPoints; ++index) {
-    EXPECT_EQ(b_r[index], 1.0);
-    EXPECT_EQ(b_p[index], 2.0);
-    EXPECT_EQ(b_z[index], 3.0);
-  }
-}
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/mgrid_provider/mgrid_provider_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/mgrid_provider/mgrid_provider_test.cc
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 #include "vmecpp/free_boundary/mgrid_provider/mgrid_provider.h"
 
+#include <cmath>
 #include <fstream>
 #include <string>
 #include <vector>
@@ -14,6 +15,7 @@
 
 #include <netcdf.h>
 
+#include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -24,6 +26,7 @@
 #include "vmecpp/common/magnetic_configuration_lib/magnetic_configuration_lib.h"
 #include "vmecpp/common/magnetic_field_provider/magnetic_field_provider_lib.h"
 #include "vmecpp/common/util/util.h"
+#include "vmecpp/common/vmec_indata/vmec_indata.h"
 
 namespace {
 using nlohmann::json;
@@ -39,6 +42,8 @@ using magnetics::ImportMagneticConfigurationFromMakegrid;
 using magnetics::MagneticConfiguration;
 using magnetics::MagneticField;
 
+using ::testing::HasSubstr;
+using ::testing::Not;
 using ::testing::TestWithParam;
 using ::testing::Values;
 }  // namespace
@@ -215,5 +220,339 @@ INSTANTIATE_TEST_SUITE_P(TestVmec, LoadMGridTest,
                          Values(DataSource{.identifier = "cth_like_free_bdy",
                                            .tolerance = 1.0e-12,
                                            .coils_file = "coils.cth_like"}));
+
+// Number of tangential grid points used by the interpolation tests below.
+static constexpr int kNumTangentialPoints = 8;
+
+class MGridInterpolationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const absl::StatusOr<std::string> indata_json =
+        ReadFile("vmecpp/test_data/cth_like_free_bdy.json");
+    ASSERT_TRUE(indata_json.ok()) << indata_json.status();
+
+    const absl::StatusOr<VmecINDATA> vmec_indata =
+        VmecINDATA::FromJson(*indata_json);
+    ASSERT_TRUE(vmec_indata.ok()) << vmec_indata.status();
+
+    const absl::Status load_status =
+        mgrid_.LoadFile(vmec_indata->mgrid_file, vmec_indata->extcur);
+    ASSERT_TRUE(load_status.ok()) << load_status;
+  }
+
+  // A closed contour that stays well inside the vacuum field grid.
+  void FillInsideGrid(int num_points, Eigen::VectorXd& m_r,
+                      Eigen::VectorXd& m_z) const {
+    const double r_center = 0.5 * (mgrid_.minR + mgrid_.maxR);
+    const double z_center = 0.5 * (mgrid_.minZ + mgrid_.maxZ);
+    const double r_amplitude = 0.25 * (mgrid_.maxR - mgrid_.minR);
+    const double z_amplitude = 0.25 * (mgrid_.maxZ - mgrid_.minZ);
+
+    m_r.resize(num_points);
+    m_z.resize(num_points);
+    for (int index = 0; index < num_points; ++index) {
+      const double theta = 2.0 * M_PI * index / num_points;
+      m_r[index] = r_center + r_amplitude * std::cos(theta);
+      m_z[index] = z_center + z_amplitude * std::sin(theta);
+    }
+  }
+
+  // How far outside the grid the deliberately out-of-bounds points are put.
+  double OutsideR() const {
+    return mgrid_.maxR + 0.1 * (mgrid_.maxR - mgrid_.minR);
+  }
+  double OutsideZ() const {
+    return mgrid_.minZ - 0.1 * (mgrid_.maxZ - mgrid_.minZ);
+  }
+
+  MGridProvider mgrid_;
+};
+
+TEST_F(MGridInterpolationTest, BoundaryInsideGridIsAccepted) {
+  Eigen::VectorXd r;
+  Eigen::VectorXd z;
+  FillInsideGrid(kNumTangentialPoints, r, z);
+
+  Eigen::VectorXd b_r(kNumTangentialPoints);
+  Eigen::VectorXd b_p(kNumTangentialPoints);
+  Eigen::VectorXd b_z(kNumTangentialPoints);
+  const absl::Status status =
+      mgrid_.interpolate(0, kNumTangentialPoints, mgrid_.numPhi,
+                         kNumTangentialPoints, r, z, b_r, b_p, b_z);
+
+  EXPECT_TRUE(status.ok()) << status;
+  for (int index = 0; index < kNumTangentialPoints; ++index) {
+    EXPECT_TRUE(std::isfinite(b_r[index]));
+    EXPECT_TRUE(std::isfinite(b_p[index]));
+    EXPECT_TRUE(std::isfinite(b_z[index]));
+  }
+}
+
+// The bounds check is inclusive, so a boundary that just touches the outermost
+// grid line is still interpolated from real data.
+TEST_F(MGridInterpolationTest, BoundaryExactlyOnGridEdgeIsAccepted) {
+  Eigen::VectorXd r;
+  Eigen::VectorXd z;
+  FillInsideGrid(kNumTangentialPoints, r, z);
+  r[0] = mgrid_.minR;
+  r[1] = mgrid_.maxR;
+  z[2] = mgrid_.minZ;
+  z[3] = mgrid_.maxZ;
+
+  Eigen::VectorXd b_r(kNumTangentialPoints);
+  Eigen::VectorXd b_p(kNumTangentialPoints);
+  Eigen::VectorXd b_z(kNumTangentialPoints);
+  const absl::Status status =
+      mgrid_.interpolate(0, kNumTangentialPoints, mgrid_.numPhi,
+                         kNumTangentialPoints, r, z, b_r, b_p, b_z);
+
+  EXPECT_TRUE(status.ok()) << status;
+  for (int index = 0; index < kNumTangentialPoints; ++index) {
+    EXPECT_TRUE(std::isfinite(b_r[index]));
+    EXPECT_TRUE(std::isfinite(b_p[index]));
+    EXPECT_TRUE(std::isfinite(b_z[index]));
+  }
+}
+
+TEST_F(MGridInterpolationTest, BoundaryOutsideGridInRIsAnError) {
+  Eigen::VectorXd r;
+  Eigen::VectorXd z;
+  FillInsideGrid(kNumTangentialPoints, r, z);
+  r[3] = OutsideR();
+
+  Eigen::VectorXd b_r(kNumTangentialPoints);
+  Eigen::VectorXd b_p(kNumTangentialPoints);
+  Eigen::VectorXd b_z(kNumTangentialPoints);
+  const absl::Status status =
+      mgrid_.interpolate(0, kNumTangentialPoints, mgrid_.numPhi,
+                         kNumTangentialPoints, r, z, b_r, b_p, b_z);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  const std::string message(status.message());
+  EXPECT_THAT(message, HasSubstr("R: boundary"));
+  EXPECT_THAT(message, Not(HasSubstr("Z: boundary")));
+
+  // The clamped field is still written, so that a thread running inside the
+  // vacuum team can carry the status past its collective barriers.
+  for (int index = 0; index < kNumTangentialPoints; ++index) {
+    EXPECT_TRUE(std::isfinite(b_r[index]));
+    EXPECT_TRUE(std::isfinite(b_p[index]));
+    EXPECT_TRUE(std::isfinite(b_z[index]));
+  }
+}
+
+TEST_F(MGridInterpolationTest, BoundaryOutsideGridInZIsAnError) {
+  Eigen::VectorXd r;
+  Eigen::VectorXd z;
+  FillInsideGrid(kNumTangentialPoints, r, z);
+  z[5] = OutsideZ();
+
+  Eigen::VectorXd b_r(kNumTangentialPoints);
+  Eigen::VectorXd b_p(kNumTangentialPoints);
+  Eigen::VectorXd b_z(kNumTangentialPoints);
+  const absl::Status status =
+      mgrid_.interpolate(0, kNumTangentialPoints, mgrid_.numPhi,
+                         kNumTangentialPoints, r, z, b_r, b_p, b_z);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  const std::string message(status.message());
+  EXPECT_THAT(message, HasSubstr("Z: boundary"));
+  EXPECT_THAT(message, Not(HasSubstr("R: boundary")));
+}
+
+TEST_F(MGridInterpolationTest, ErrorNamesTheBoundaryAndTheGridExtents) {
+  Eigen::VectorXd r;
+  Eigen::VectorXd z;
+  FillInsideGrid(kNumTangentialPoints, r, z);
+  r[3] = OutsideR();
+  z[5] = OutsideZ();
+
+  Eigen::VectorXd b_r(kNumTangentialPoints);
+  Eigen::VectorXd b_p(kNumTangentialPoints);
+  Eigen::VectorXd b_z(kNumTangentialPoints);
+  const absl::Status status =
+      mgrid_.interpolate(0, kNumTangentialPoints, mgrid_.numPhi,
+                         kNumTangentialPoints, r, z, b_r, b_p, b_z);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  const std::string message(status.message());
+  EXPECT_THAT(message, HasSubstr("R: boundary"));
+  EXPECT_THAT(message, HasSubstr("Z: boundary"));
+  EXPECT_THAT(message, HasSubstr(absl::StrFormat("% .6e", OutsideR())));
+  EXPECT_THAT(message, HasSubstr(absl::StrFormat("% .6e", mgrid_.maxR)));
+  EXPECT_THAT(message, HasSubstr(absl::StrFormat("% .6e", OutsideZ())));
+  EXPECT_THAT(message, HasSubstr(absl::StrFormat("% .6e", mgrid_.minZ)));
+}
+
+// Pins the behaviour the error status describes: the returned field is the one
+// belonging to the nearest point on the grid boundary, not the field of the
+// requested point.
+TEST_F(MGridInterpolationTest, FieldOutsideGridIsClampedToTheGridEdge) {
+  Eigen::VectorXd r;
+  Eigen::VectorXd z;
+  FillInsideGrid(kNumTangentialPoints, r, z);
+
+  Eigen::VectorXd r_on_edge = r;
+  r_on_edge[3] = mgrid_.maxR;
+  r[3] = OutsideR();
+
+  Eigen::VectorXd b_r_outside(kNumTangentialPoints);
+  Eigen::VectorXd b_p_outside(kNumTangentialPoints);
+  Eigen::VectorXd b_z_outside(kNumTangentialPoints);
+  const absl::Status outside = mgrid_.interpolate(
+      0, kNumTangentialPoints, mgrid_.numPhi, kNumTangentialPoints, r, z,
+      b_r_outside, b_p_outside, b_z_outside);
+  EXPECT_EQ(outside.code(), absl::StatusCode::kFailedPrecondition);
+
+  Eigen::VectorXd b_r_on_edge(kNumTangentialPoints);
+  Eigen::VectorXd b_p_on_edge(kNumTangentialPoints);
+  Eigen::VectorXd b_z_on_edge(kNumTangentialPoints);
+  const absl::Status on_edge = mgrid_.interpolate(
+      0, kNumTangentialPoints, mgrid_.numPhi, kNumTangentialPoints, r_on_edge,
+      z, b_r_on_edge, b_p_on_edge, b_z_on_edge);
+  EXPECT_TRUE(on_edge.ok()) << on_edge;
+
+  for (int index = 0; index < kNumTangentialPoints; ++index) {
+    EXPECT_EQ(b_r_outside[index], b_r_on_edge[index]);
+    EXPECT_EQ(b_p_outside[index], b_p_on_edge[index]);
+    EXPECT_EQ(b_z_outside[index], b_z_on_edge[index]);
+  }
+}
+
+// Each thread of the vacuum team interpolates one tangential slice, so the
+// status a call returns describes that slice and no other.
+TEST_F(MGridInterpolationTest, OnlyTheRequestedTangentialSliceIsChecked) {
+  const int num_points = 2 * kNumTangentialPoints;
+  Eigen::VectorXd r;
+  Eigen::VectorXd z;
+  FillInsideGrid(num_points, r, z);
+  r[num_points - 1] = OutsideR();
+
+  Eigen::VectorXd b_r(kNumTangentialPoints);
+  Eigen::VectorXd b_p(kNumTangentialPoints);
+  Eigen::VectorXd b_z(kNumTangentialPoints);
+
+  const absl::Status first_slice = mgrid_.interpolate(
+      0, kNumTangentialPoints, mgrid_.numPhi, num_points, r, z, b_r, b_p, b_z);
+  EXPECT_TRUE(first_slice.ok()) << first_slice;
+
+  const absl::Status second_slice =
+      mgrid_.interpolate(kNumTangentialPoints, num_points, mgrid_.numPhi,
+                         num_points, r, z, b_r, b_p, b_z);
+  EXPECT_EQ(second_slice.code(), absl::StatusCode::kFailedPrecondition);
+}
+
+// Which thread of the vacuum team wins the reduction in IdealMhdModel is a
+// race, so the extents named in the message are taken over the whole boundary
+// rather than over the reporting thread's slice. Anything slice-local here
+// would name a minimum that is not the boundary's and would make the error a
+// user sees change from run to run.
+TEST_F(MGridInterpolationTest, ReportedExtentsDoNotDependOnTheReportingSlice) {
+  const int num_points = 2 * kNumTangentialPoints;
+  Eigen::VectorXd r;
+  Eigen::VectorXd z;
+  FillInsideGrid(num_points, r, z);
+  // One point in each half of the boundary leaves the grid, so both slices
+  // report. The boundary's minimum R lies in the second slice only.
+  r[0] = OutsideR();
+  r[num_points - 1] = OutsideR() + 0.01;
+
+  Eigen::VectorXd b_r(kNumTangentialPoints);
+  Eigen::VectorXd b_p(kNumTangentialPoints);
+  Eigen::VectorXd b_z(kNumTangentialPoints);
+
+  const absl::Status first_slice = mgrid_.interpolate(
+      0, kNumTangentialPoints, mgrid_.numPhi, num_points, r, z, b_r, b_p, b_z);
+  const absl::Status second_slice =
+      mgrid_.interpolate(kNumTangentialPoints, num_points, mgrid_.numPhi,
+                         num_points, r, z, b_r, b_p, b_z);
+
+  EXPECT_EQ(first_slice.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_EQ(second_slice.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_EQ(first_slice.message(), second_slice.message());
+
+  // The extents are the boundary's, not either slice's.
+  const std::string message(first_slice.message());
+  EXPECT_THAT(message, HasSubstr(absl::StrFormat("% .6e", r.minCoeff())));
+  EXPECT_THAT(message, HasSubstr(absl::StrFormat("% .6e", r.maxCoeff())));
+}
+
+#ifdef _OPENMP
+// The barrier at the end of interpolate is collective over the vacuum team, so
+// a thread whose own slice left the grid has to reach it along with everyone
+// else. This splits a boundary that leaves the grid at one end only across a
+// team, which is the case that hangs if the barrier is ever made conditional
+// on the slice being inside the grid.
+TEST_F(MGridInterpolationTest, MixedInAndOutOfGridSlicesDoNotDeadlock) {
+  constexpr int kNumThreads = 4;
+  const int num_points = kNumThreads * kNumTangentialPoints;
+
+  Eigen::VectorXd r;
+  Eigen::VectorXd z;
+  FillInsideGrid(num_points, r, z);
+  // Only the slice owned by the last thread leaves the grid.
+  r[num_points - 1] = OutsideR();
+
+  std::vector<absl::Status> per_thread_status(kNumThreads);
+  int team_size = 0;
+
+#pragma omp parallel num_threads(kNumThreads)
+  {
+    const int thread_id = omp_get_thread_num();
+#pragma omp single
+    {
+      team_size = omp_get_num_threads();
+    }
+
+    const int zt_min = thread_id * kNumTangentialPoints;
+    const int zt_max = zt_min + kNumTangentialPoints;
+
+    Eigen::VectorXd b_r(kNumTangentialPoints);
+    Eigen::VectorXd b_p(kNumTangentialPoints);
+    Eigen::VectorXd b_z(kNumTangentialPoints);
+    per_thread_status[thread_id] = mgrid_.interpolate(
+        zt_min, zt_max, mgrid_.numPhi, num_points, r, z, b_r, b_p, b_z);
+  }
+
+  ASSERT_EQ(team_size, kNumThreads);
+  for (int thread_id = 0; thread_id < kNumThreads - 1; ++thread_id) {
+    EXPECT_TRUE(per_thread_status[thread_id].ok())
+        << per_thread_status[thread_id];
+  }
+  EXPECT_EQ(per_thread_status[kNumThreads - 1].code(),
+            absl::StatusCode::kFailedPrecondition);
+}
+#endif  // _OPENMP
+
+// A fixed field is handed over per tangential grid point rather than
+// interpolated, so there is no vacuum field grid to leave.
+TEST_F(MGridInterpolationTest, FixedFieldIgnoresGridBounds) {
+  const Eigen::VectorXd fixed_b_r =
+      Eigen::VectorXd::Constant(kNumTangentialPoints, 1.0);
+  const Eigen::VectorXd fixed_b_p =
+      Eigen::VectorXd::Constant(kNumTangentialPoints, 2.0);
+  const Eigen::VectorXd fixed_b_z =
+      Eigen::VectorXd::Constant(kNumTangentialPoints, 3.0);
+  mgrid_.SetFixedMagneticField(fixed_b_r, fixed_b_p, fixed_b_z);
+
+  const Eigen::VectorXd r =
+      Eigen::VectorXd::Constant(kNumTangentialPoints, OutsideR());
+  const Eigen::VectorXd z =
+      Eigen::VectorXd::Constant(kNumTangentialPoints, OutsideZ());
+
+  Eigen::VectorXd b_r(kNumTangentialPoints);
+  Eigen::VectorXd b_p(kNumTangentialPoints);
+  Eigen::VectorXd b_z(kNumTangentialPoints);
+  const absl::Status status =
+      mgrid_.interpolate(0, kNumTangentialPoints, mgrid_.numPhi,
+                         kNumTangentialPoints, r, z, b_r, b_p, b_z);
+
+  EXPECT_TRUE(status.ok()) << status;
+  for (int index = 0; index < kNumTangentialPoints; ++index) {
+    EXPECT_EQ(b_r[index], 1.0);
+    EXPECT_EQ(b_p[index], 2.0);
+    EXPECT_EQ(b_z[index], 3.0);
+  }
+}
 
 }  // namespace vmecpp


### PR DESCRIPTION
`MGridProvider::interpolate` clamped the vacuum field to the grid edge and wrote a warning to stderr when the plasma boundary left the mgrid domain. The clamped field no longer represents the coils outside the grid, but the run continued to convergence on it, so the effect showed up as a shifted boundary rather than as a domain error. In #639 that appeared as a roughly 12 cm discrepancy against another solver, and that PR's notes conclude that "Plasma Boundary exceeded Vacuum Grid Size" warnings should be treated as fatal for scan purposes. This makes them fatal in the solver, so a scan does not have to enforce that by convention.

`interpolate` now returns `absl::Status`. The status is carried through `ExternalMagneticField::update`, `FreeBoundaryBase::update` (now `absl::StatusOr<bool>`), `Nestor` and `OnlyCoils`, past every collective barrier, and reduced across the nested vacuum OpenMP team through a new `HandoverStorage::vacuum_status` slot before it is acted on. The barrier at the end of `interpolate` stays unconditional, so a thread whose own tangential slice left the grid still reaches it along with the rest of the team.

The code is `kFailedPrecondition`, so `indata.return_outputs_even_if_not_converged` still recovers the run and returns best-effort output. The message names the boundary extents against the grid extents in R, Z, or both. Those extents are taken over the whole boundary rather than over the reporting thread's slice, so the text is the same whichever thread wins the reduction.

The second commit is in `Vmec::SolveEquilibrium`'s aggregation helper. `absl::InternalError` takes an `absl::string_view`, so the `std::move` there did not move and the first reporting thread's message was appended a second time by the code below the `if`; the header string was assigned to a local that was never passed anywhere. With seven radial threads the aggregate held eight copies of the message and no header.

Four Bazel targets also gained a direct `@abseil-cpp//absl/status` dependency, which they had been picking up transitively.

Verification: `//vmecpp_large_cpp_tests/free_boundary/mgrid_provider:mgrid_provider_test` covers in-grid, on-edge, R-only, Z-only, both-axes, the clamped values, per-slice scoping, cross-slice message identity, and the fixed-field path, plus a nested-team case that deadlocks if the barrier is ever made conditional on the slice being inside the grid. Free-boundary and fixed-boundary outputs are unchanged bit-for-bit against the parent commit.
