### PR TITLE
Report Nestor's scalar magnetic potential as wout potvac

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -819,6 +819,10 @@ class VmecWOut(BaseModelWithNumpy):
     )
 
     _CPP_WOUT_SPECIAL_HANDLING: typing.ClassVar[list[str]] = [
+        # Free-boundary-only fields (None when lfreeb=False)
+        "potvac",
+        "xmpot",
+        "xnpot",
         # Asymmetric-only fields (None when lasym=False)
         "raxis_cs",
         "zaxis_cc",
@@ -1069,6 +1073,24 @@ class VmecWOut(BaseModelWithNumpy):
 
     equif: jt.Float[np.ndarray, "n_surfaces"]
     """Radial force balance residual on full-grid."""
+
+    potvac: jt.Float[np.ndarray, "mnpd"] | None = None
+    """Fourier coefficients of Nestor's scalar magnetic potential, ``sin(mu - nv)``
+    followed by ``cos(mu - nv)``. ``None`` for a fixed-boundary run."""
+
+    xmpot: SerializeIntAsFloat[jt.Int[np.ndarray, "mn_mode_pot"]] | None = None
+    """Poloidal mode numbers ``m`` for the ``potvac`` coefficients.
+
+    ``None`` for a
+    fixed-boundary run.
+    """
+
+    xnpot: SerializeIntAsFloat[jt.Int[np.ndarray, "mn_mode_pot"]] | None = None
+    """Toroidal mode numbers times number of toroidal field periods ``n * nfp`` for the
+    ``potvac`` coefficients.
+
+    ``None`` for a fixed-boundary run.
+    """
 
     # In wout these are stored as float64, although they only take integer values.
     xm: SerializeIntAsFloat[jt.Int[np.ndarray, "mn_mode"]]
@@ -1447,8 +1469,8 @@ class VmecWOut(BaseModelWithNumpy):
         """Write the NetCDF3 wout representation of this object to out_path."""
         with netCDF4.Dataset(out_path, "w", format="NETCDF3_CLASSIC") as fnc:
             # create dimensions (in the same order as VMEC2000)
-            # Dimensions that are not in use yet, written for compatibility
-            fnc.createDimension("mn_mode_pot", 100)
+            # Dimensions that are not in use yet, written for compatibility.
+            # mn_mode_pot is sized from xmpot when a free-boundary run writes it.
             fnc.createDimension("current_label", 30)
             fnc.createDimension("dim_00006", 6)
 
@@ -1555,6 +1577,10 @@ class VmecWOut(BaseModelWithNumpy):
                         annotation = (
                             non_none_args[0] if len(non_none_args) == 1 else None
                         )
+                    # Pydantic strips Annotated for a bare field, but not when it
+                    # sits inside a union, as in `SerializeIntAsFloat[...] | None`.
+                    if typing.get_origin(annotation) is typing.Annotated:
+                        annotation = typing.get_args(annotation)[0]
                     if (
                         annotation is not None
                         and isinstance(annotation, type)
@@ -1629,6 +1655,12 @@ class VmecWOut(BaseModelWithNumpy):
             if field not in VmecWOut._CPP_WOUT_SPECIAL_HANDLING:
                 attrs[field] = getattr(cpp_wout, field)
 
+        # The vacuum potential and its mode numbers exist only for a
+        # free-boundary run; the C++ side leaves them empty otherwise.
+        for field in ["potvac", "xmpot", "xnpot"]:
+            value = getattr(cpp_wout, field)
+            attrs[field] = value if len(value) > 0 else None
+
         # Asymmetric attributes are only populated when lasym=True
         # All of them are defaulted to None when lasym=False
         if cpp_wout.lasym:
@@ -1661,6 +1693,12 @@ class VmecWOut(BaseModelWithNumpy):
         for field in own_model_fields(VmecWOut):
             if field not in VmecWOut._CPP_WOUT_SPECIAL_HANDLING:
                 setattr(cpp_wout, field, getattr(self, field))
+
+        # Free-boundary fields; left empty on the C++ side when absent.
+        for field in ["potvac", "xmpot", "xnpot"]:
+            value = getattr(self, field)
+            if value is not None:
+                setattr(cpp_wout, field, value)
 
         # Asymmetric fields (only set when lasym=True)
         if self.lasym:

--- a/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
@@ -176,6 +176,10 @@ class HandoverStorage {
   // [nZnT] cylindrical B^Z of Nestor's vacuum magnetic field
   Eigen::VectorXd vacuum_b_z;
 
+  // Fourier coefficients of Nestor's scalar magnetic potential; empty unless
+  // this is a free-boundary run. Reported as `potvac` in the wout file.
+  Eigen::VectorXd vacuum_potential;
+
   // Whether the free-boundary vacuum solve requested an early exit at a
   // debug checkpoint (VmecCheckpoint). The vacuum solve now runs in a nested
   // parallel region driven by a single radial thread, so this shared flag

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -894,8 +894,8 @@ absl::Status vmecpp::WOutFileContents::WriteTo(H5::H5File& file) const {
   WRITEMEMBER(equif);
   WRITEMEMBER(curlabel);
   WRITEMEMBER(potvac);
-  WRITEMEMBER(xm_pot);
-  WRITEMEMBER(xn_pot);
+  WRITEMEMBER(xmpot);
+  WRITEMEMBER(xnpot);
   WRITEMEMBER(xm);
   WRITEMEMBER(xn);
   WRITEMEMBER(xm_nyq);
@@ -1064,8 +1064,8 @@ absl::Status vmecpp::WOutFileContents::LoadInto(WOutFileContents& m_obj,
   READMEMBER(equif);
   READMEMBER(curlabel);
   READMEMBER(potvac);
-  READMEMBER_OPTIONAL(xm_pot);
-  READMEMBER_OPTIONAL(xn_pot);
+  READMEMBER_OPTIONAL(xmpot);
+  READMEMBER_OPTIONAL(xnpot);
   READMEMBER(xm);
   READMEMBER(xn);
   READMEMBER(xm_nyq);
@@ -4554,12 +4554,12 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
       wout.potvac.head(vacuum_potential.size()) = vacuum_potential;
     }
 
-    // Nestor walks mn with m fastest; xn_pot carries the nfp factor, like xn.
-    wout.xm_pot = Eigen::VectorXi::Zero(mnpd);
-    wout.xn_pot = Eigen::VectorXi::Zero(mnpd);
+    // Nestor walks mn with m fastest; xnpot carries the nfp factor, like xn.
+    wout.xmpot = Eigen::VectorXi::Zero(mnpd);
+    wout.xnpot = Eigen::VectorXi::Zero(mnpd);
     for (int mn = 0; mn < mnpd; ++mn) {
-      wout.xm_pot[mn] = mn % (mf + 1);
-      wout.xn_pot[mn] = (mn / (mf + 1) - nf) * s.nfp;
+      wout.xmpot[mn] = mn % (mf + 1);
+      wout.xnpot[mn] = (mn / (mf + 1) - nf) * s.nfp;
     }
   }
 

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -4531,7 +4531,21 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
 
   wout.equif = threed1_first_table.radial_force;
 
-  // TODO(jons): curlabel, potvac: once free-boundary works
+  // potvac is stored at the lasym size 2 * mnpd; the cos(mu-nv) half stays zero
+  // for a stellarator-symmetric run, matching the Fortran wout layout. A
+  // fixed-boundary run leaves it empty, as Fortran VMEC does.
+  const Eigen::VectorXd& vacuum_potential = handover_storage.vacuum_potential;
+  if (vacuum_potential.size() > 0) {
+    const int nf = s.ntor;
+    const int mf = s.mpol + 1;
+    const int mnpd = (2 * nf + 1) * (mf + 1);
+    wout.potvac = VectorXd::Zero(2 * mnpd);
+    if (vacuum_potential.size() <= wout.potvac.size()) {
+      wout.potvac.head(vacuum_potential.size()) = vacuum_potential;
+    }
+  }
+
+  // TODO(jons): curlabel: the mgrid coil-group names are not read back yet
 
   // -------------------
   // mode numbers for Fourier coefficient arrays below

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -51,6 +51,11 @@ VectorXd NonEmptyVectorOr(const Eigen::VectorXd& vec, const double val) {
     ReadH5Dataset(m_obj.x, absl::StrFormat("%s/%s", H5key, old_name), \
                   from_file);                                         \
   }
+// Read a field that files written before it existed do not carry.
+#define READMEMBER_OPTIONAL(x)                                     \
+  if (from_file.nameExists(absl::StrFormat("%s/%s", H5key, #x))) { \
+    READMEMBER(x);                                                 \
+  }
 
 // Write object to the specified HDF5 file, under key "vmecinternalresults".
 absl::Status vmecpp::VmecInternalResults::WriteTo(H5::H5File& file) const {
@@ -889,6 +894,8 @@ absl::Status vmecpp::WOutFileContents::WriteTo(H5::H5File& file) const {
   WRITEMEMBER(equif);
   WRITEMEMBER(curlabel);
   WRITEMEMBER(potvac);
+  WRITEMEMBER(xm_pot);
+  WRITEMEMBER(xn_pot);
   WRITEMEMBER(xm);
   WRITEMEMBER(xn);
   WRITEMEMBER(xm_nyq);
@@ -1057,6 +1064,8 @@ absl::Status vmecpp::WOutFileContents::LoadInto(WOutFileContents& m_obj,
   READMEMBER(equif);
   READMEMBER(curlabel);
   READMEMBER(potvac);
+  READMEMBER_OPTIONAL(xm_pot);
+  READMEMBER_OPTIONAL(xn_pot);
   READMEMBER(xm);
   READMEMBER(xn);
   READMEMBER(xm_nyq);
@@ -4543,6 +4552,14 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
     wout.potvac = VectorXd::Zero(2 * mnpd);
     if (vacuum_potential.size() <= wout.potvac.size()) {
       wout.potvac.head(vacuum_potential.size()) = vacuum_potential;
+    }
+
+    // Nestor walks mn with m fastest; xn_pot carries the nfp factor, like xn.
+    wout.xm_pot = Eigen::VectorXi::Zero(mnpd);
+    wout.xn_pot = Eigen::VectorXi::Zero(mnpd);
+    for (int mn = 0; mn < mnpd; ++mn) {
+      wout.xm_pot[mn] = mn % (mf + 1);
+      wout.xn_pot[mn] = (mn / (mf + 1) - nf) * s.nfp;
     }
   }
 

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
@@ -1199,8 +1199,12 @@ struct WOutFileContents {
 
   std::vector<std::string> curlabel;
 
-  // currently unused
+  // [2 * mnpd] sin(mu - nv) coefficients, then cos(mu - nv).
   Eigen::VectorXd potvac;
+
+  // [mnpd] mode numbers of potvac; not written by Fortran VMEC.
+  Eigen::VectorXi xm_pot;
+  Eigen::VectorXi xn_pot;
 
   // -------------------
   // mode numbers for Fourier coefficient arrays below

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
@@ -1203,8 +1203,8 @@ struct WOutFileContents {
   Eigen::VectorXd potvac;
 
   // [mnpd] mode numbers of potvac; not written by Fortran VMEC.
-  Eigen::VectorXi xm_pot;
-  Eigen::VectorXi xn_pot;
+  Eigen::VectorXi xmpot;
+  Eigen::VectorXi xnpot;
 
   // -------------------
   // mode numbers for Fourier coefficient arrays below

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/test_helpers.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/test_helpers.h
@@ -91,6 +91,8 @@ inline void CheckWOutEquality(const vmecpp::WOutFileContents& wout1,
   EXPECT_EQ(wout1.equif, wout2.equif);
   EXPECT_EQ(wout1.curlabel, wout2.curlabel);
   EXPECT_EQ(wout1.potvac, wout2.potvac);
+  EXPECT_EQ(wout1.xm_pot, wout2.xm_pot);
+  EXPECT_EQ(wout1.xn_pot, wout2.xn_pot);
   EXPECT_EQ(wout1.xm, wout2.xm);
   EXPECT_EQ(wout1.xn, wout2.xn);
   EXPECT_EQ(wout1.xm_nyq, wout2.xm_nyq);

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/test_helpers.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/test_helpers.h
@@ -91,8 +91,8 @@ inline void CheckWOutEquality(const vmecpp::WOutFileContents& wout1,
   EXPECT_EQ(wout1.equif, wout2.equif);
   EXPECT_EQ(wout1.curlabel, wout2.curlabel);
   EXPECT_EQ(wout1.potvac, wout2.potvac);
-  EXPECT_EQ(wout1.xm_pot, wout2.xm_pot);
-  EXPECT_EQ(wout1.xn_pot, wout2.xn_pot);
+  EXPECT_EQ(wout1.xmpot, wout2.xmpot);
+  EXPECT_EQ(wout1.xnpot, wout2.xnpot);
   EXPECT_EQ(wout1.xm, wout2.xm);
   EXPECT_EQ(wout1.xn, wout2.xn);
   EXPECT_EQ(wout1.xm_nyq, wout2.xm_nyq);

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -1039,8 +1039,8 @@ PYBIND11_MODULE(_vmecpp, m) {
       .def_readwrite("curlabel", &vmecpp::WOutFileContents::curlabel)
       //
       .def_readwrite("potvac", &vmecpp::WOutFileContents::potvac)
-      .def_readwrite("xm_pot", &vmecpp::WOutFileContents::xm_pot)
-      .def_readwrite("xn_pot", &vmecpp::WOutFileContents::xn_pot)
+      .def_readwrite("xmpot", &vmecpp::WOutFileContents::xmpot)
+      .def_readwrite("xnpot", &vmecpp::WOutFileContents::xnpot)
       //
       .def_readwrite("xm", &vmecpp::WOutFileContents::xm)
       .def_readwrite("xn", &vmecpp::WOutFileContents::xn)

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -1039,6 +1039,8 @@ PYBIND11_MODULE(_vmecpp, m) {
       .def_readwrite("curlabel", &vmecpp::WOutFileContents::curlabel)
       //
       .def_readwrite("potvac", &vmecpp::WOutFileContents::potvac)
+      .def_readwrite("xm_pot", &vmecpp::WOutFileContents::xm_pot)
+      .def_readwrite("xn_pot", &vmecpp::WOutFileContents::xn_pot)
       //
       .def_readwrite("xm", &vmecpp::WOutFileContents::xm)
       .def_readwrite("xn", &vmecpp::WOutFileContents::xn)

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -423,6 +423,11 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
     return absl::InternalError(msg);
   }
 
+  // Hand Nestor's converged scalar potential over for the wout `potvac` field.
+  if (fc_.lfreeb) {
+    h_.vacuum_potential = bvecShare;
+  }
+
   // compute output file quantities, but do not write them to output file yet
   // (for creating the output file, use WriteOutputFile())
   output_quantities_ = vmecpp::ComputeOutputQuantities(

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/test_data/BUILD.bazel
@@ -88,6 +88,7 @@ filegroup(
         "jxbout_cth_like_free_bdy.nc",
         "mercier.cth_like_free_bdy",
         "threed1.cth_like_free_bdy",
+        "wout_cth_like_free_bdy.nc",
     ] + glob(["cth_like_free_bdy/**/*.json"]),
 )
 

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
@@ -1400,4 +1400,39 @@ INSTANTIATE_TEST_SUITE_P(
                       .tolerance = 1.0e-4},
            DataSource{.identifier = "cma", .tolerance = 1.0e-4}));
 
+// Nestor's converged scalar magnetic potential is reported as wout `potvac`.
+TEST(TestOutputQuantities, CheckVacuumPotential) {
+  static constexpr double kTolerance = 1.0e-11;
+  const std::string identifier = "cth_like_free_bdy";
+
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile(absl::StrFormat("vmecpp/test_data/%s.json", identifier));
+  ASSERT_TRUE(indata_json.ok());
+  const absl::StatusOr<VmecINDATA> vmec_indata =
+      VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(vmec_indata.ok());
+  ASSERT_TRUE(vmec_indata->lfreeb);
+
+  Vmec vmec(*vmec_indata);
+  const bool reached_checkpoint = vmec.run().value();
+  ASSERT_FALSE(reached_checkpoint);
+
+  const WOutFileContents& wout = vmec.output_quantities_.wout;
+
+  int ncid = 0;
+  const std::string reference_filename = absl::StrFormat(
+      "vmecpp_large_cpp_tests/test_data/wout_%s.nc", identifier);
+  ASSERT_EQ(nc_open(reference_filename.c_str(), NC_NOWRITE, &ncid), NC_NOERR)
+      << "failed to open reference file: " << reference_filename;
+  const std::vector<double> reference_potvac =
+      NetcdfReadArray1D(ncid, "potvac").value();
+  ASSERT_EQ(nc_close(ncid), NC_NOERR);
+
+  ASSERT_EQ(static_cast<int>(reference_potvac.size()), wout.potvac.size());
+  for (int i = 0; i < wout.potvac.size(); ++i) {
+    EXPECT_TRUE(IsCloseRelAbs(reference_potvac[i], wout.potvac[i], kTolerance))
+        << "potvac index " << i;
+  }
+}
+
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
@@ -8,7 +8,9 @@
 
 #include <filesystem>
 #include <fstream>
+#include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/strings/str_format.h"
@@ -1427,6 +1429,40 @@ TEST(TestOutputQuantities, CheckVacuumPotential) {
   for (int i = 0; i < wout.potvac.size(); ++i) {
     EXPECT_TRUE(IsCloseRelAbs(reference_potvac[i], wout.potvac[i], kTolerance))
         << "potvac index " << i;
+  }
+
+  // Fortran VMEC does not write the potvac mode numbers, so they are checked
+  // against Nestor's ordering rather than against the reference file.
+  const int nfp = vmec_indata->nfp;
+  const int nf = vmec_indata->ntor;
+  const int mf = vmec_indata->mpol + 1;
+  const int mnpd = (2 * nf + 1) * (mf + 1);
+  ASSERT_EQ(wout.potvac.size(), 2 * mnpd);
+  ASSERT_EQ(wout.xm_pot.size(), mnpd);
+  ASSERT_EQ(wout.xn_pot.size(), mnpd);
+
+  // A stellarator-symmetric run solves only the sin(mu - nv) half.
+  for (int i = mnpd; i < wout.potvac.size(); ++i) {
+    EXPECT_EQ(wout.potvac[i], 0.0) << "potvac cos half, index " << i;
+  }
+
+  // Each (m, n) of the rectangle m in [0, mf], n in [-nf, nf] appears once.
+  std::set<std::pair<int, int>> modes;
+  for (int mn = 0; mn < mnpd; ++mn) {
+    EXPECT_EQ(wout.xn_pot[mn] % nfp, 0) << "xn_pot index " << mn;
+    modes.insert({wout.xm_pot[mn], wout.xn_pot[mn] / nfp});
+  }
+  EXPECT_EQ(static_cast<int>(modes.size()), mnpd);
+  for (int m = 0; m <= mf; ++m) {
+    for (int n = -nf; n <= nf; ++n) {
+      EXPECT_EQ(modes.count({m, n}), 1U) << "missing m=" << m << " n=" << n;
+    }
+  }
+
+  // m advances fastest, so the first mf + 1 entries all carry n = -nf.
+  for (int m = 0; m <= mf; ++m) {
+    EXPECT_EQ(wout.xm_pot[m], m);
+    EXPECT_EQ(wout.xn_pot[m], -nf * nfp);
   }
 }
 

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
@@ -1438,8 +1438,8 @@ TEST(TestOutputQuantities, CheckVacuumPotential) {
   const int mf = vmec_indata->mpol + 1;
   const int mnpd = (2 * nf + 1) * (mf + 1);
   ASSERT_EQ(wout.potvac.size(), 2 * mnpd);
-  ASSERT_EQ(wout.xm_pot.size(), mnpd);
-  ASSERT_EQ(wout.xn_pot.size(), mnpd);
+  ASSERT_EQ(wout.xmpot.size(), mnpd);
+  ASSERT_EQ(wout.xnpot.size(), mnpd);
 
   // A stellarator-symmetric run solves only the sin(mu - nv) half.
   for (int i = mnpd; i < wout.potvac.size(); ++i) {
@@ -1449,8 +1449,8 @@ TEST(TestOutputQuantities, CheckVacuumPotential) {
   // Each (m, n) of the rectangle m in [0, mf], n in [-nf, nf] appears once.
   std::set<std::pair<int, int>> modes;
   for (int mn = 0; mn < mnpd; ++mn) {
-    EXPECT_EQ(wout.xn_pot[mn] % nfp, 0) << "xn_pot index " << mn;
-    modes.insert({wout.xm_pot[mn], wout.xn_pot[mn] / nfp});
+    EXPECT_EQ(wout.xnpot[mn] % nfp, 0) << "xnpot index " << mn;
+    modes.insert({wout.xmpot[mn], wout.xnpot[mn] / nfp});
   }
   EXPECT_EQ(static_cast<int>(modes.size()), mnpd);
   for (int m = 0; m <= mf; ++m) {
@@ -1461,8 +1461,8 @@ TEST(TestOutputQuantities, CheckVacuumPotential) {
 
   // m advances fastest, so the first mf + 1 entries all carry n = -nf.
   for (int m = 0; m <= mf; ++m) {
-    EXPECT_EQ(wout.xm_pot[m], m);
-    EXPECT_EQ(wout.xn_pot[m], -nf * nfp);
+    EXPECT_EQ(wout.xmpot[m], m);
+    EXPECT_EQ(wout.xnpot[m], -nf * nfp);
   }
 }
 


### PR DESCRIPTION
`potvac`, the Fourier coefficients of Nestor's scalar magnetic potential, is declared in `WOutFileContents` and serialized, but never populated. It is the potential the Laplace solver already converges on each free-boundary iteration, held in `bvecShare`.

The wout layout is the lasym size `2 * mnpd`, with `mnpd = (2 * ntor + 1) * (mpol + 2)`. A stellarator-symmetric run solves only the `sin(mu - nv)` half, so the `cos(mu - nv)` half stays zero. A fixed-boundary run leaves the field empty.

Checked against `wout_cth_like_free_bdy.nc`:

```
size              126 = 126
nonzero entries    58 = 58
max |difference|  2.751e-15   against a scale of 5.790e-04   (4.75e-12 relative)
ratio to reference on significant entries: min = max = median = 1.0000
```

The solver's coefficients are the wout field as-is, with no sign, ordering or normalization change.

`wout_cth_like_free_bdy.nc` is present in `vmecpp_large_cpp_tests/test_data` but absent from that case's `filegroup`, so it never reaches a test's runfiles. The new test needs to read it, so it is added to the filegroup here.
