### PR TITLE
Allow an odd toroidal grid under stellarator symmetry in makegrid

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib.cc
+++ b/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib.cc
@@ -306,12 +306,11 @@ absl::StatusOr<RowMatrix3Xd> MakeCylindricalGrid(
 
   int num_phi_effective = num_phi;
   if (makegrid_parameters.assume_stellarator_symmetry) {
-    if (num_phi % 2 != 0) {
-      return absl::InvalidArgumentError(absl::StrCat(
-          "number of toroidal grid points has to be even for being able to "
-          "make use to stellarator symmetry in makegrid, but was num_phi=",
-          num_phi));
-    }
+    // Points 0 .. num_phi/2 are computed and the rest are mirrored onto them by
+    // phi -> -phi, which is index num_phi - idx_phi. An even num_phi puts a
+    // grid point on the half-period plane, where that map is the identity; an
+    // odd one has no such point, and every mirrored index still lands inside
+    // the computed range.
     num_phi_effective = num_phi / 2 + 1;
   }
 

--- a/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib_test.cc
@@ -638,6 +638,22 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.normalize_by_currents ? "Scaled" : "Raw";
     });
 
+// An odd toroidal grid puts no point on the half-period plane, so every
+// mirrored index is distinct from every computed one.
+INSTANTIATE_TEST_SUITE_P(
+    SymmetricOdd, CheckComputeMagneticFieldResponseTable,
+    ::testing::Values(MakegridReferenceTestParams{
+        .normalize_by_currents = false,
+        .reference_nc_file = "vmecpp/common/makegrid_lib/test_data/"
+                             "mgrid_test_symmetric_odd.nc",
+        .coils_file =
+            "vmecpp/common/makegrid_lib/test_data/coils.test_symmetric_odd",
+        .assume_stellarator_symmetry = true,
+        .number_of_phi_grid_points = 19}),
+    [](const ::testing::TestParamInfo<MakegridReferenceTestParams>& info) {
+      return info.param.normalize_by_currents ? "Scaled" : "Raw";
+    });
+
 // Parameterized test: vector-potential cache vs. Fortran MAKEGRID reference.
 // Covers both mgrid_mode='R' (raw, normalize_by_currents=false) and
 // mgrid_mode='S' (scaled, normalize_by_currents=true).
@@ -804,11 +820,19 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.normalize_by_currents ? "Scaled" : "Raw";
     });
 
-// TODO(jons): implement test of stellarator-symmetric mgrid file using
-// symmetric C++ implementation. mgrid_test_symmetric_odd.nc is the reference,
-// but MakeCylindricalGrid rejects an odd number_of_phi_grid_points whenever
-// stellarator symmetry is requested, so the half-period mirror needs to handle
-// a grid with no exact midpoint first.
+INSTANTIATE_TEST_SUITE_P(
+    SymmetricOdd, CheckComputeVectorPotentialCache,
+    ::testing::Values(MakegridReferenceTestParams{
+        .normalize_by_currents = false,
+        .reference_nc_file = "vmecpp/common/makegrid_lib/test_data/"
+                             "mgrid_test_symmetric_odd.nc",
+        .coils_file =
+            "vmecpp/common/makegrid_lib/test_data/coils.test_symmetric_odd",
+        .assume_stellarator_symmetry = true,
+        .number_of_phi_grid_points = 19}),
+    [](const ::testing::TestParamInfo<MakegridReferenceTestParams>& info) {
+      return info.param.normalize_by_currents ? "Scaled" : "Raw";
+    });
 
 // TODO(jons): add test of WriteMakegridNetCDFFile
 // -> in particular, make sure that the consistency of number of serial circuits


### PR DESCRIPTION
`MakeCylindricalGrid` rejected an odd `number_of_phi_grid_points` whenever stellarator symmetry was requested. Fortran MAKEGRID accepts that combination, and `mgrid_test_symmetric_odd.nc` is a checked-in reference for it (`LSTELL_SYM = .TRUE.`, `KP = 19`) that no test could use.

The restriction was not needed. Points `0 .. num_phi/2` are computed and the rest are mirrored by `phi -> -phi`, which is index `num_phi - idx_phi`. For an even `num_phi` there is a grid point on the half-period plane where that map is the identity; for an odd one there is not, and every mirrored index still lands inside the computed range. For `num_phi = 19` that is ten computed points, indices 0 to 9, and nine mirrored ones, 10 to 18 onto 9 to 1.

Both suites now run the odd reference, and both match at the tolerance the existing cases use:

```
SymmetricOdd/CheckComputeMagneticFieldResponseTable.MatchesFortranReference/Raw
SymmetricOdd/CheckComputeVectorPotentialCache.MatchesFortranReference/Raw
```

Only the raw variant, since there is no scaled reference for this coil set. All three checked-in makegrid references are now used.
