### PR TITLE
Reject a multigrid step count below one

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib.cc
+++ b/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib.cc
@@ -964,10 +964,10 @@ absl::Status WriteMakegridNetCDFFile(
 
   for (int circuit_index = 0; circuit_index < n_serial_circuits;
        ++circuit_index) {
-    // TODO(jons): Figure out how the name of the coil groups is determined in
-    // MAKEGRID. The challenge is that many coils (with individual names) can
-    // belong to one coil group, but only a single name for a coil group is
-    // written to the mgrid file.
+    // TODO(jons): MAKEGRID names a coil group by the group name on the
+    // terminating line of its coils in the coils file. That name reaches here
+    // only once the MagneticConfiguration is threaded through or the names are
+    // carried on MagneticFieldResponseTable.
     std::string coil_group_name = absl::StrFormat("circuit_%d", circuit_index);
 
     // NOTE: 30 has to be consistent with the value of kStringSize.

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -228,6 +228,12 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
                                const int iterations_before_checkpointing,
                                const int maximum_multi_grid_step,
                                std::optional<HotRestartState> initial_state) {
+  if (maximum_multi_grid_step < 1) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("maximum_multi_grid_step must be at least 1, but is %d",
+                        maximum_multi_grid_step));
+  }
+
   if (indata_.lfreeb) {
     if (!mgrid_.IsLoaded()) {
       // Fallback: load mgrid from file if constructed directly via the public

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
@@ -987,3 +987,18 @@ TEST(TestVmec, BloatScalesTheEnclosedToroidalFlux) {
         << "bloat = " << bloat;
   }
 }  // BloatScalesTheEnclosedToroidalFlux
+
+// A multigrid step count below one solves nothing and is rejected.
+TEST(TestVmec, ZeroMaximumMultiGridStepIsRejected) {
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile("vmecpp/test_data/solovev.json");
+  ASSERT_TRUE(indata_json.ok());
+  const absl::StatusOr<VmecINDATA> indata = VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(indata.ok());
+
+  Vmec vmec(*indata);
+  const absl::StatusOr<bool> reached =
+      vmec.run(VmecCheckpoint::NONE, INT_MAX, /*maximum_multi_grid_step=*/0);
+  ASSERT_FALSE(reached.ok());
+  EXPECT_EQ(reached.status().code(), absl::StatusCode::kInvalidArgument);
+}  // ZeroMaximumMultiGridStepIsRejected


### PR DESCRIPTION
`Vmec::run` takes `maximum_multi_grid_step`. Below 1 the multigrid loop runs no step and the function falls through to `return false` with an OK status, which reads as "checkpoint not reached" rather than "nothing was solved". It is now rejected, with a test that takes the previous code down the silent path.

The parameter is C++-only and nothing in the tree passes a non-default value, so this is insurance against exposing it rather than a live bug.

The `TODO(jons)` on the mgrid coil group names is rewritten to say what is known and what is missing. MAKEGRID takes the name from the coils file: the terminating line of every coil carries a group index and a group name, coils sharing an index share the name, so one name per group is well defined, and `ImportMagneticConfigurationFromCoilsFile` already keeps it on each filament. `coils.cth_like` is `HF-OVF` on group 1 and `TVF` on group 2. It is not reachable at the point it would be written: `WriteMakegridNetCDFFile` receives the response table and the currents, not the `MagneticConfiguration` the names live on, so using them means threading the configuration through or carrying them on `MagneticFieldResponseTable`. Nothing reads `coil_group` back and the checked-in mgrid files were written by this code, so they already carry the `circuit_%d` placeholders. The marker stays for that plumbing.

Two markers this PR previously touched are dropped from it. The boundary handedness one is resolved on main by #789, which replaced the `rTest * zTest` product with the signed area of the m = 1 ellipse, the invariant the marker proposed. The `Sizes` reference values cannot be parameterized until educational_VMEC dumps them.

`bazel test --config=opt //vmecpp/... //vmecpp_large_cpp_tests/...` and `pytest` pass.
