### PR TITLE
Record the measured floor for the hot restart comparison tolerance

### DIFF
--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec_hot_restart_test/vmec_hot_restart_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec_hot_restart_test/vmec_hot_restart_test.cc
@@ -757,10 +757,10 @@ TEST(HotRestartIntegration, FreeBoundary) {
 
   // COMPARE RUN FROM SCRATCH AND HOT-RESTARTED RUN
   //
-  // The bound is set by jdotb, which differs by 2.8e-2 between the two runs,
-  // and jcuru at 1.6e-2. Everything else stays at or below 1.8e-3 (DMerc),
-  // with the geometry and field coefficients at 1e-5 and the integrated
-  // scalars at 1e-10 or tighter.
+  // 0.1 is close to the floor: DCurr differs by 5.9e-2 between the two runs,
+  // jdotb by 2.8e-2 and jcuru by 1.6e-2, while the geometry and field
+  // coefficients sit at 1e-5. Those are derivative diagnostics of two
+  // convergence paths into the same shallow minimum, not of one state.
   const double tolerance = 0.1;
   const bool check_equal_maximum_iterations = false;
   CompareWOut(displaced_hotrestarted_output->wout,


### PR DESCRIPTION
`HotRestartIntegration.FreeBoundary` compares a hot-restarted run against a from-scratch run of the same displaced configuration at a tolerance of 0.1, with a marker asking whether that is realistic. Measured, and it is: comments only.

Tightening it from above, 8e-2 passes and 5e-2 does not, so 0.1 sits within a factor of two of the floor rather than being an arbitrary loose bound. Everything else in the file compares at 1e-15, and the other `CompareWOut` callers use 1e-7, which is what makes 0.1 look out of place.

What binds is `DCurr`, one of the Mercier terms, then `jdotb`, then `jcuru`. Splitting the current densities off behind `current_density_tolerance`, which `CompareWOut` provides for exactly this, buys nothing here because `DCurr` fails before them. All three are derivative diagnostics of the converged state and amplify the difference between two convergence paths.

The reason the floor is where it is: the two runs do not land on the same point to `ftol`. Even `rmax_surf`, a plain geometric quantity, only agrees to about 1e-6. The test is asking two iteration paths into the same shallow minimum to agree, not two evaluations of one state.

Left at 0.1. A factor of 1.25 is not worth the churn and would be fragile across platforms.
