### PR TITLE
Fix the sign of the perpendicular current v component in jxbout

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -2630,7 +2630,8 @@ vmecpp::JxBOutFileContents vmecpp::ComputeJxBOutputFileContents(
           vmec_internal_results.bsubv(jHi * s.nZnT + kl);
 
       kperpu[kl] = 0.5 * (bsubv_outside + bsubv_inside) * pprime / sqgb2[kl];
-      kperpv[kl] = 0.5 * (bsubu_outside + bsubu_inside) * pprime / sqgb2[kl];
+      // J_perp = (B x grad p)/|B|^2, so the v component carries a minus sign.
+      kperpv[kl] = -0.5 * (bsubu_outside + bsubu_inside) * pprime / sqgb2[kl];
 
       // --------
 

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
@@ -504,12 +504,8 @@ TEST_P(JxBOutputContentsTest, CheckJxBOutputContents) {
     EXPECT_TRUE(IsCloseRelAbs(jxbout["jpar2"][jF],
                               output_quantities.jxbout.jpar2[jF], tolerance));
 
-    // catastrophic cancellation
-    // TODO(jons): Can we make this more accurate?
-    // FIXME(jons): This looks SO MUCH off that there actually could be an error
-    // still present...
     EXPECT_TRUE(IsCloseRelAbs(jxbout["jperp2"][jF],
-                              output_quantities.jxbout.jperp2[jF], 0.2));
+                              output_quantities.jxbout.jperp2[jF], tolerance));
   }  // jF
 
   // The loop in jxbforce.f90:594 goes over js=2,ns1,
@@ -990,12 +986,11 @@ TEST_P(Threed1GeometricMagneticQuantitiesTest,
     EXPECT_TRUE(IsCloseRelAbs(threed1_geomag["jPS2"][jF - 1],
                               intermediate.jPS2[jF], tolerance));
   }  // jF
-  // TODO(jons): Is this catastrophic cancellation again?
-  EXPECT_TRUE(IsCloseRelAbs(threed1_geomag["s2"], intermediate.s2, 0.2));
+  EXPECT_TRUE(IsCloseRelAbs(threed1_geomag["s2"], intermediate.s2, tolerance));
   EXPECT_TRUE(
-      IsCloseRelAbs(threed1_geomag["jpar_perp"], result.jpar_perp, 0.15));
-  EXPECT_TRUE(
-      IsCloseRelAbs(threed1_geomag["jparPS_perp"], result.jparPS_perp, 0.1));
+      IsCloseRelAbs(threed1_geomag["jpar_perp"], result.jpar_perp, tolerance));
+  EXPECT_TRUE(IsCloseRelAbs(threed1_geomag["jparPS_perp"], result.jparPS_perp,
+                            tolerance));
 
   for (int jF = 0; jF < fc.ns; ++jF) {
     EXPECT_TRUE(


### PR DESCRIPTION
`jperp2` in the jxbout output is the flux-surface average of `|J_perp|^2`, built from the contravariant components of `J_perp = (B x grad p) / |B|^2`. With `grad p = p' grad s` those are

```
J_perp^u = + B_v p' / (sqrt(g) |B|^2)
J_perp^v = - B_u p' / (sqrt(g) |B|^2)
```

and `kperpv` was computed with a plus sign. Since

```
|J_perp|^2 = k^u k^u g_uu + 2 k^u k^v g_uv + k^v k^v g_vv
```

the two squared terms are unaffected and only the `g_uv` cross term takes the wrong sign. That is why the error is invisible for axisymmetric configurations, where `g_uv` vanishes, and shows up only in 3D.

Measured against the educational_VMEC reference data used by `JxBOutputContentsTest`, over all 121 compared points:

| case | ratio before | ratio after |
| --- | --- | --- |
| solovev | 1.000000 | 1.000000 |
| solovev_no_axis | 1.000000 | 1.000000 |
| cth_like_fixed_bdy | 1.057109 .. 1.148439 | 1.000000 |
| cth_like_fixed_bdy_nzeta_37 | 1.057109 .. 1.148439 | 1.000000 |
| cth_like_free_bdy | 1.063766 .. 1.160695 | 1.000000 |

Worst deviation from the reference goes from 0.160695 to 0.000000.

Four assertions had been loosened to accommodate this and now hold at the strict per-case tolerance, which is 1e-12 to 5e-11 depending on the case: `jperp2` was at 0.2, the `s2` geometric-and-magnetic integral at 0.2, `jpar_perp` at 0.15 and `jparPS_perp` at 0.1. They move together because `jperp2` feeds `s2` through the volume integral and feeds both ratios through `loc_jpar_perp`.

This resolves the two markers at those sites, `FIXME(jons): This looks SO MUCH off that there actually could be an error still present...` and `TODO(jons): Is this catastrophic cancellation again?`. Neither was cancellation.

The quantity is confined to the jxbout and threed1 diagnostic outputs and does not enter the equilibrium iteration, so converged equilibria are unchanged.
