### PR TITLE
Fix the too-close exclusion mask in the makegrid test and cover it

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/makegrid_lib/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/common/makegrid_lib/BUILD.bazel
@@ -29,6 +29,7 @@ cc_test(
     ],
     deps = [
         ":makegrid_lib",
+        "@abseil-cpp//absl/status:status",
         "@googletest//:gtest_main",
         "//util/file_io",
         "//util/netcdf_io",

--- a/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib_test.cc
@@ -6,10 +6,12 @@
 
 #include <netcdf.h>
 
+#include <cmath>
 #include <string>
 #include <vector>
 
 #include "absl/log/log.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
 #include "gtest/gtest.h"
@@ -236,9 +238,9 @@ absl::Status DetermineIfTooCloseToCurrentCarrierForComparison(
     evaluation_location.set_y(evaluation_locations[i][1]);
     evaluation_location.set_z(evaluation_locations[i][2]);
 
-    // connection vector from evaluation position to center of loop
+    // connection vector from center of loop to evaluation position
     Vector3d delta_eval_origin =
-        Subtract(circular_filament.center(), evaluation_location);
+        Subtract(evaluation_location, circular_filament.center());
 
     // distance between evaluation position and center of loop, parallel to
     // filament direction
@@ -260,7 +262,7 @@ absl::Status DetermineIfTooCloseToCurrentCarrierForComparison(
     const double normalized_rho = evaluation_position_radius / radius;
 
     if (normalized_rho < kRhoMin ||
-        (normalized_z < kZMax && kRhoZMin < normalized_rho &&
+        (std::abs(normalized_z) < kZMax && kRhoZMin < normalized_rho &&
          normalized_rho < kRhoZMax)) {
       m_exclude_from_comparison[i] = true;
     }
@@ -269,8 +271,75 @@ absl::Status DetermineIfTooCloseToCurrentCarrierForComparison(
   return absl::OkStatus();
 }  // DetermineIfTooCloseToCurrentCarrierForComparison
 
-// TODO(jons): write a test for
-// DetermineIfTooCloseToCurrentCarrierForComparison(CircularFilament ...)
+// A unit circular filament in the z = 0 plane, centered on the origin.
+CircularFilament UnitCircularFilament() {
+  CircularFilament circular_filament;
+  circular_filament.set_radius(1.0);
+  circular_filament.mutable_center()->set_x(0.0);
+  circular_filament.mutable_center()->set_y(0.0);
+  circular_filament.mutable_center()->set_z(0.0);
+  circular_filament.mutable_normal()->set_x(0.0);
+  circular_filament.mutable_normal()->set_y(0.0);
+  circular_filament.mutable_normal()->set_z(1.0);
+  return circular_filament;
+}
+
+TEST(TestMakegridLib, CheckTooCloseToCircularFilament) {
+  // Excluded is the loop axis, where e_phi has no defined direction, and a box
+  // of half-width kTooCloseDistance around the wire in both rho' and z'.
+  const std::vector<std::vector<double>> evaluation_locations = {
+      {0.0, 0.0, 0.3},     // on the axis
+      {1.0, 0.0, 0.0},     // on the wire
+      {1.0, 0.0, 0.005},   // just above the wire
+      {1.0, 0.0, -0.005},  // just below the wire
+      {1.0, 0.0, 0.5},     // above the wire, outside the box
+      {1.0, 0.0, -0.5},    // below the wire, outside the box
+      {1.5, 0.0, 0.0},     // outside the loop
+      {0.5, 0.0, 0.0},     // inside the loop
+  };
+  const std::vector<bool> expected = {true,  true,  true,  true,
+                                      false, false, false, false};
+
+  std::vector<bool> exclude_from_comparison(evaluation_locations.size(), false);
+  const absl::Status status = DetermineIfTooCloseToCurrentCarrierForComparison(
+      UnitCircularFilament(), evaluation_locations,
+      /*m_exclude_from_comparison=*/exclude_from_comparison);
+  ASSERT_TRUE(status.ok()) << status;
+
+  for (std::size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_EQ(exclude_from_comparison[i], expected[i]) << "at location " << i;
+  }
+}
+
+TEST(TestMakegridLib, CheckTooCloseToTiltedCircularFilament) {
+  // Same criterion for a loop that is neither centered on the origin nor
+  // aligned with a coordinate axis, and whose normal is not of unit length.
+  CircularFilament circular_filament;
+  circular_filament.set_radius(2.0);
+  circular_filament.mutable_center()->set_x(1.0);
+  circular_filament.mutable_center()->set_y(2.0);
+  circular_filament.mutable_center()->set_z(3.0);
+  circular_filament.mutable_normal()->set_x(0.0);
+  circular_filament.mutable_normal()->set_y(3.0);
+  circular_filament.mutable_normal()->set_z(0.0);
+
+  const std::vector<std::vector<double>> evaluation_locations = {
+      {3.0, 2.0, 3.0},  // on the wire
+      {1.0, 5.0, 3.0},  // on the axis
+      {3.0, 3.0, 3.0},  // at rho' = 1, half a radius off the loop plane
+  };
+  const std::vector<bool> expected = {true, true, false};
+
+  std::vector<bool> exclude_from_comparison(evaluation_locations.size(), false);
+  const absl::Status status = DetermineIfTooCloseToCurrentCarrierForComparison(
+      circular_filament, evaluation_locations,
+      /*m_exclude_from_comparison=*/exclude_from_comparison);
+  ASSERT_TRUE(status.ok()) << status;
+
+  for (std::size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_EQ(exclude_from_comparison[i], expected[i]) << "at location " << i;
+  }
+}
 
 // For a PolygonFilament made up of multiple straight wire segments,
 // check for every segment and an evaluation point at rho' = rho / L, z' = z /
@@ -311,8 +380,8 @@ absl::Status DetermineIfTooCloseToCurrentCarrierForComparison(
       const double length = Length(segment);
       Vector3d direction = Normalize(segment);
 
-      // connection vector from evaluation position to start of segment
-      Vector3d delta_eval_origin = Subtract(origin, evaluation_location);
+      // connection vector from start of segment to evaluation position
+      Vector3d delta_eval_origin = Subtract(evaluation_location, origin);
 
       // distance between evaluation position and segment, parallel to filament
       // direction
@@ -346,8 +415,92 @@ absl::Status DetermineIfTooCloseToCurrentCarrierForComparison(
   return absl::OkStatus();
 }  // DetermineIfTooCloseToCurrentCarrierForComparison
 
-// TODO(jons): write a test for
-// DetermineIfTooCloseToCurrentCarrierForComparison(PolygonFilament ...)
+// A single straight segment of unit length, from the origin along +x.
+PolygonFilament UnitSegmentFilament() {
+  PolygonFilament polygon_filament;
+  Vector3d* start = polygon_filament.add_vertices();
+  start->set_x(0.0);
+  start->set_y(0.0);
+  start->set_z(0.0);
+  Vector3d* end = polygon_filament.add_vertices();
+  end->set_x(1.0);
+  end->set_y(0.0);
+  end->set_z(0.0);
+  return polygon_filament;
+}
+
+TEST(TestMakegridLib, CheckTooCloseToPolygonFilament) {
+  // Excluded is a tube of radius kTooCloseDistance around the segment, running
+  // from z' = -kTooCloseDistance to z' = 1 + kTooCloseDistance.
+  const std::vector<std::vector<double>> evaluation_locations = {
+      {0.5, 0.0, 0.0},     // on the segment
+      {0.5, 0.005, 0.0},   // just off the segment
+      {-0.005, 0.0, 0.0},  // just before the start
+      {1.005, 0.0, 0.0},   // just past the end
+      {0.5, 0.5, 0.0},     // off the segment in rho'
+      {-0.5, 0.0, 0.0},    // on the segment's line, before the start
+      {1.5, 0.0, 0.0},     // on the segment's line, past the end
+  };
+  const std::vector<bool> expected = {true,  true,  true, true,
+                                      false, false, false};
+
+  std::vector<bool> exclude_from_comparison(evaluation_locations.size(), false);
+  const absl::Status status = DetermineIfTooCloseToCurrentCarrierForComparison(
+      UnitSegmentFilament(), evaluation_locations,
+      /*m_exclude_from_comparison=*/exclude_from_comparison);
+  ASSERT_TRUE(status.ok()) << status;
+
+  for (std::size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_EQ(exclude_from_comparison[i], expected[i]) << "at location " << i;
+  }
+}
+
+TEST(TestMakegridLib, CheckTooCloseToPolygonFilamentOverAllSegments) {
+  // Being too close to any one segment is enough, and flags already set by an
+  // earlier current carrier are left alone.
+  PolygonFilament polygon_filament;
+  const std::vector<std::vector<double>> vertices = {
+      {0.0, 0.0, 0.0}, {1.0, 0.0, 0.0}, {1.0, 1.0, 0.0}};
+  for (const std::vector<double>& vertex : vertices) {
+    Vector3d* v = polygon_filament.add_vertices();
+    v->set_x(vertex[0]);
+    v->set_y(vertex[1]);
+    v->set_z(vertex[2]);
+  }
+
+  const std::vector<std::vector<double>> evaluation_locations = {
+      {0.5, 0.0, 0.0},  // on the first segment
+      {1.0, 0.5, 0.0},  // on the second segment
+      {0.5, 0.5, 0.0},  // close to neither
+      {5.0, 5.0, 5.0},  // far away, but already excluded on entry
+  };
+  const std::vector<bool> expected = {true, true, false, true};
+
+  std::vector<bool> exclude_from_comparison = {false, false, false, true};
+  const absl::Status status = DetermineIfTooCloseToCurrentCarrierForComparison(
+      polygon_filament, evaluation_locations,
+      /*m_exclude_from_comparison=*/exclude_from_comparison);
+  ASSERT_TRUE(status.ok()) << status;
+
+  for (std::size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_EQ(exclude_from_comparison[i], expected[i]) << "at location " << i;
+  }
+}
+
+TEST(TestMakegridLib, CheckTooCloseRejectsEmptyEvaluationLocations) {
+  std::vector<bool> exclude_from_comparison;
+
+  EXPECT_EQ(DetermineIfTooCloseToCurrentCarrierForComparison(
+                UnitCircularFilament(), {},
+                /*m_exclude_from_comparison=*/exclude_from_comparison)
+                .code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(DetermineIfTooCloseToCurrentCarrierForComparison(
+                UnitSegmentFilament(), {},
+                /*m_exclude_from_comparison=*/exclude_from_comparison)
+                .code(),
+            absl::StatusCode::kInvalidArgument);
+}
 
 // We need to exclude points which are too close to the current carrier
 // filaments, as the Biot-Savart routines used in MAKEGRID do not feature the
@@ -499,8 +652,14 @@ TEST_P(CheckComputeMagneticFieldResponseTable, MatchesFortranReference) {
   const int number_of_serial_circuits =
       magnetic_configuration->serial_circuits_size();
 
+  // The response table and the reference file both cover the whole field
+  // period, so the exclusion mask has to as well: with stellarator symmetry
+  // MakeCylindricalGrid only emits the half it computes, and the mirrored half
+  // would go uncompared.
+  MakegridParameters full_period_parameters = makegrid_parameters;
+  full_period_parameters.assume_stellarator_symmetry = false;
   absl::StatusOr<RowMatrix3Xd> cylindrical_grid_eigen =
-      MakeCylindricalGrid(makegrid_parameters);
+      MakeCylindricalGrid(full_period_parameters);
   ASSERT_OK(cylindrical_grid_eigen);
   absl::StatusOr<std::vector<std::vector<double>>> cylindrical_grid =
       EigenToStl(cylindrical_grid_eigen.value().transpose());
@@ -560,14 +719,10 @@ TEST_P(CheckComputeMagneticFieldResponseTable, MatchesFortranReference) {
 
     // perform comparison of points that are not explicitly excluded from the
     // comparison
-    // FIXME(jons): allocate `exclude_from_comparison` on the whole field
-    // period and actually check the whole field period.
     int number_of_tested_evaluation_locations = 0;
-    int num_phi_effective = makegrid_parameters.number_of_phi_grid_points;
-    if (makegrid_parameters.assume_stellarator_symmetry) {
-      num_phi_effective = num_phi_effective / 2 + 1;
-    }
-    for (int index_phi = 0; index_phi < num_phi_effective; ++index_phi) {
+    for (int index_phi = 0;
+         index_phi < makegrid_parameters.number_of_phi_grid_points;
+         ++index_phi) {
       for (int index_z = 0;
            index_z < makegrid_parameters.number_of_z_grid_points; ++index_z) {
         for (int index_r = 0;
@@ -656,8 +811,12 @@ TEST_P(CheckComputeVectorPotentialCache, MatchesFortranReference) {
   const int number_of_serial_circuits =
       magnetic_configuration->serial_circuits_size();
 
+  // The exclusion mask has to cover the whole field period; see the same
+  // comment in CheckComputeMagneticFieldResponseTable above.
+  MakegridParameters full_period_parameters = makegrid_parameters;
+  full_period_parameters.assume_stellarator_symmetry = false;
   absl::StatusOr<RowMatrix3Xd> cylindrical_grid_eigen =
-      MakeCylindricalGrid(makegrid_parameters);
+      MakeCylindricalGrid(full_period_parameters);
   ASSERT_OK(cylindrical_grid_eigen);
 
   // MakeCylindricalGrid() returns a 3xN matrix, instead of Nx3, so we tranpose
@@ -728,14 +887,10 @@ TEST_P(CheckComputeVectorPotentialCache, MatchesFortranReference) {
 
     // perform comparison of points that are not explicitly excluded from the
     // comparison
-    // FIXME(jons): allocate `exclude_from_comparison` on the whole field
-    // period and actually check the whole field period.
     int number_of_tested_evaluation_locations = 0;
-    int num_phi_effective = makegrid_parameters.number_of_phi_grid_points;
-    if (makegrid_parameters.assume_stellarator_symmetry) {
-      num_phi_effective = num_phi_effective / 2 + 1;
-    }
-    for (int index_phi = 0; index_phi < num_phi_effective; ++index_phi) {
+    for (int index_phi = 0;
+         index_phi < makegrid_parameters.number_of_phi_grid_points;
+         ++index_phi) {
       for (int index_z = 0;
            index_z < makegrid_parameters.number_of_z_grid_points; ++index_z) {
         for (int index_r = 0;


### PR DESCRIPTION
Both overloads of `DetermineIfTooCloseToCurrentCarrierForComparison` build the connection vector as `origin - eval`, while the comment above it and the criteria below read it as `eval - origin`, so `normalized_z` carries the wrong sign.

Circular filament: `normalized_z < kZMax` becomes `z' > -kTooCloseDistance`, unbounded above, so the excluded band is everything above the loop plane inside the `rho'` band.

Polygon filament: `kZRhoMin < normalized_z && normalized_z < kZRhoMax` selects the mirror image of the segment behind its start vertex. Points on the wire are not excluded, and points an equal distance behind the start are.

Both `MatchesFortranReference` suites pass today only because no grid point of these coil sets lands within 1% of a wire, and `EXPECT_GT(tested_fraction, 0.99)` guards against over-exclusion only, so the polygon case is invisible to it.

The circular band becomes `std::abs(normalized_z) < kZMax`, a box of half-width `kTooCloseDistance` around the wire in both `rho'` and `z'`. The polygon criterion is then correct as written. Both connection vectors are computed as `eval - origin`, so the two overloads agree.

The two `FIXME(jons)`: `exclude_from_comparison` was built from what `MakeCylindricalGrid` returns, which under stellarator symmetry is only the half period it computes, so both comparison loops stopped at `num_phi/2 + 1`. The response table and the reference file cover the whole field period, so the mirrored half went uncompared. The mask is now built on the full period and both loops run to `number_of_phi_grid_points`. Flipping the sign of the mirrored `b_p` in `makegrid_lib.cc` now fails both suites; it did not before.

Five tests for the two overloads: a unit loop, and a tilted off-center loop with a non-unit normal; a single segment, and an L-shaped two-segment filament, including that a flag set by an earlier current carrier is left alone; and the empty-input rejection.
