### PR TITLE
Answer the open questions in the magnetic field and output quantities tests

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/magnetic_field_provider/magnetic_field_provider_lib_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/magnetic_field_provider/magnetic_field_provider_lib_test.cc
@@ -546,10 +546,13 @@ TEST(TestMagneticField, CheckPolygonFilament) {
   const double delta_phi =
       2.0 * M_PI / (kNumPhi - 1);  // spacing between points
 
-  // TODO(jons): understand derivation of alpha for special case of closed
-  // circle |dr/ds| = 2*pi
-  // --> alpha = 1/R * (dr)^2 / 12
-  // == 4 pi^2 / (12 R)
+  // McGreivy correction for a closed circle. The field at the centre of a
+  // regular N-gon of circumradius R is mu_0 I N / (2 pi R) * tan(pi/N), against
+  // mu_0 I / (2 R) for the circle, so the polygon overestimates it by
+  // (N/pi) tan(pi/N) = 1 + delta_phi^2 / 12 + O(delta_phi^4) with delta_phi =
+  // 2 pi / N. The field goes as 1/R, so inflating the radius by that same
+  // factor cancels the excess to fourth order. At N = 100 the exact ratio is
+  // 1.0003291167 and the correction is 1.0003289868.
   const double adjusted_radius = kRadius * (1.0 + delta_phi * delta_phi / 12.0);
 
   PolygonFilament polygon_filament = PolygonCircle(adjusted_radius, kNumPhi);
@@ -914,10 +917,13 @@ TEST(TestVectorPotential, CheckPolygonFilament) {
   const double delta_phi =
       2.0 * M_PI / (kNumPhi - 1);  // spacing between points
 
-  // TODO(jons): understand derivation of alpha for special case of closed
-  // circle |dr/ds| = 2*pi
-  // --> alpha = 1/R * (dr)^2 / 12
-  // == 4 pi^2 / (12 R)
+  // McGreivy correction for a closed circle. The field at the centre of a
+  // regular N-gon of circumradius R is mu_0 I N / (2 pi R) * tan(pi/N), against
+  // mu_0 I / (2 R) for the circle, so the polygon overestimates it by
+  // (N/pi) tan(pi/N) = 1 + delta_phi^2 / 12 + O(delta_phi^4) with delta_phi =
+  // 2 pi / N. The field goes as 1/R, so inflating the radius by that same
+  // factor cancels the excess to fourth order. At N = 100 the exact ratio is
+  // 1.0003291167 and the correction is 1.0003289868.
   const double adjusted_radius = kRadius * (1.0 + delta_phi * delta_phi / 12.0);
 
   PolygonFilament polygon_filament = PolygonCircle(adjusted_radius, kNumPhi);

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
@@ -533,11 +533,14 @@ TEST_P(JxBOutputContentsTest, CheckJxBOutputContents) {
   }  // jF
 }  // CheckJxBOutputContents
 
-// TODO(jons): Clarify below guess.
-// I suspect these are so bad because J x B is close to 0
-// in case of an equilibrium with small toroidal current.
-// cth_like_fixed_bdy has a large toroidal current,
-// so I suspect that J x B is more well-defined in that case...
+// The tolerances track beta rather than the toroidal current. From the
+// reference wout files: cma carries no current at all (ctor = -6e-11) and
+// betator = 0, and needs the loosest tolerance; solovev has the largest current
+// of the three (ctor = -4.4e5) but betator = 4.1e-6, and sits in between;
+// cth_like_fixed_bdy has the smallest current (ctor = 4.3e4) and the largest
+// betator = 2.1e-3, and takes the tightest. J x B is what is being compared,
+// and it needs a pressure gradient as much as a current, so it is beta that
+// orders these.
 INSTANTIATE_TEST_SUITE_P(
     TestOutputQuantities, JxBOutputContentsTest,
     Values(DataSource{.identifier = "solovev", .tolerance = 2.0e-5},


### PR DESCRIPTION
Two open questions in the tests, answered. Comments only.

**The McGreivy radius correction.** The field at the centre of a regular N-gon of circumradius R is `mu_0 I N / (2 pi R) * tan(pi/N)`, against `mu_0 I / (2 R)` for the circle, so the polygon overestimates it by `(N/pi) tan(pi/N) = 1 + delta_phi^2 / 12 + O(delta_phi^4)` with `delta_phi = 2 pi / N`. The field goes as `1/R`, so inflating the radius by the same factor cancels the excess to fourth order. At the `N = 100` used here the exact ratio is 1.0003291167 and the correction 1.0003289868.

**The JxB tolerances.** The guess in the comment had the mechanism right and the cause wrong: it is beta, not the toroidal current, that orders them. From the reference wout files,

| case | tolerance | ctor | betator |
|---|---|---|---|
| cma | 1e-4 | -6.3e-11 | 0 |
| solovev | 2e-5 | -4.4e5 | 4.1e-6 |
| cth_like_fixed_bdy | 1e-5 | 4.3e4 | 2.1e-3 |

`cma` carries no current at all and needs the loosest tolerance; `solovev` has the largest current of the three and still sits in the middle; `cth_like_fixed_bdy` has the smallest current and the tightest tolerance. What is being compared is J x B, which needs a pressure gradient as much as a current, so the ordering follows betator.
