### PR TITLE
Fix the toroidal mirror of the magnetic axis guess for an odd nZeta

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/BUILD.bazel
@@ -29,6 +29,26 @@ cc_library(
 )
 
 cc_test(
+    name = "guess_magnetic_axis_test",
+    srcs = ["guess_magnetic_axis_test.cc"],
+    data = [
+        "//vmecpp/test_data:cma",
+        "//vmecpp/test_data:cth_like_fixed_bdy",
+        "//vmecpp/test_data:cth_like_fixed_bdy_nzeta_37",
+        "//vmecpp/test_data:solovev",
+    ],
+    deps = [
+        ":boundaries",
+        ":guess_magnetic_axis",
+        "//vmecpp/vmec/vmec_constants:vmec_constants",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings:str_format",
+        "@googletest//:gtest_main",
+    ],
+    size = "small",
+)
+
+cc_test(
     name = "boundaries_test",
     srcs = ["boundaries_test.cc"],
     data = [

--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/guess_magnetic_axis.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/guess_magnetic_axis.cc
@@ -454,7 +454,11 @@ RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
   // in order to always have a full toroidal module for the Fourier transform
   // below
   if (!s.lasym) {
-    for (int k = 1; k < s.nZeta / 2; ++k) {
+    // The search above covered 0 .. nZeta / 2. Every remaining plane is the
+    // mirror image of one of those: for an even number of toroidal grid points
+    // the half-period plane is its own mirror and is already done, for an odd
+    // number it is not, and its mirror is the first plane past the half period.
+    for (int k = 1; k <= (s.nZeta - 1) / 2; ++k) {
       const int k_reversed = (s.nZeta - k) % s.nZeta;
       w.new_r_axis[k_reversed] = w.new_r_axis[k];
       w.new_z_axis[k_reversed] = -w.new_z_axis[k];

--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/guess_magnetic_axis.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/guess_magnetic_axis.cc
@@ -454,10 +454,7 @@ RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
   // in order to always have a full toroidal module for the Fourier transform
   // below
   if (!s.lasym) {
-    // The search above covered 0 .. nZeta / 2. Every remaining plane is the
-    // mirror image of one of those: for an even number of toroidal grid points
-    // the half-period plane is its own mirror and is already done, for an odd
-    // number it is not, and its mirror is the first plane past the half period.
+    // mirror image along zeta, for even and odd nZeta
     for (int k = 1; k <= (s.nZeta - 1) / 2; ++k) {
       const int k_reversed = (s.nZeta - k) % s.nZeta;
       w.new_r_axis[k_reversed] = w.new_r_axis[k];

--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/guess_magnetic_axis_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/guess_magnetic_axis_test.cc
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+// <info@proximafusion.com>
+//
+// SPDX-License-Identifier: MIT
+#include "vmecpp/vmec/boundaries/guess_magnetic_axis.h"
+
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "gtest/gtest.h"
+#include "vmecpp/common/fourier_basis_fast_poloidal/fourier_basis_fast_poloidal.h"
+#include "vmecpp/common/sizes/sizes.h"
+#include "vmecpp/common/vmec_indata/vmec_indata.h"
+#include "vmecpp/vmec/boundaries/boundaries.h"
+#include "vmecpp/vmec/vmec_constants/vmec_algorithm_constants.h"
+
+namespace vmecpp {
+
+namespace {
+using ::testing::TestWithParam;
+using ::testing::Values;
+
+struct AxisGuessCase {
+  std::string identifier;
+  int number_of_flux_surfaces;
+};
+}  // namespace
+
+// The axis guess is reached from Vmec::SolveEquilibrium when the initial
+// Jacobian changes sign, on whatever boundary the run was given. The set-up
+// here is the solver's own: parse the input, build the basis, and let
+// Boundaries fill the boundary and initial-axis coefficient arrays.
+class GuessMagneticAxisTest : public TestWithParam<AxisGuessCase> {
+ protected:
+  void SetUp() override {
+    const absl::StatusOr<VmecINDATA> indata = VmecINDATA::FromFile(
+        absl::StrFormat("vmecpp/test_data/%s.json", GetParam().identifier));
+    ASSERT_TRUE(indata.ok()) << indata.status();
+    indata_ = *indata;
+
+    sizes_.emplace(indata_);
+    fourier_basis_.emplace(&sizes_.value());
+    boundaries_.emplace(&sizes_.value(), &fourier_basis_.value(),
+                        vmec_algorithm_constants::kSignOfJacobian);
+    // The return value says whether theta had to be flipped, not whether the
+    // set-up succeeded.
+    boundaries_->setupFromIndata(indata_, /*verbose=*/false);
+  }
+
+  RecomputeAxisWorkspace Recompute() const {
+    return RecomputeMagneticAxisToFixJacobianSign(
+        GetParam().number_of_flux_surfaces,
+        vmec_algorithm_constants::kSignOfJacobian, sizes_.value(),
+        fourier_basis_.value(), boundaries_->rbcc, boundaries_->rbss,
+        boundaries_->rbsc, boundaries_->rbcs, boundaries_->zbsc,
+        boundaries_->zbcs, boundaries_->zbcc, boundaries_->zbss,
+        boundaries_->raxis_c, boundaries_->raxis_s, boundaries_->zaxis_s,
+        boundaries_->zaxis_c);
+  }
+
+  VmecINDATA indata_;
+  std::optional<Sizes> sizes_;
+  std::optional<FourierBasisFastPoloidal> fourier_basis_;
+  std::optional<Boundaries> boundaries_;
+};
+
+TEST_P(GuessMagneticAxisTest, CheckAxisGuessLiesInsideTheBoundary) {
+  const RecomputeAxisWorkspace w = Recompute();
+
+  for (int k = 0; k < sizes_->nZeta; ++k) {
+    const double min_r =
+        *std::min_element(w.r_lcfs[k].begin(), w.r_lcfs[k].end());
+    const double max_r =
+        *std::max_element(w.r_lcfs[k].begin(), w.r_lcfs[k].end());
+    const double min_z =
+        *std::min_element(w.z_lcfs[k].begin(), w.z_lcfs[k].end());
+    const double max_z =
+        *std::max_element(w.z_lcfs[k].begin(), w.z_lcfs[k].end());
+
+    EXPECT_GT(w.new_r_axis[k], min_r) << "plane " << k;
+    EXPECT_LT(w.new_r_axis[k], max_r) << "plane " << k;
+    EXPECT_GE(w.new_z_axis[k], min_z) << "plane " << k;
+    EXPECT_LE(w.new_z_axis[k], max_z) << "plane " << k;
+  }  // k
+}
+
+TEST_P(GuessMagneticAxisTest, CheckStellaratorSymmetryMirrorsTheAxisGuess) {
+  ASSERT_FALSE(sizes_->lasym);
+  const RecomputeAxisWorkspace w = Recompute();
+
+  // Only the planes from 0 to nZeta / 2 are searched; the rest follow from
+  // zeta -> -zeta, which is index nZeta - k.
+  for (int k = 1; k < sizes_->nZeta; ++k) {
+    const int k_reversed = sizes_->nZeta - k;
+    if (k >= k_reversed) {
+      continue;
+    }
+    EXPECT_EQ(w.new_r_axis[k_reversed], w.new_r_axis[k]) << "plane " << k;
+    EXPECT_EQ(w.new_z_axis[k_reversed], -w.new_z_axis[k]) << "plane " << k;
+  }  // k
+
+  // The zeta = 0 plane is its own mirror image, so the axis sits in the
+  // symmetry plane there.
+  EXPECT_EQ(w.new_z_axis[0], 0.0);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TestGuessMagneticAxis, GuessMagneticAxisTest,
+    Values(
+        // axisymmetric: ntor = 0, so nZeta = 1 and there is one plane
+        AxisGuessCase{.identifier = "solovev", .number_of_flux_surfaces = 5},
+        // nzeta left to the default 2 * ntor + 4, so nZeta = 16
+        AxisGuessCase{.identifier = "cma", .number_of_flux_surfaces = 15},
+        // even nZeta = 36, with a grid point on the half-period plane
+        AxisGuessCase{.identifier = "cth_like_fixed_bdy",
+                      .number_of_flux_surfaces = 15},
+        // odd nZeta = 37, with no grid point on the half-period plane
+        AxisGuessCase{.identifier = "cth_like_fixed_bdy_nzeta_37",
+                      .number_of_flux_surfaces = 15}));
+
+}  // namespace vmecpp


### PR DESCRIPTION
`RecomputeMagneticAxisToFixJacobianSign` searches the toroidal planes from 0 to `nZeta / 2` and fills the rest by the mirror `zeta -> -zeta`, index `nZeta - k`. The mirror loop runs `k < nZeta / 2`, which is one short for an odd `nZeta`: at `nZeta = 37` it writes planes 36 down to 20 and leaves plane 19 at the zero from `resize`, which then enters the toroidal Fourier transform of the new axis. `cth_like_fixed_bdy_nzeta_37` has that resolution.

The bound becomes `k <= (nZeta - 1) / 2`. Even `nZeta` is unaffected, where the half-period plane is its own mirror and is already covered by the search.

`guess_magnetic_axis.cc` had no test, although the comment at the call site in `boundaries.cc` says it was split out of `Boundaries` for that purpose. Two are added, over `solovev` (`nZeta = 1`), `cma` (16), `cth_like_fixed_bdy` (36) and `cth_like_fixed_bdy_nzeta_37` (37): the guess lies inside the boundary in every plane, and the mirror relation holds with the axis in the symmetry plane at `zeta = 0`. Both fail on the old bound. No existing test does.
