### PR TITLE
ci: skip the CPython 3.14 Intel macOS wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,10 @@ version_file = "src/vmecpp/__about__.py"
 
 [tool.cibuildwheel]
 archs = ["native"]
-skip = ["*-musllinux*"]
+# jaxlib, a transitive dependency of simsopt, publishes no macOS x86_64 wheels
+# for CPython 3.14, so installing the built wheel to test it cannot resolve
+# there. Intel macOS still builds and tests CPython 3.10-3.13.
+skip = ["*-musllinux*", "cp314-macosx_x86_64"]
 build-frontend = "build[uv]" # More modern package manager than pip, with faster builds
 test-requires = "pytest"
 test-command = "pytest {package}/tests/test_simsopt_compat.py {package}/tests/test_free_boundary.py"


### PR DESCRIPTION
`Build wheels on macos-15-intel` currently fails on every pull request, including ones that touch nothing outside C++. The failure is a dependency resolution, not a build error:

```
hint: Wheels are available for `jaxlib` (v0.11.1) on the following platforms:
      `manylinux_2_27_aarch64`, `manylinux_2_27_x86_64`, `macosx_11_0_arm64`, `win_amd64`
hint: You require CPython 3.14 (`cp314`), but we only found wheels for `jaxlib` (v0.7.0)
      with the following Python ABI tags: `cp311`, `cp312`, `cp313`, `cp313t`
```

jaxlib has published no macOS x86_64 wheels since 0.4.31, and none at all for CPython 3.14. `simsopt` depends on jaxlib, so when cibuildwheel installs the freshly built `cp314-macosx_x86_64` wheel to run its test command, `uv pip install` cannot resolve and the job dies. The C++ build and the wheel itself are fine; only the test install fails.

This skips that single build via `[tool.cibuildwheel] skip`. Deliberately minimal:

- Intel macOS still builds **and** tests wheels for CPython 3.10 through 3.13.
- arm64 macOS, Linux and the sdist are untouched.
- No change to `.github/constraints.txt`, so nothing is pinned or downgraded elsewhere.

Once jaxlib ships macOS x86_64 cp314 wheels the line can simply be dropped again. If you would rather retire `macos-15-intel` from the matrix entirely, that is a one-line change too, but this keeps the platform covered where it still works.

https://claude.ai/code/session_01Tt1qwjDt7AVCt55QfgbsSr