### PR TITLE
ci: skip free-threaded Python 3.14 Intel macOS wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,9 @@ version_file = "src/vmecpp/__about__.py"
 archs = ["native"]
 # jaxlib, a transitive dependency of simsopt, publishes no macOS x86_64 wheels
 # for CPython 3.14, so installing the built wheel to test it cannot resolve
-# there. Intel macOS still builds and tests CPython 3.10-3.13.
-skip = ["*-musllinux*", "cp314-macosx_x86_64"]
+# there. Skip both the GIL and free-threaded variants. Intel macOS still builds
+# and tests CPython 3.10-3.13.
+skip = ["*-musllinux*", "cp314*-macosx_x86_64"]
 build-frontend = "build[uv]" # More modern package manager than pip, with faster builds
 test-requires = "pytest"
 test-command = "pytest {package}/tests/test_simsopt_compat.py {package}/tests/test_free_boundary.py"


### PR DESCRIPTION
Follow-up to #717.

The previous skip matched `cp314-macosx_x86_64`, but cibuildwheel 3.3.1 also selects `cp314t-macosx_x86_64`. That free-threaded wheel builds and then fails its install test because `jaxlib`, pulled in through `simsopt`, has no compatible macOS x86_64 wheel.

Use cibuildwheel's pattern matching to skip both Python 3.14 ABIs on Intel macOS while retaining CPython 3.10-3.13.

Verified with cibuildwheel 3.3.1 `--print-build-identifiers`: the Intel macOS matrix is now exactly cp310, cp311, cp312, and cp313. Pre-commit passes.