### PR TITLE
Resolve the stale and unanswered markers across the solver

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/magnetic_field_provider/magnetic_field_provider_lib_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/magnetic_field_provider/magnetic_field_provider_lib_test.cc
@@ -370,10 +370,8 @@ TEST(TestMagneticField, CheckCircularFilament) {
   static constexpr int kNumEvaluationLocations = 30;
 
   // centered at the origin, normal along z axis
-  std::vector<double> center = {
-      0.0, 0.0, 0.0};  // TODO(jons): make const once ABSCAB supports this
-  std::vector<double> normal = {
-      0.0, 0.0, 1.0};  // TODO(jons): make const once ABSCAB supports this
+  const std::vector<double> center = {0.0, 0.0, 0.0};
+  const std::vector<double> normal = {0.0, 0.0, 1.0};
 
   CircularFilament circular_filament;
 
@@ -457,10 +455,10 @@ TEST(TestMagneticField, CheckCircularFilamentAgainstDirectAbscab) {
   static constexpr double kRadius = 2.71;
   static constexpr int kNumEvaluationLocations = 3;
 
-  std::vector<double> center = {
-      1.23, 4.56, 7.89};  // TODO(jons): make const once ABSCAB supports this
-  std::vector<double> normal = {
-      9.87, 6.54, 3.21};  // TODO(jons): make const once ABSCAB supports this
+  // not const: abscab takes double*, and this pair is handed to it directly
+  // below
+  std::vector<double> center = {1.23, 4.56, 7.89};
+  std::vector<double> normal = {9.87, 6.54, 3.21};
 
   CircularFilament circular_filament;
 
@@ -580,6 +578,8 @@ TEST(TestMagneticField, CheckPolygonFilament) {
   // ABSCAB
   std::vector<double> magnetic_field_reference(kNumEvaluationLocations * 3,
                                                0.0);
+  // not const: abscab takes double*, and this pair is handed to it directly
+  // below
   std::vector<double> center = {0.0, 0.0, 0.0};
   std::vector<double> normal = {0.0, 0.0, 1.0};
   abscab::magneticFieldCircularFilament(
@@ -823,10 +823,10 @@ TEST(TestVectorPotential, CheckCircularFilamentAgainstDirectAbscab) {
   static constexpr double kRadius = 2.71;
   static constexpr int kNumEvaluationLocations = 3;
 
-  std::vector<double> center = {
-      1.23, 4.56, 7.89};  // TODO(jons): make const once ABSCAB supports this
-  std::vector<double> normal = {
-      9.87, 6.54, 3.21};  // TODO(jons): make const once ABSCAB supports this
+  // not const: abscab takes double*, and this pair is handed to it directly
+  // below
+  std::vector<double> center = {1.23, 4.56, 7.89};
+  std::vector<double> normal = {9.87, 6.54, 3.21};
 
   CircularFilament circular_filament;
 
@@ -948,6 +948,8 @@ TEST(TestVectorPotential, CheckPolygonFilament) {
   // ABSCAB
   std::vector<double> vector_potential_reference(kNumEvaluationLocations * 3,
                                                  0.0);
+  // not const: abscab takes double*, and this pair is handed to it directly
+  // below
   std::vector<double> center = {0.0, 0.0, 0.0};
   std::vector<double> normal = {0.0, 0.0, 1.0};
 
@@ -1135,10 +1137,8 @@ MagneticConfiguration MakeMagneticConfiguration(
   static constexpr double kRadius = 2.71;
 
   // centered at the origin, normal along z axis
-  std::vector<double> center = {
-      0.0, 0.0, 0.0};  // TODO(jons): make const once ABSCAB supports this
-  std::vector<double> normal = {
-      0.0, 0.0, 1.0};  // TODO(jons): make const once ABSCAB supports this
+  const std::vector<double> center = {0.0, 0.0, 0.0};
+  const std::vector<double> normal = {0.0, 0.0, 1.0};
 
   SerialCircuit *serial_circuit_1 =
       magnetic_configuration.add_serial_circuits();
@@ -1972,10 +1972,8 @@ class MagneticFieldNumWindingsTest : public Test {
   void SetNumWindings(int num_windings) {
     coil_->set_num_windings(num_windings);
   }
-  std::vector<double> center_ = {
-      1.23, 4.56, 7.89};  // TODO(jons): make const once ABSCAB supports this
-  std::vector<double> normal_ = {
-      9.87, 6.54, 3.21};  // TODO(jons): make const once ABSCAB supports this
+  std::vector<double> center_ = {1.23, 4.56, 7.89};
+  std::vector<double> normal_ = {9.87, 6.54, 3.21};
   MagneticConfiguration magnetic_configuration_;
   Coil *coil_;
   std::vector<std::vector<double> > evaluation_positions_;
@@ -2264,10 +2262,8 @@ class VectorPotentialNumWindingsTest : public Test {
   void SetNumWindings(int num_windings) {
     coil_->set_num_windings(num_windings);
   }
-  std::vector<double> center_ = {
-      1.23, 4.56, 7.89};  // TODO(jons): make const once ABSCAB supports this
-  std::vector<double> normal_ = {
-      9.87, 6.54, 3.21};  // TODO(jons): make const once ABSCAB supports this
+  std::vector<double> center_ = {1.23, 4.56, 7.89};
+  std::vector<double> normal_ = {9.87, 6.54, 3.21};
   MagneticConfiguration magnetic_configuration_;
   Coil *coil_;
   std::vector<std::vector<double> > evaluation_positions_;

--- a/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib.cc
+++ b/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib.cc
@@ -33,11 +33,6 @@ using magnetics::NumWindingsToCircuitCurrents;
 using magnetics::SetCircuitCurrents;
 using magnetics::VectorPotential;
 
-// TODO(jons): implement stellarator-symmetric grid and follow-up flip-mirroring
-// of magnetic quantities NOTE: For now, everything here is computed as
-// non-stellarator-symmetric,
-//       so there is a factor of ~2 speedup around the corner.
-
 absl::Status IsValidMakegridParameters(
     const MakegridParameters& makegrid_parameters) {
   // number of field periods has to be at least 1

--- a/src/vmecpp/cpp/vmecpp/common/util/util.cc
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.cc
@@ -174,9 +174,11 @@ void TridiagonalSolveOpenMP(
 
   for (int j = nsMinF; j < std::min(jMax, nsMaxF); ++j) {
     for (int mn = 0; mn < mnmax; ++mn) {
+      // forward elimination reaches back one surface, so it can only start
+      // one past jMin
       if (j < jMin[mn] + 1) {
         continue;
-      }  // TODO(jons)
+      }
 
       int idx_mn_0 = (j - nsMinF) * mnmax + mn;      //  0
       int idx_mn_m = (j - 1 - nsMinF) * mnmax + mn;  // -1
@@ -259,9 +261,11 @@ void TridiagonalSolveOpenMP(
 
   for (int j = std::min(jMax - 2, nsMaxF - 1); j >= nsMinF; --j) {
     for (int mn = 0; mn < mnmax; ++mn) {
+      // back substitution reaches forward instead, so it runs down to jMin
+      // itself
       if (j < jMin[mn]) {
         continue;
-      }  // TODO(jons)
+      }
 
       int idx_mn_p = (j + 1 - nsMinF) * mnmax + mn;  // +1
       int idx_mn_0 = (j - nsMinF) * mnmax + mn;      //  0

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -858,8 +858,8 @@ absl::StatusOr<bool> IdealMhdModel::update(
         }
 
         for (int kl = 0; kl < s_.nZnT; ++kl) {
-          // extrapolate total pressure (from inside) to LCFS
-          // TODO(jons): mark that this is bsqsav(lk,3)
+          // extrapolate total pressure (from inside) to LCFS; this is
+          // bsqsav(:,3) in Fortran VMEC
           insideTotalPressure[kl] =
               1.5 * totalPressure[(r_.nsMaxH - 1 - r_.nsMinH) * s_.nZnT + kl] -
               0.5 * totalPressure[(r_.nsMaxH - 2 - r_.nsMinH) * s_.nZnT + kl];

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -810,7 +810,9 @@ absl::Status vmecpp::WOutFileContents::WriteTo(H5::H5File& file) const {
   file.createGroup(this->H5key);
 
   WRITEMEMBER(version_);
-  // TODO(jurasic) input_extension
+  // input_extension is deliberately absent: it names the Fortran INDATA file a
+  // run came from, and VMEC++ runs from JSON. WOutFileContents sets it to the
+  // empty string for the same reason.
   WRITEMEMBER(signgs);
   WRITEMEMBER(gamma);
   WRITEMEMBER(pcurr_type);
@@ -948,7 +950,7 @@ absl::Status vmecpp::WOutFileContents::LoadInto(WOutFileContents& m_obj,
                   from_file);
     m_obj.version_ = std::stod(version_str);
   }
-  // TODO(jurasic) input_extension
+  // input_extension is not written; see WriteTo
   READMEMBER_COMPAT(signgs, "sign_of_jacobian");
   READMEMBER(gamma);
   READMEMBER(pcurr_type);
@@ -3595,10 +3597,9 @@ vmecpp::ComputeIntermediateThreed1GeometricMagneticQuantities(
   //
   // b poloidals (cylindrical estimates)
 
-  // TODO(jons): rcenin (not used anywhere?)
-  // TODO(jons): aminr2in (not used anywhere?)
-  // TODO(jons): bminz2in (not used anywhere?)
-  // TODO(jons): bminz2 (not used anywhere?)
+  // Fortran eqfor.f90 also forms rcenin, aminr2in, bminz2in and bminz2 here.
+  // Their only consumers are the add_real calls in its debug dump, and
+  // bminz2in and bminz2 are the same expression, so nothing depends on them.
 
   // cylindrical estimates for beta poloidal
   double sump_sum = 0.0;
@@ -3660,10 +3661,8 @@ vmecpp::ComputeIntermediateThreed1GeometricMagneticQuantities(
   intermediate.delphid_exact *= intermediate.anorm;
   intermediate.rshaf = intermediate.rshaf1 / intermediate.rshaf2;
 
-  // TODO(jons): could also use threed1_first_table_intermediate.bvcof[0]
-  // directly...
-  intermediate.fpsi0 = 1.5 * threed1_first_table_intermediate.bvcoH[0] -
-                       0.5 * threed1_first_table_intermediate.bvcoH[1];
+  // bvcof[0] is this same extrapolation of bvcoH to the axis
+  intermediate.fpsi0 = threed1_first_table_intermediate.bvcof[0];
 
   intermediate.redge = VectorXd::Zero(s.nZnT);
   for (int kl = 0; kl < s.nZnT; ++kl) {
@@ -4000,14 +3999,13 @@ vmecpp::ComputeThreed1GeometricMagneticQuantities(
     for (int jF = 1; jF < fc.ns; ++jF) {
       double minimum_z = DBL_MAX;
       double maximum_z = -DBL_MAX;
-      // TODO(jons): rename to ..._r
-      double minimum_x = DBL_MAX;
-      // TODO(jons): rename to ..._r
-      double maximum_x = -DBL_MAX;
+      double minimum_r = DBL_MAX;
+      double maximum_r = -DBL_MAX;
 
       double rzmax = 0.0;
 
-      // TODO(jons): these seem to not be used anywhere in Fortran VMEC?
+      // Fortran eqfor.f90 assigns rzmin, zxmax and zxmin alongside rzmax in
+      // the loop below and then reads none of them, so they are left out here.
       // double rzmin = 0.0;
       // double zxmax = 0.0;
       // double zxmin = 0.0;
@@ -4043,13 +4041,13 @@ vmecpp::ComputeThreed1GeometricMagneticQuantities(
             // rzmin = yr1u;
           }
 
-          if (yr1u >= maximum_x) {
-            maximum_x = yr1u;
+          if (yr1u >= maximum_r) {
+            maximum_r = yr1u;
 
             // TODO(jons): these seem to not be used anywhere  in Fortran VMEC?
             // zxmax = yz1u;
-          } else if (yr1u <= minimum_x) {
-            minimum_x = yr1u;
+          } else if (yr1u <= minimum_r) {
+            minimum_r = yr1u;
 
             // TODO(jons): these seem to not be used anywhere in Fortran VMEC?
             // zxmin = yz1u;
@@ -4075,17 +4073,17 @@ vmecpp::ComputeThreed1GeometricMagneticQuantities(
       result.ygeo[nplanes * fc.ns + jF] = (xmidb - xmida) / 2.0;
 
       result.yinden[nplanes * fc.ns + jF] =
-          (xmida - minimum_x) / (maximum_x - minimum_x);
+          (xmida - minimum_r) / (maximum_r - minimum_r);
 
       result.yellip[nplanes * fc.ns + jF] =
-          (maximum_z - minimum_z) / (maximum_x - minimum_x);
+          (maximum_z - minimum_z) / (maximum_r - minimum_r);
 
       result.ytrian[nplanes * fc.ns + jF] =
-          (rgeo - rzmax) / (maximum_x - minimum_x);
+          (rgeo - rzmax) / (maximum_r - minimum_r);
 
       const double r_axis = vmec_internal_results.r_e(k * s.nThetaEff + 0);
       result.yshift[nplanes * fc.ns + jF] =
-          (r_axis - rgeo) / (maximum_x - minimum_x);
+          (r_axis - rgeo) / (maximum_r - minimum_r);
     }  // jF
   }  // nplanes
 


### PR DESCRIPTION
Nine stale or unanswered markers, resolved. The only behaviour-affecting change is a de-duplication that is bit-identical by construction.

**`fpsi0`.** `1.5*bvcoH[0] - 0.5*bvcoH[1]` is the expression `bvcof[0]` is already assigned, a few hundred lines earlier in the same intermediate struct, so the extrapolation is now read rather than repeated.

**`makegrid_lib.cc`.** The marker asks for the stellarator-symmetric grid and the follow-up flip-mirroring, and for the factor of two that would come with them. `MakeCylindricalGrid` has honoured `assume_stellarator_symmetry` for some time, emitting `num_phi/2 + 1` planes, and both `ComputeMagneticFieldResponseTable` and `ComputeVectorPotentialCache` mirror the rest. Removed.

**`util.cc`.** The two bare markers sit on the guards of the two sweeps of the tridiagonal solve, which differ by one. Forward elimination reaches back a surface, so it starts one past `jMin`; back substitution reaches forward, so it runs down to `jMin` itself.

**`minimum_x` / `maximum_x`** are extrema in R, and are renamed accordingly.

**`input_extension`.** Deliberately not serialized: it names the Fortran INDATA file a run came from, and VMEC++ runs from JSON, which is why `WOutFileContents` sets it to the empty string.

**`bsqsav`.** The extrapolation of total pressure to the LCFS is `bsqsav(:,3)` in Fortran VMEC; named in the comment.

**`rcenin`, `aminr2in`, `bminz2in`, `bminz2`.** Fortran `eqfor.f90` forms all four, and their only consumers are the `add_real` calls in its debug dump. `bminz2in` and `bminz2` are the same expression there. Nothing depends on them, so nothing is missing here.

**`rzmin`, `zxmax`, `zxmin`.** `eqfor.f90` assigns them beside `rzmax` and then reads none of them, so leaving them out is right.

**"make const once ABSCAB supports this"** was accurate for two thirds of its twelve sites and stale for the rest. The eight that are handed to `abscab::magneticFieldCircularFilament` or `vectorPotentialCircularFilament`, which take `double*`, stay mutable and now say why. The four that only fill a `CircularFilament` protobuf are const.

Not touched, with reasons: the `input_extension` marker in `__init__.py` belongs to #697, which rewrites that file; the standalone-repo move needs a repository that does not exist yet; and the `debian:testing` re-enable is a CI matrix change gated on upstream 3.14 support.
