### PR TITLE
Reject unusable profile parameterization names at input validation

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/BUILD.bazel
@@ -23,6 +23,7 @@ cc_library(
     deps = [
         ":boundary_from_json",
         "//vmecpp/common/util:util",
+        "//vmecpp/vmec/profile_parameterization_data",
         "//util/hdf5_io",
         "//util/file_io",
         "@abseil-cpp//absl/algorithm:container",

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -21,6 +21,7 @@
 #include "util/json_io/json_io.h"
 #include "vmecpp/common/util/util.h"
 #include "vmecpp/common/vmec_indata/boundary_from_json.h"
+#include "vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.h"
 
 namespace {
 [[noreturn]] void ErrorToException(const absl::Status& status,
@@ -28,6 +29,66 @@ namespace {
   const std::string msg =
       "There was an error " + context + ":\n" + std::string(status.message());
   throw std::runtime_error(msg);
+}
+
+std::string ProfileTypeName(vmecpp::ProfileType profile_type) {
+  switch (profile_type) {
+    case vmecpp::ProfileType::PRESSURE:
+      return "mass/pressure";
+    case vmecpp::ProfileType::CURRENT:
+      return "current";
+    case vmecpp::ProfileType::IOTA:
+      return "iota";
+  }
+  return "unknown";
+}
+
+// Checks that `type_name` names a profile parameterization that may be used for
+// `profile_type`, and that a spline parameterization was given its knots. An
+// unrecognized name otherwise reaches the solver as a zero profile, which
+// converges to a silently wrong equilibrium.
+//
+// The polynomial coefficient arrays are deliberately not required to be
+// non-empty: they are zero-padded on read, so an empty array is a valid way to
+// specify a zero profile.
+absl::Status CheckProfile(const std::string& type_key,
+                          const std::string& type_name,
+                          vmecpp::ProfileType profile_type,
+                          const std::string& aux_key,
+                          const Eigen::VectorXd& aux_s,
+                          const Eigen::VectorXd& aux_f) {
+  const vmecpp::ProfileParameterizationData* const parameterization =
+      vmecpp::FindProfileParameterization(type_name);
+  if (parameterization == nullptr) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "input variable '%s' is '%s', which is not a known profile "
+        "parameterization\n",
+        type_key, type_name));
+  }
+
+  if (!vmecpp::IsProfileParameterizationAllowedFor(type_name, profile_type)) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "input variable '%s' is '%s', which cannot be used for the %s "
+        "profile\n",
+        type_key, type_name, ProfileTypeName(profile_type)));
+  }
+
+  if (parameterization->NeedsSplineData()) {
+    if (aux_s.size() == 0 || aux_f.size() == 0) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "'%s' is '%s', which is a spline profile, so '%s_aux_s' and "
+          "'%s_aux_f' must be given\n",
+          type_key, type_name, aux_key, aux_key));
+    }
+    if (aux_s.size() != aux_f.size()) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "'%s_aux_s' and '%s_aux_f' must have the same number of entries, "
+          "but have %d and %d\n",
+          aux_key, aux_key, aux_s.size(), aux_f.size()));
+    }
+  }
+
+  return absl::OkStatus();
 }
 }  // namespace
 
@@ -1361,15 +1422,15 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
 
   /* --------------------------------- */
 
-  // pmass_type
-  // TODO(jons): check for allowed value
-
-  // am
-  // TODO(jons): must be given for parameterized profiles
-
-  // am_aux_s
-  // am_aux_f
-  // TODO(jons): must be given for spline data profiles
+  // pmass_type, am_aux_s, am_aux_f
+  {
+    const absl::Status status = CheckProfile(
+        "pmass_type", vmec_indata.pmass_type, ProfileType::PRESSURE, "am",
+        vmec_indata.am_aux_s, vmec_indata.am_aux_f);
+    if (!status.ok()) {
+      return status;
+    }
+  }
 
   // pres_scale
   if (vmec_indata.pres_scale < 0) {
@@ -1395,15 +1456,13 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
   /* --------------------------------- */
 
   if (vmec_indata.ncurr == 0) {
-    // piota_type
-    // TODO(jons): check for allowed value
-
-    // ai
-    // TODO(jons): must be given for parameterized profiles
-
-    // ai_aux_s
-    // ai_aux_f
-    // TODO(jons): must be given for spline data profiles
+    // piota_type, ai_aux_s, ai_aux_f
+    const absl::Status status =
+        CheckProfile("piota_type", vmec_indata.piota_type, ProfileType::IOTA,
+                     "ai", vmec_indata.ai_aux_s, vmec_indata.ai_aux_f);
+    if (!status.ok()) {
+      return status;
+    }
 
     if (vmec_indata.bloat != 1.0) {
       // bloat != 1 is only allowed when ncurr == 1 (constrained toroidal
@@ -1415,15 +1474,13 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
     }
 
   } else if (vmec_indata.ncurr == 1) {
-    // pcurr_type
-    // TODO(jons): check for allowed value
-
-    // ac
-    // TODO(jons): must be given for parameterized profiles
-
-    // ac_aux_s
-    // ac_aux_f
-    // TODO(jons): must be given for spline data profiles
+    // pcurr_type, ac_aux_s, ac_aux_f
+    const absl::Status status =
+        CheckProfile("pcurr_type", vmec_indata.pcurr_type, ProfileType::CURRENT,
+                     "ac", vmec_indata.ac_aux_s, vmec_indata.ac_aux_f);
+    if (!status.ok()) {
+      return status;
+    }
 
     // curtor --> any value is ok
 

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -1423,13 +1423,11 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
   /* --------------------------------- */
 
   // pmass_type, am_aux_s, am_aux_f
-  {
-    const absl::Status status = CheckProfile(
-        "pmass_type", vmec_indata.pmass_type, ProfileType::PRESSURE, "am",
-        vmec_indata.am_aux_s, vmec_indata.am_aux_f);
-    if (!status.ok()) {
-      return status;
-    }
+  if (absl::Status status = CheckProfile(
+          "pmass_type", vmec_indata.pmass_type, ProfileType::PRESSURE, "am",
+          vmec_indata.am_aux_s, vmec_indata.am_aux_f);
+      !status.ok()) {
+    return status;
   }
 
   // pres_scale
@@ -1455,15 +1453,24 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
 
   /* --------------------------------- */
 
-  if (vmec_indata.ncurr == 0) {
-    // piota_type, ai_aux_s, ai_aux_f
-    const absl::Status status =
-        CheckProfile("piota_type", vmec_indata.piota_type, ProfileType::IOTA,
-                     "ai", vmec_indata.ai_aux_s, vmec_indata.ai_aux_f);
-    if (!status.ok()) {
-      return status;
-    }
+  // piota_type, ai_aux_s, ai_aux_f. Checked for either ncurr: piota is the
+  // initial guess for the iota profile even in a current-constrained run.
+  if (absl::Status status =
+          CheckProfile("piota_type", vmec_indata.piota_type, ProfileType::IOTA,
+                       "ai", vmec_indata.ai_aux_s, vmec_indata.ai_aux_f);
+      !status.ok()) {
+    return status;
+  }
 
+  // pcurr_type, ac_aux_s, ac_aux_f. Ignored for ncurr == 0, still checked.
+  if (absl::Status status = CheckProfile(
+          "pcurr_type", vmec_indata.pcurr_type, ProfileType::CURRENT, "ac",
+          vmec_indata.ac_aux_s, vmec_indata.ac_aux_f);
+      !status.ok()) {
+    return status;
+  }
+
+  if (vmec_indata.ncurr == 0) {
     if (vmec_indata.bloat != 1.0) {
       // bloat != 1 is only allowed when ncurr == 1 (constrained toroidal
       // current)
@@ -1472,20 +1479,8 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
           "'bloat' must be 1.0 for ncurr == 0 (constrained-iota), but is %g\n",
           vmec_indata.bloat));
     }
-
-  } else if (vmec_indata.ncurr == 1) {
-    // pcurr_type, ac_aux_s, ac_aux_f
-    const absl::Status status =
-        CheckProfile("pcurr_type", vmec_indata.pcurr_type, ProfileType::CURRENT,
-                     "ac", vmec_indata.ac_aux_s, vmec_indata.ac_aux_f);
-    if (!status.ok()) {
-      return status;
-    }
-
-    // curtor --> any value is ok
-
-    // bloat --> any value is ok
   }
+  // ncurr == 1: curtor and bloat may take any value.
 
   /* --------------------------------- */
 

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
@@ -206,6 +206,59 @@ TEST(TestVmecINDATA, CheckDeltBounds) {
   EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
 }
 
+// An unusable profile parameterization silently evaluates to zero in the
+// solver, so it has to be rejected here instead.
+TEST(TestVmecINDATA, CheckProfileParameterizationNames) {
+  VmecINDATA indata;
+  ASSERT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+
+  // unknown name
+  indata.pmass_type = "power_serise";
+  EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+
+  // known, but not applicable to the pressure profile
+  indata.pmass_type = "sum_atan";
+  EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+
+  indata.pmass_type = "power_series";
+  EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+
+  // iota parameterization is only consulted for ncurr == 0
+  indata.ncurr = 0;
+  indata.piota_type = "power_series_i";  // current-only
+  EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+  indata.piota_type = "power_series";
+  EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+
+  // current parameterization is only consulted for ncurr == 1
+  indata.ncurr = 1;
+  indata.pcurr_type = "two_lorentz";  // pressure-only
+  EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+  indata.pcurr_type = "power_series";
+  EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+}
+
+// A spline profile cannot be evaluated without its knots. The polynomial
+// coefficient arrays, by contrast, are zero-padded on read, so an empty one is
+// a valid way to ask for a zero profile.
+TEST(TestVmecINDATA, CheckSplineProfilesNeedKnots) {
+  VmecINDATA indata;
+  indata.pmass_type = "cubic_spline";
+  EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+
+  indata.am_aux_s = Eigen::VectorXd::LinSpaced(4, 0.0, 1.0);
+  indata.am_aux_f = Eigen::VectorXd::Zero(3);
+  EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+
+  indata.am_aux_f = Eigen::VectorXd::Zero(4);
+  EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+
+  // empty polynomial coefficients stay acceptable
+  indata.pmass_type = "power_series";
+  indata.am = Eigen::VectorXd();
+  EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+}
+
 TEST(TestVmecINDATA, ToJson) {
   const absl::StatusOr<std::string> indata_json =
       ReadFile("vmecpp/test_data/cth_like_free_bdy.json");

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
@@ -223,17 +223,25 @@ TEST(TestVmecINDATA, CheckProfileParameterizationNames) {
   indata.pmass_type = "power_series";
   EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
 
-  // iota parameterization is only consulted for ncurr == 0
-  indata.ncurr = 0;
-  indata.piota_type = "power_series_i";  // current-only
-  EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
-  indata.piota_type = "power_series";
-  EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+  // All three are checked for either ncurr: piota is the initial guess for the
+  // iota profile even when the run is current-constrained.
+  for (const int ncurr : {0, 1}) {
+    indata.ncurr = ncurr;
+    ASSERT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok())
+        << "ncurr=" << ncurr;
 
-  // current parameterization is only consulted for ncurr == 1
+    indata.piota_type = "power_series_i";  // current-only
+    EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok())
+        << "ncurr=" << ncurr;
+    indata.piota_type = "power_series";
+
+    indata.pcurr_type = "two_lorentz";  // pressure-only
+    EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok())
+        << "ncurr=" << ncurr;
+    indata.pcurr_type = "power_series";
+  }
+
   indata.ncurr = 1;
-  indata.pcurr_type = "two_lorentz";  // pressure-only
-  EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
   indata.pcurr_type = "power_series";
   EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
 }

--- a/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/BUILD.bazel
@@ -5,5 +5,5 @@ cc_library(
     name = "profile_parameterization_data",
     srcs = ["profile_parameterization_data.cc"],
     hdrs = ["profile_parameterization_data.h"],
-    visibility = ["//vmecpp/vmec:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.cc
@@ -5,8 +5,111 @@
 #include "vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.h"
 
 #include <string>
+#include <vector>
 
 namespace vmecpp {
+namespace {
+
+std::vector<ProfileParameterizationData> BuildProfileParameterizations() {
+  // Entries are in ProfileParameterization order; findParameterization relies
+  // on the index matching the enumerator.
+  //
+  //                       current | iota | pressure
+  //                       --------+------+---------
+  // POWER_SERIES          I-prime |   X  |     X
+  // POWER_SERIES_I        I       |      |
+  // GAUSS_TRUNC           I-prime |      |     X
+  // SUM_ATAN              I       |   X  |
+  // TWO_LORENTZ                   |      |     X
+  // TWO_POWER             I-prime |      |     X
+  // TWO_POWER_GS          I-prime |      |     X
+  // AKIMA_SPLINE                  |   X  |     X
+  // AKIMA_SPLINE_I        I       |      |
+  // AKIMA_SPLINE_IP       I-prime |      |
+  // CUBIC_SPLINE                  |   X  |     X
+  // CUBIC_SPLINE_I        I       |      |
+  // CUBIC_SPLINE_IP       I-prime |      |
+  // PEDESTAL              I       |      |     X
+  // RATIONAL              I       |   X  |     X
+  // LINE_SEGMENT                  |   X  |     X
+  // LINE_SEGMENT_I        I       |      |
+  // LINE_SEGMENT_IP       I-prime |      |
+  // NICE_QUADRATIC                |   X  |
+  std::vector<ProfileParameterizationData> all;
+  all.reserve(NUM_PARAM);
+  all.emplace_back("---invalid---", /*allowedForPres=*/false,
+                   /*allowedForCurr*/ false, /*allowedForIota*/ false,
+                   /*needsSplineData*/ false);
+  all.emplace_back("power_series", /*allowedForPres=*/true,
+                   /*allowedForCurr*/ true, /*allowedForIota*/ true,
+                   /*needsSplineData*/ false);
+  all.emplace_back("power_series_i", /*allowedForPres=*/false,
+                   /*allowedForCurr*/ true, /*allowedForIota*/ false,
+                   /*needsSplineData*/ false);
+  all.emplace_back("gauss_trunc", /*allowedForPres=*/true,
+                   /*allowedForCurr*/ true, /*allowedForIota*/ false,
+                   /*needsSplineData*/ false);
+  all.emplace_back("sum_atan", /*allowedForPres=*/false,
+                   /*allowedForCurr*/ true, /*allowedForIota*/ true,
+                   /*needsSplineData*/ false);
+  all.emplace_back("two_lorentz", /*allowedForPres=*/true,
+                   /*allowedForCurr*/ false, /*allowedForIota*/ false,
+                   /*needsSplineData*/ false);
+  all.emplace_back("two_power", /*allowedForPres=*/true,
+                   /*allowedForCurr*/ true, /*allowedForIota*/ false,
+                   /*needsSplineData*/ false);
+  all.emplace_back("two_power_gs", /*allowedForPres=*/true,
+                   /*allowedForCurr*/ true, /*allowedForIota*/ false,
+                   /*needsSplineData*/ false);
+  all.emplace_back("akima_spline", /*allowedForPres=*/true,
+                   /*allowedForCurr*/ false, /*allowedForIota*/ true,
+                   /*needsSplineData*/ true);
+  all.emplace_back("akima_spline_i", /*allowedForPres=*/false,
+                   /*allowedForCurr*/ true, /*allowedForIota*/ false,
+                   /*needsSplineData*/ true);
+  all.emplace_back("akima_spline_ip", /*allowedForPres=*/false,
+                   /*allowedForCurr*/ true, /*allowedForIota*/ false,
+                   /*needsSplineData*/ true);
+  all.emplace_back("cubic_spline", /*allowedForPres=*/true,
+                   /*allowedForCurr*/ false, /*allowedForIota*/ true,
+                   /*needsSplineData*/ true);
+  all.emplace_back("cubic_spline_i", /*allowedForPres=*/false,
+                   /*allowedForCurr*/ true, /*allowedForIota*/ false,
+                   /*needsSplineData*/ true);
+  all.emplace_back("cubic_spline_ip", /*allowedForPres=*/false,
+                   /*allowedForCurr*/ true, /*allowedForIota*/ false,
+                   /*needsSplineData*/ true);
+  all.emplace_back("pedestal", /*allowedForPres=*/true,
+                   /*allowedForCurr*/ true, /*allowedForIota*/ false,
+                   /*needsSplineData*/ false);
+  all.emplace_back("rational", /*allowedForPres=*/true,
+                   /*allowedForCurr*/ true, /*allowedForIota*/ true,
+                   /*needsSplineData*/ false);
+  all.emplace_back("line_segment", /*allowedForPres=*/true,
+                   /*allowedForCurr*/ false, /*allowedForIota*/ true,
+                   /*needsSplineData*/ true);
+  all.emplace_back("line_segment_i", /*allowedForPres=*/false,
+                   /*allowedForCurr*/ true, /*allowedForIota*/ false,
+                   /*needsSplineData*/ true);
+  all.emplace_back("line_segment_ip", /*allowedForPres=*/false,
+                   /*allowedForCurr*/ true, /*allowedForIota*/ false,
+                   /*needsSplineData*/ true);
+  all.emplace_back("nice_quadratic", /*allowedForPres=*/false,
+                   /*allowedForCurr*/ false, /*allowedForIota*/ true,
+                   /*needsSplineData*/ false);
+  all.emplace_back("sum_cossq_s", /*allowedForPres=*/false,
+                   /*allowedForCurr*/ true, /*allowedForIota*/ false,
+                   /*needsSplineData*/ false);
+  all.emplace_back("sum_cossq_sqrts", /*allowedForPres=*/false,
+                   /*allowedForCurr*/ true, /*allowedForIota*/ false,
+                   /*needsSplineData*/ false);
+  all.emplace_back("sum_cossq_s_free", /*allowedForPres=*/false,
+                   /*allowedForCurr*/ true, /*allowedForIota*/ false,
+                   /*needsSplineData*/ false);
+  return all;
+}
+
+}  // namespace
 
 ProfileParameterizationData::ProfileParameterizationData(
     const std::string& name, bool allowedForPres, bool allowedForCurr,
@@ -17,12 +120,51 @@ ProfileParameterizationData::ProfileParameterizationData(
                    .curr = allowedForCurr,
                    .iota = allowedForIota}) {}
 
-const std::string& ProfileParameterizationData::Name() { return name_; }
+const std::string& ProfileParameterizationData::Name() const { return name_; }
 
 bool ProfileParameterizationData::NeedsSplineData() const {
   return needsSplineData_;
 }
 
-AllowedFor ProfileParameterizationData::IsAllowedFor() { return allowedFor_; }
+AllowedFor ProfileParameterizationData::IsAllowedFor() const {
+  return allowedFor_;
+}
+
+const std::vector<ProfileParameterizationData>& AllProfileParameterizations() {
+  static const std::vector<ProfileParameterizationData>* const all =
+      new std::vector<ProfileParameterizationData>(
+          BuildProfileParameterizations());
+  return *all;
+}
+
+const ProfileParameterizationData* FindProfileParameterization(
+    const std::string& name) {
+  for (const ProfileParameterizationData& entry :
+       AllProfileParameterizations()) {
+    if (entry.Name() == name) {
+      return &entry;
+    }
+  }
+  return nullptr;
+}
+
+bool IsProfileParameterizationAllowedFor(const std::string& name,
+                                         ProfileType type) {
+  const ProfileParameterizationData* const entry =
+      FindProfileParameterization(name);
+  if (entry == nullptr) {
+    return false;
+  }
+  const AllowedFor allowed = entry->IsAllowedFor();
+  switch (type) {
+    case ProfileType::PRESSURE:
+      return allowed.pres;
+    case ProfileType::CURRENT:
+      return allowed.curr;
+    case ProfileType::IOTA:
+      return allowed.iota;
+  }
+  return false;
+}
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.cc
@@ -131,10 +131,10 @@ AllowedFor ProfileParameterizationData::IsAllowedFor() const {
 }
 
 const std::vector<ProfileParameterizationData>& AllProfileParameterizations() {
-  static const std::vector<ProfileParameterizationData>* const all =
+  static const std::vector<ProfileParameterizationData>* const kAll =
       new std::vector<ProfileParameterizationData>(
           BuildProfileParameterizations());
-  return *all;
+  return *kAll;
 }
 
 const ProfileParameterizationData* FindProfileParameterization(

--- a/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <string>
+#include <vector>
 
 namespace vmecpp {
 
@@ -28,9 +29,9 @@ class ProfileParameterizationData {
                               bool allowedForCurr, bool allowedForIota,
                               bool needsSplineData);
 
-  const std::string& Name();
+  const std::string& Name() const;
   bool NeedsSplineData() const;
-  AllowedFor IsAllowedFor();
+  AllowedFor IsAllowedFor() const;
 
  private:
   const std::string name_;
@@ -63,6 +64,17 @@ enum class ProfileParameterization : std::uint8_t {
   SUM_COSSQ_SQRTS = 21,
   SUM_COSSQ_S_FREE = 22
 };
+
+// All known parameterizations, indexed by ProfileParameterization.
+const std::vector<ProfileParameterizationData>& AllProfileParameterizations();
+
+// The entry carrying `name`, or nullptr if no parameterization has that name.
+const ProfileParameterizationData* FindProfileParameterization(
+    const std::string& name);
+
+// Whether `name` is a known parameterization that may be used for `type`.
+bool IsProfileParameterizationAllowedFor(const std::string& name,
+                                         ProfileType type);
 
 }  // namespace vmecpp
 

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
@@ -232,8 +232,6 @@ RadialProfiles::RadialProfiles(const RadialPartitioning* r,
   piotaType = ProfileParameterization::INVALID_PARAM;
   pcurrType = ProfileParameterization::INVALID_PARAM;
 
-  setupProfileParameterizations();
-
   // half-grid
   phipH.resize(r_.nsMaxH - r_.nsMinH);
   chipH.resize(r_.nsMaxH - r_.nsMinH);
@@ -285,121 +283,20 @@ void RadialProfiles::setupInputProfiles() {
   computeMagneticFluxes();
 }
 
-void RadialProfiles::setupProfileParameterizations() {
-  // clang-format off
-  //                       current | iota | pressure
-  //                       --------+------+---------
-  // INVALID_PARAM                 |      |
-  // POWER_SERIES          I-prime |   X  |     X
-  // POWER_SERIES_I        I       |      |
-  // GAUSS_TRUNC           I-prime |      |     X
-  // SUM_ATAN              I       |   X  |
-  // TWO_LORENTZ                   |      |     X
-  // TWO_POWER             I-prime |      |     X
-  // TWO_POWER_GS          I-prime |      |     X
-  // AKIMA_SPLINE                  |   X  |     X
-  // AKIMA_SPLINE_I        I       |      |
-  // AKIMA_SPLINE_IP       I-prime |      |
-  // CUBIC_SPLINE                  |   X  |     X
-  // CUBIC_SPLINE_I        I       |      |
-  // CUBIC_SPLINE_IP       I-prime |      |
-  // PEDESTAL              I       |      |     X
-  // RATIONAL              I       |   X  |     X
-  // LINE_SEGMENT                  |   X  |     X
-  // LINE_SEGMENT_I        I       |      |
-  // LINE_SEGMENT_IP       I-prime |      |
-  // NICE_QUADRATIC                |   X  |
-  // SUM_COSSQ_S           I-prime |      |
-  // SUM_COSSQ_SQRTS       I-prime |      |
-  // SUM_COSSQ_S_FREE      I-prime |      |
-  // clang-format on
-
-  ALL_PARAMS.reserve(NUM_PARAM);
-  ALL_PARAMS.emplace_back("---invalid---", /*allowedForPres=*/false,
-                          /*allowedForCurr*/ false, /*allowedForIota*/ false,
-                          /*needsSplineData*/ false);
-  ALL_PARAMS.emplace_back("power_series", /*allowedForPres=*/true,
-                          /*allowedForCurr*/ true, /*allowedForIota*/ true,
-                          /*needsSplineData*/ false);
-  ALL_PARAMS.emplace_back("power_series_i", /*allowedForPres=*/false,
-                          /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                          /*needsSplineData*/ false);
-  ALL_PARAMS.emplace_back("gauss_trunc", /*allowedForPres=*/true,
-                          /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                          /*needsSplineData*/ false);
-  ALL_PARAMS.emplace_back("sum_atan", /*allowedForPres=*/false,
-                          /*allowedForCurr*/ true, /*allowedForIota*/ true,
-                          /*needsSplineData*/ false);
-  ALL_PARAMS.emplace_back("two_lorentz", /*allowedForPres=*/true,
-                          /*allowedForCurr*/ false, /*allowedForIota*/ false,
-                          /*needsSplineData*/ false);
-  ALL_PARAMS.emplace_back("two_power", /*allowedForPres=*/true,
-                          /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                          /*needsSplineData*/ false);
-  ALL_PARAMS.emplace_back("two_power_gs", /*allowedForPres=*/true,
-                          /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                          /*needsSplineData*/ false);
-  ALL_PARAMS.emplace_back("akima_spline", /*allowedForPres=*/true,
-                          /*allowedForCurr*/ false, /*allowedForIota*/ true,
-                          /*needsSplineData*/ true);
-  ALL_PARAMS.emplace_back("akima_spline_i", /*allowedForPres=*/false,
-                          /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                          /*needsSplineData*/ true);
-  ALL_PARAMS.emplace_back("akima_spline_ip", /*allowedForPres=*/false,
-                          /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                          /*needsSplineData*/ true);
-  ALL_PARAMS.emplace_back("cubic_spline", /*allowedForPres=*/true,
-                          /*allowedForCurr*/ false, /*allowedForIota*/ true,
-                          /*needsSplineData*/ true);
-  ALL_PARAMS.emplace_back("cubic_spline_i", /*allowedForPres=*/false,
-                          /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                          /*needsSplineData*/ true);
-  ALL_PARAMS.emplace_back("cubic_spline_ip", /*allowedForPres=*/false,
-                          /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                          /*needsSplineData*/ true);
-  ALL_PARAMS.emplace_back("pedestal", /*allowedForPres=*/true,
-                          /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                          /*needsSplineData*/ false);
-  ALL_PARAMS.emplace_back("rational", /*allowedForPres=*/true,
-                          /*allowedForCurr*/ true, /*allowedForIota*/ true,
-                          /*needsSplineData*/ false);
-  ALL_PARAMS.emplace_back("line_segment", /*allowedForPres=*/true,
-                          /*allowedForCurr*/ false, /*allowedForIota*/ true,
-                          /*needsSplineData*/ true);
-  ALL_PARAMS.emplace_back("line_segment_i", /*allowedForPres=*/false,
-                          /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                          /*needsSplineData*/ true);
-  ALL_PARAMS.emplace_back("line_segment_ip", /*allowedForPres=*/false,
-                          /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                          /*needsSplineData*/ true);
-  ALL_PARAMS.emplace_back("nice_quadratic", /*allowedForPres=*/false,
-                          /*allowedForCurr*/ false, /*allowedForIota*/ true,
-                          /*needsSplineData*/ false);
-  ALL_PARAMS.emplace_back("sum_cossq_s", /*allowedForPres=*/false,
-                          /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                          /*needsSplineData*/ false);
-  ALL_PARAMS.emplace_back("sum_cossq_sqrts", /*allowedForPres=*/false,
-                          /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                          /*needsSplineData*/ false);
-  ALL_PARAMS.emplace_back("sum_cossq_s_free", /*allowedForPres=*/false,
-                          /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                          /*needsSplineData*/ false);
-}
-
 ProfileParameterization RadialProfiles::findParameterization(
     const std::string& name, ProfileType intendedType) {
   for (int i = 0; i < NUM_PARAM; ++i) {
-    if (name == ALL_PARAMS[i].Name()) {
+    if (name == AllProfileParameterizations()[i].Name()) {
       bool isApplicable = false;
       switch (intendedType) {
         case ProfileType::PRESSURE:
-          isApplicable = ALL_PARAMS[i].IsAllowedFor().pres;
+          isApplicable = AllProfileParameterizations()[i].IsAllowedFor().pres;
           break;
         case ProfileType::CURRENT:
-          isApplicable = ALL_PARAMS[i].IsAllowedFor().curr;
+          isApplicable = AllProfileParameterizations()[i].IsAllowedFor().curr;
           break;
         case ProfileType::IOTA:
-          isApplicable = ALL_PARAMS[i].IsAllowedFor().iota;
+          isApplicable = AllProfileParameterizations()[i].IsAllowedFor().iota;
           break;
         default:
           std::cerr << absl::StrFormat("unknown profile: %s",
@@ -411,7 +308,7 @@ ProfileParameterization RadialProfiles::findParameterization(
       if (!isApplicable) {
         std::cerr << absl::StrFormat(
                          "profile name '%s' is not applicable for %s profile",
-                         ALL_PARAMS[i].Name(),
+                         AllProfileParameterizations()[i].Name(),
                          profileTypeToString(intendedType))
                   << '\n';
         return ProfileParameterization::INVALID_PARAM;
@@ -603,10 +500,11 @@ double RadialProfiles::evalProfileFunction(const ProfileParameterization& param,
     case ProfileParameterization::SUM_COSSQ_SQRTS:
     case ProfileParameterization::SUM_COSSQ_S_FREE:
     default:
-      std::cerr << absl::StrFormat(
-                       "profile parameterization '%s' not implemented yet",
-                       ALL_PARAMS[static_cast<int>(param)].Name())
-                << '\n';
+      std::cerr
+          << absl::StrFormat(
+                 "profile parameterization '%s' not implemented yet",
+                 AllProfileParameterizations()[static_cast<int>(param)].Name())
+          << '\n';
   }
 
   return 0.0;

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.h
@@ -62,7 +62,7 @@ class RadialProfiles {
   // some parameterizations of the current profile need to be radially
   // integrated and some not, which is what `shouldIntegrate` is then used for.
   // Which profile parameterization is integrated and which not is documented in
-  // the body of `RadialProfiles::setupProfileParameterizations`, where `I`
+  // the body of `BuildProfileParameterizations`, where `I`
   // refers to the profile parameterization specifying the enclosed toroidal
   // current profile already (hence no integration is needed), and `I-prime`
   // indicating that the given profile parameterization needs to be integrated.
@@ -192,10 +192,7 @@ class RadialProfiles {
   const int signOfJacobian;
   const double pDamp;
 
-  std::vector<ProfileParameterizationData> ALL_PARAMS;
-
   /** one entry for every value of ProfileParameterization */
-  void setupProfileParameterizations();
 };
 
 }  // namespace vmecpp


### PR DESCRIPTION
A profile parameterization name that VMEC++ does not recognize reaches the solver as a zero profile. The run converges and returns a plausible-looking equilibrium with the wrong physics.

On `solovev`, changing `pmass_type` from `power_series` to the typo `power_serise`:

| input | exit | MHD energy | beta |
| --- | --- | --- | --- |
| unmodified | 0 | 2.548352e+00 | 3.8723e-06 |
| `pmass_type: "power_serise"` | 0 | 2.548362e+00 | 0.0 |
| `pmass_type: "sum_atan"` | 0 | 2.548362e+00 | 0.0 |

`sum_atan` is a real parameterization, but only for the current and iota profiles. Both cases print `profile parameterization '---invalid---' not implemented yet` to stderr and carry on.

`IsConsistent` now rejects both, along with a spline parameterization whose knots are missing or whose `aux_s` and `aux_f` differ in length:

```
input variable 'pmass_type' is 'power_serise', which is not a known profile parameterization
input variable 'pmass_type' is 'sum_atan', which cannot be used for the mass/pressure profile
'pmass_type' is 'cubic_spline', which is a spline profile, so 'am_aux_s' and 'am_aux_f' must be given
```

`piota_type` is checked only for `ncurr == 0` and `pcurr_type` only for `ncurr == 1`, matching where each is consulted.

The polynomial coefficient arrays `am`, `ai` and `ac` are deliberately not required to be non-empty. They are zero-padded on read, so an empty array is a valid way to specify a zero profile, and `near_axis_iota_nfp4` ships that way with `ncurr = 1` and an empty `ac`.

Reaching the parameterization table from `IsConsistent` required moving it out of the private `RadialProfiles::ALL_PARAMS` member into the `profile_parameterization_data` module, behind `AllProfileParameterizations()`, `FindProfileParameterization()` and `IsProfileParameterizationAllowedFor()`. Entry order is unchanged, so `findParameterization` still indexes it by `ProfileParameterization` enumerator. That move accounts for most of the diff.

All sixteen inputs under `vmecpp/test_data` still validate.
