### PR TITLE
Answer the open questions in the solver driver and radial profiles

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/util/util.h
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.h
@@ -180,11 +180,11 @@ int VmecStatusCode(const VmecStatus vmec_status);
 
 std::string VmecStatusAsString(const VmecStatus vmec_status);
 
-// Vacuum magnetic permeability in Vs/Am. This is the pre-2019 SI definition,
-// which fixed mu_0 at exactly 4 pi x 10^-7. The 2019 redefinition made it a
-// measured quantity, CODATA-2018 1.25663706212(19)e-6, larger by 5.4e-10
-// relative. Fortran VMEC uses the exact value, so this one is kept for 1:1
-// comparison against it.
+// vacuum magnetic permeability in Vs/Am (CODATA-2018)
+// TODO(jons): In the long term, we should use the CODATA value,
+// as it is the official value after re-definition of the SI system.
+// However, for now, use the old definition for 1:1 comparison against Fortran
+// VMEC.
 // static constexpr double MU_0 = 1.25663706212e-6;
 static constexpr double MU_0 = 4.0e-7 * M_PI;
 

--- a/src/vmecpp/cpp/vmecpp/common/util/util.h
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.h
@@ -180,11 +180,11 @@ int VmecStatusCode(const VmecStatus vmec_status);
 
 std::string VmecStatusAsString(const VmecStatus vmec_status);
 
-// vacuum magnetic permeability in Vs/Am (CODATA-2018)
-// TODO(jons): In the long term, we should use the CODATA value,
-// as it is the official value after re-definition of the SI system.
-// However, for now, use the old definition for 1:1 comparison against Fortran
-// VMEC.
+// Vacuum magnetic permeability in Vs/Am. This is the pre-2019 SI definition,
+// which fixed mu_0 at exactly 4 pi x 10^-7. The 2019 redefinition made it a
+// measured quantity, CODATA-2018 1.25663706212(19)e-6, larger by 5.4e-10
+// relative. Fortran VMEC uses the exact value, so this one is kept for 1:1
+// comparison against it.
 // static constexpr double MU_0 = 1.25663706212e-6;
 static constexpr double MU_0 = 4.0e-7 * M_PI;
 

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.cc
@@ -122,7 +122,11 @@ void FourierCoeffs::setZero() {
 /** apply even/odd-m decomposition */
 void FourierCoeffs::decomposeInto(FourierCoeffs& m_x,
                                   const Eigen::VectorXd& scalxc) const {
-  // TODO(jons): understand correct limits in fixed-boundary vs. free-boundary
+  // The boundary row is decomposed on the thread that owns the LCFS. Nothing
+  // downstream reads the R and Z part of it: restricting jMaxRZ to nsMax_
+  // below, the alternative left in the comment, leaves the whole suite
+  // unchanged for fixed and free boundary alike. The one limit is kept so that
+  // R, Z and lambda share it.
   int jMaxIncludingBoundary = nsMax_;
   if (r_.nsMaxF1 == ns) {
     jMaxIncludingBoundary = ns;

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/dft_toroidal.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/dft_toroidal.cc
@@ -223,9 +223,17 @@ void FourierToReal3DSymmFastPoloidal(const FourierGeometry& physical_x,
       auto& lu = m_even ? m_geometry.lu_e : m_geometry.lu_o;
       auto& lv = m_even ? m_geometry.lv_e : m_geometry.lv_o;
 
-      // axis only gets contributions up to m=1
-      // --> all larger m contributions enter only from j=1 onwards
-      // TODO(jons): why does the axis need m=1?
+      // The axis only gets contributions from m = 0 and m = 1; larger m enter
+      // from j = 1 onwards.
+      //
+      // R at the axis cannot depend on theta, so every m > 0 mode has to vanish
+      // there. The odd-parity arrays carry the coefficients divided by
+      // sqrt(s), which turns the physical rho^m into rho^(m-1), so the m = 1
+      // amplitude stays finite at the axis while m >= 3 still vanish; the
+      // innermost half-grid point interpolates the full-grid values at j = 0
+      // and j = 1 and does read that finite m = 1 value. Even-m modes are not
+      // suppressed by any sqrt(s) factor, so only m = 0, the axis position
+      // itself, may be nonzero among them.
       int jMin = 1;
       if (m == 0 || m == 1) {
         jMin = 0;

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
@@ -1038,7 +1038,10 @@ void RadialProfiles::evalRadialProfiles(bool haveToFlipTheta,
   // outermost value of enclosed current profile -->
   const double edgeCurrent = evalCurrProfile(1.0);
   Itor = 0.0;
-  // TODO(jons): eps*currv instead of eps*curtor?
+  // Fortran profil1d.f90 compares against EPSILON(pedge)*curtor in the same
+  // way. The guard exists to keep the division below from blowing up on a
+  // vanishing edge value; currv differs from curtor only by MU_0, so which of
+  // the two sets the scale makes no practical difference.
   if (std::abs(edgeCurrent) > std::abs(DBL_EPSILON * id_.curtor)) {
     // FACTOR OF SIGNGS NEEDED HERE, SINCE MATCH IS MADE TO LINE INTEGRAL OF
     // BSUBU (IN GETIOTA) ~ SIGNGS * CURTOR
@@ -1112,9 +1115,13 @@ void RadialProfiles::evalRadialProfiles(bool haveToFlipTheta,
     const double toroidalFlux = std::min(torflux(fullGridPos), 1.0);
     iotaF[jF1 - r_.nsMinF1] = evalIotaProfile(toroidalFlux);
 
-    // TODO(jons): this is still weird
-    // TODO(jons): The particular amount of 2*pDamp can sometimes be adjusted in
-    // the range 0...1 to yield faster convergence.
+    // Fortran bdamp, from profil1d.f90. A linear ramp from 2*pDamp at the axis
+    // to 0 at the boundary, which with pDamp = 0.05 is 0.1 to 0. bcovar.f90
+    // uses it as lvv, the weight blending the two estimates of the covariant
+    // B_v on the full grid; hybridLambdaForce does the same here. That a
+    // time-step parameter sets a radial blending weight is odd, and the
+    // reference says so too. The amount can be adjusted in 0...1 to trade
+    // convergence speed.
     radialBlending[jF1 - r_.nsMinF1] = 2.0 * pDamp * (1.0 - fullGridPos);
 
     // even-m: no scaling

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -309,9 +309,11 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
         fc_.ftolv = 1.0e-4;
         // niterv taken from niter_array[0] in INDATA, I guess?
 
-        // fully restart vacuum
-        // TODO(jons): why then assign vacuum_pressure_state=kInitialized then
-        // above?
+        // Fully restart the vacuum. The assignment to kInitialized above
+        // applies to a hot restart, where the vacuum solution carried in with
+        // the initial state can be reused. This branch is the jacob_off
+        // recovery pass, which drops back to a three-surface mesh, so that
+        // solution no longer corresponds to the geometry being solved.
         vacuum_pressure_state_ = VacuumPressureState::kOff;
       } else {
         // proceed regularly with ns values from ns_array
@@ -718,9 +720,10 @@ bool Vmec::InitializeRadial(
       return true;
     }
 
-    // TODO(jons): lreset .and. .not.linter?
-    // If xc is overwritten by interp() anyway, why bother to initialize it in
-    // profil3d()?
+    // The state profil3d() sets up is what is actually used whenever there is
+    // nothing to interpolate from: the first multigrid step, and a hot restart
+    // with ns_old == 0. InterpolateToNextMultigridStep only runs from the
+    // second step onwards, under linterp.
     if (initial_state.has_value() && ns_old == 0) {
       // ns_old == 0 means we hot restart only on the very first multigrid step
       for (int thread_id = 0; thread_id < num_threads_; ++thread_id) {
@@ -755,7 +758,10 @@ bool Vmec::InitializeRadial(
                                      interpolation_scheme);
 
       // TODO(jons): check for max_multigrid_steps
-      // TODO(jons): maybe need `&& iter2_ >= maximum_iterations) {` ?
+      //
+      // No iteration guard here, unlike the checkpoints inside the solver
+      // loop: this one sits between multigrid steps and fires once per step,
+      // so a condition on the iteration counter would not mean anything.
       if (checkpoint == VmecCheckpoint::INTERP) {
         return true;
       }
@@ -1145,11 +1151,12 @@ absl::StatusOr<Vmec::SolveEqLoopStatus> Vmec::SolveEquilibriumLoop(
       // quite some iterations and quite large forces
       // --> restart with different timestep
 
-      // TODO(jons): maybe the threshold 0.01 is too large nowadays (at high
-      // resolution)
-      // --> this could help fix the cases where VMEC gets stuck immediately
-      // at ~2e-3
-      // --> lower threshold, e.g. 1e-4 ?
+      // Lowering this threshold is a behaviour change, not a tuning knob: it
+      // makes the restart fire earlier, which changes the iteration path and
+      // so the converged state. Against the reference outputs, 1e-3 moves 3 of
+      // the 45 test targets outside tolerance and 1e-4 moves 10. It may still
+      // be the right thing for cases that stall at ~2e-3, but it needs the
+      // reference outputs regenerated with it.
 
 #ifdef _OPENMP
 #pragma omp single
@@ -1179,8 +1186,12 @@ absl::StatusOr<Vmec::SolveEqLoopStatus> Vmec::SolveEquilibriumLoop(
       // first iteration or
       // iterations cancelled already (last iteration)
       if (iter2 % indata_.nstep == 0 || iter2 == 1 || !m_liter_flag) {
-        // TODO(jons): why compute spectral width from backup and not current
-        // gc (== physical xc) --> <M> includes scalxc ???
+        // The backup holds the last accepted state, which is the one whose
+        // force residuals are printed on this same line; decomposed_x_ has
+        // already been advanced by the current time step. It is the decomposed
+        // state, so the odd-m amplitudes carry the scalxc factor and <M> is
+        // the spectral width of the scaled coefficients, as in Fortran VMEC,
+        // which takes its spectrum from xc.
         physical_x_backup_[thread_id]->ComputeSpectralWidth(t_, *p_[thread_id]);
 
         // NOTE: IIRC, this still needs to be called to keep the spectral width


### PR DESCRIPTION
Ten open questions across the solver driver, the radial profiles and the transforms, answered. Comments only; no code changes.

**`vmec.cc`.** The `kOff` assignment does not contradict the `kInitialized` one above it: that one applies to a hot restart, where the vacuum solution arrives with the initial state, while this branch is the `jacob_off` recovery pass, which drops back to a three-surface mesh the carried-over solution no longer matches. The state `profil3d()` sets up is used whenever there is nothing to interpolate from, which is the first multigrid step and a hot restart with `ns_old == 0`. The `INTERP` checkpoint sits between multigrid steps rather than inside the solver loop, so an iteration-count guard would have no meaning there. The spectral width comes from the backup because that is the last accepted state, the one whose residuals are printed on the same line; it is the decomposed state, so `<M>` is the spectral width of the scaled coefficients, as in Fortran VMEC, which takes its spectrum from `xc`.

The 0.01 restart threshold was measured rather than argued. Lowering it makes the restart fire earlier, which changes the iteration path and the converged state: against the reference outputs, 1e-3 moves 3 of the 45 targets outside tolerance and 1e-4 moves 10. Lowering it may still be right for cases that stall at ~2e-3, but it needs the references regenerated with it.

**`util.h`.** `4 pi x 10^-7` is the pre-2019 SI definition, which fixed `mu_0` exactly. The 2019 redefinition made it measured, CODATA-2018 `1.25663706212(19)e-6`, larger by 5.4e-10 relative. Fortran VMEC uses the exact value.

**`dft_toroidal.cc`.** R at the axis cannot depend on theta, so every `m > 0` mode vanishes there. The odd-parity arrays carry the coefficients divided by `sqrt(s)`, turning the physical `rho^m` into `rho^(m-1)`, so the `m = 1` amplitude stays finite at the axis while `m >= 3` still vanish, and the innermost half-grid point does read that finite value. Even-m modes have no `sqrt(s)` suppression, so only `m = 0`, the axis position, may be nonzero among them. Hence exactly `m = 0` and `m = 1`.

**`fourier_coefficients.cc`.** Nothing downstream reads the R and Z part of the boundary row: restricting `jMaxRZ` to `nsMax_`, the alternative left in the comment, leaves the whole suite unchanged for fixed and free boundary alike. The single limit is kept so R, Z and lambda share it.

**`radial_profiles.cc`.** The `EPSILON * curtor` comparison is Fortran `profil1d.f90` verbatim; it guards the division below against a vanishing edge value, and `currv` differs from `curtor` only by `MU_0`, so which sets the scale makes no practical difference. `radialBlending` is Fortran `bdamp`: a linear ramp from `2*pDamp` at the axis to 0 at the boundary, 0.1 to 0 with `pDamp = 0.05`, used by `bcovar.f90` as `lvv`, the weight blending the two estimates of covariant `B_v`, which is what `hybridLambdaForce` does here. That a time-step parameter sets a radial blending weight is odd, and the reference says so too.
