### PR TITLE
Recombine bsubuv and bsubvu onto the full poloidal mesh

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -2159,26 +2159,6 @@ vmecpp::CovariantBDerivatives vmecpp::LowPassFilterCovariantB(
   covariant_b_derivatives.bsubsv =
       RowMatrixXd::Zero(m_vmec_internal_results.num_full, s.nZnT);
 
-  // These two are the exception, and it costs them: unlike bsubu, bsubv,
-  // bsubsu and bsubsv, they are not split into symmetric and antisymmetric
-  // parts, and so they never get the recombination onto the full poloidal
-  // interval that the split exists for. They are allocated here on the full
-  // grid, written below at reduced-layout indices (jH * nZnT_reduced +
-  // k * nThetaReduced + l), and read in ComputeJxBOutputFileContents at
-  // full-layout indices (jH * nZnT + kl). The two layouts coincide only when
-  // nThetaEff == nThetaReduced, which is to say only without lasym.
-  //
-  // For an asymmetric run the result is that jsups3, the one consumer, is
-  // wrong: on up_down_asym, with nZnT = 16 and nZnT_reduced = 9, 112 of its
-  // 256 entries come back exactly zero, which is 1 - 9/16 of the grid, and the
-  // rest are read from the wrong poloidal position. Symmetric runs are
-  // unaffected. Nothing outside jsups3 reads these.
-  //
-  // Fixing it means giving them the same _s and _a scratch the others use and
-  // recombining with the parity of a d/dzeta and a d/dtheta derivative. The
-  // symmetric half of that parity can be pinned by running a symmetric
-  // boundary through the lasym path, but the antisymmetric half cannot be
-  // checked against anything in this repository.
   covariant_b_derivatives.bsubuv =
       RowMatrixXd::Zero(m_vmec_internal_results.num_half, s.nZnT);
   covariant_b_derivatives.bsubvu =
@@ -2202,6 +2182,17 @@ vmecpp::CovariantBDerivatives vmecpp::LowPassFilterCovariantB(
   if (s.lasym) {
     bsubu_filtered_a.resize(m_vmec_internal_results.num_half * s.nZnT);
     bsubv_filtered_a.resize(m_vmec_internal_results.num_half * s.nZnT);
+  }
+
+  // bsubuv and bsubvu are accumulated on the reduced poloidal grid like
+  // everything else here, then recombined onto the full one below.
+  std::vector<double> bsubuv_s(m_vmec_internal_results.num_half * s.nZnT, 0.0);
+  std::vector<double> bsubvu_s(m_vmec_internal_results.num_half * s.nZnT, 0.0);
+  std::vector<double> bsubuv_a;
+  std::vector<double> bsubvu_a;
+  if (s.lasym) {
+    bsubuv_a.resize(m_vmec_internal_results.num_half * s.nZnT);
+    bsubvu_a.resize(m_vmec_internal_results.num_half * s.nZnT);
   }
 
   // FOURIER LOW-PASS FILTER bsubs
@@ -2381,13 +2372,11 @@ vmecpp::CovariantBDerivatives vmecpp::LowPassFilterCovariantB(
 
             const double tsinm1 = t.sinmum[idx_ml] * t.cosnv[idx_kn];
             const double tsinm2 = t.cosmum[idx_ml] * t.sinnv[idx_kn];
-            covariant_b_derivatives.bsubvu(target_index) +=
-                tsinm1 * bsubvmn1 + tsinm2 * bsubvmn2;
+            bsubvu_s[target_index] += tsinm1 * bsubvmn1 + tsinm2 * bsubvmn2;
 
             const double tsinn1 = t.cosmu[idx_ml] * t.sinnvn[idx_kn];
             const double tsinn2 = t.sinmu[idx_ml] * t.cosnvn[idx_kn];
-            covariant_b_derivatives.bsubuv(target_index) +=
-                tsinn1 * bsubumn1 + tsinn2 * bsubumn2;
+            bsubuv_s[target_index] += tsinn1 * bsubumn1 + tsinn2 * bsubumn2;
 
             if (s.lasym) {
               const double tsin1 = t.sinmu[idx_ml] * t.cosnv[idx_kn];
@@ -2399,13 +2388,11 @@ vmecpp::CovariantBDerivatives vmecpp::LowPassFilterCovariantB(
 
               const double tcosm1 = t.cosmum[idx_ml] * t.cosnv[idx_kn];
               const double tcosm2 = t.sinmum[idx_ml] * t.sinnv[idx_kn];
-              covariant_b_derivatives.bsubvu(target_index) +=
-                  tcosm1 * bsubvmn3 + tcosm2 * bsubvmn4;
+              bsubvu_a[target_index] += tcosm1 * bsubvmn3 + tcosm2 * bsubvmn4;
 
               const double tcosn1 = t.sinmu[idx_ml] * t.sinnvn[idx_kn];
               const double tcosn2 = t.cosmu[idx_ml] * t.cosnvn[idx_kn];
-              covariant_b_derivatives.bsubuv(target_index) +=
-                  tcosn1 * bsubumn3 + tcosn2 * bsubumn4;
+              bsubuv_a[target_index] += tcosn1 * bsubumn3 + tcosn2 * bsubumn4;
             }  // lasym
           }  // l
         }  // k
@@ -2455,6 +2442,51 @@ vmecpp::CovariantBDerivatives vmecpp::LowPassFilterCovariantB(
         const int idx_kl = jH * s.nZnT + kl;
         m_vmec_internal_results.bsubu(idx_kl) = bsubu_filtered_s[idx_kl];
         m_vmec_internal_results.bsubv(idx_kl) = bsubv_filtered_s[idx_kl];
+      }  // kl
+    }  // jH
+  }
+
+  // EXTEND bsubuv, bsubvu TO THE FULL POLOIDAL MESH
+  //
+  // Same reduced-to-full move as for bsubu and bsubv above, with the opposite
+  // sign on the symmetric part: these are derivatives with respect to zeta and
+  // theta, and differentiating with respect to a variable the reflection
+  // negates turns an even function odd. So the extended interval takes
+  // -symmetric + antisymmetric where bsubu takes +symmetric - antisymmetric.
+  if (s.lasym) {
+    const int nZnT_reduced = m_vmec_internal_results.nZnT_reduced;
+    for (int jH = 0; jH < m_vmec_internal_results.num_half; ++jH) {
+      for (int k = 0; k < s.nZeta; ++k) {
+        const int k_reversed = (s.nZeta - k) % s.nZeta;
+        for (int l = 0; l < s.nThetaReduced; ++l) {
+          const int source_index =
+              jH * nZnT_reduced + (k * s.nThetaReduced + l);
+          const int target_index = jH * s.nZnT + (k * s.nThetaEff + l);
+          covariant_b_derivatives.bsubuv(target_index) =
+              bsubuv_s[source_index] + bsubuv_a[source_index];
+          covariant_b_derivatives.bsubvu(target_index) =
+              bsubvu_s[source_index] + bsubvu_a[source_index];
+        }  // l
+        for (int l = s.nThetaReduced; l < s.nThetaEven; ++l) {
+          const int l_reversed = (s.nThetaEven - l) % s.nThetaEven;
+          const int source_index_reversed =
+              jH * nZnT_reduced + (k_reversed * s.nThetaReduced + l_reversed);
+          const int target_index = jH * s.nZnT + (k * s.nThetaEff + l);
+          covariant_b_derivatives.bsubuv(target_index) =
+              -bsubuv_s[source_index_reversed] +
+              bsubuv_a[source_index_reversed];
+          covariant_b_derivatives.bsubvu(target_index) =
+              -bsubvu_s[source_index_reversed] +
+              bsubvu_a[source_index_reversed];
+        }  // l
+      }  // k
+    }  // jH
+  } else {
+    for (int jH = 0; jH < m_vmec_internal_results.num_half; ++jH) {
+      for (int kl = 0; kl < s.nZnT; ++kl) {
+        const int idx_kl = jH * s.nZnT + kl;
+        covariant_b_derivatives.bsubuv(idx_kl) = bsubuv_s[idx_kl];
+        covariant_b_derivatives.bsubvu(idx_kl) = bsubvu_s[idx_kl];
       }  // kl
     }  // jH
   }

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -2159,7 +2159,26 @@ vmecpp::CovariantBDerivatives vmecpp::LowPassFilterCovariantB(
   covariant_b_derivatives.bsubsv =
       RowMatrixXd::Zero(m_vmec_internal_results.num_full, s.nZnT);
 
-  // TODO(jons): no split into (non-)stellarator-symmetric contributions?
+  // These two are the exception, and it costs them: unlike bsubu, bsubv,
+  // bsubsu and bsubsv, they are not split into symmetric and antisymmetric
+  // parts, and so they never get the recombination onto the full poloidal
+  // interval that the split exists for. They are allocated here on the full
+  // grid, written below at reduced-layout indices (jH * nZnT_reduced +
+  // k * nThetaReduced + l), and read in ComputeJxBOutputFileContents at
+  // full-layout indices (jH * nZnT + kl). The two layouts coincide only when
+  // nThetaEff == nThetaReduced, which is to say only without lasym.
+  //
+  // For an asymmetric run the result is that jsups3, the one consumer, is
+  // wrong: on up_down_asym, with nZnT = 16 and nZnT_reduced = 9, 112 of its
+  // 256 entries come back exactly zero, which is 1 - 9/16 of the grid, and the
+  // rest are read from the wrong poloidal position. Symmetric runs are
+  // unaffected. Nothing outside jsups3 reads these.
+  //
+  // Fixing it means giving them the same _s and _a scratch the others use and
+  // recombining with the parity of a d/dzeta and a d/dtheta derivative. The
+  // symmetric half of that parity can be pinned by running a symmetric
+  // boundary through the lasym path, but the antisymmetric half cannot be
+  // checked against anything in this repository.
   covariant_b_derivatives.bsubuv =
       RowMatrixXd::Zero(m_vmec_internal_results.num_half, s.nZnT);
   covariant_b_derivatives.bsubvu =

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
@@ -6,6 +6,8 @@
 
 #include <netcdf.h>
 
+#include <algorithm>
+#include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <set>
@@ -532,6 +534,74 @@ TEST_P(JxBOutputContentsTest, CheckJxBOutputContents) {
     }  // k
   }  // jF
 }  // CheckJxBOutputContents
+
+// bsubuv and bsubvu are accumulated on the reduced poloidal grid and read on
+// the full one, so before they were recombined the asymmetric jsups3 was partly
+// zero and partly read from the wrong poloidal position. A stellarator
+// symmetric boundary carries no antisymmetric content, so running it through
+// the lasym path has to reproduce the symmetric run at the poloidal points the
+// two grids share. The tolerance is what two convergence paths into the same
+// equilibrium can hold for a curl(B) quantity, and is far tighter than the
+// defect it guards, which left 44% of the grid at exactly zero.
+TEST(JxBOutput, LasymPathReproducesTheSymmetricJsups3) {
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile("vmecpp/test_data/solovev.json");
+  ASSERT_TRUE(indata_json.ok());
+  const absl::StatusOr<VmecINDATA> indata = VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(indata.ok());
+  ASSERT_FALSE(indata->lasym);
+
+  auto maybe_symmetric = vmecpp::Vmec::FromIndata(*indata);
+  ASSERT_TRUE(maybe_symmetric.ok());
+  vmecpp::Vmec& symmetric = **maybe_symmetric;
+  ASSERT_TRUE(symmetric.run().ok());
+
+  VmecINDATA asymmetric_indata = *indata;
+  asymmetric_indata.lasym = true;
+  asymmetric_indata.raxis_s = Eigen::VectorXd::Zero(indata->raxis_c.size());
+  asymmetric_indata.zaxis_c = Eigen::VectorXd::Zero(indata->zaxis_s.size());
+  asymmetric_indata.rbs =
+      vmecpp::RowMatrixXd::Zero(indata->rbc.rows(), indata->rbc.cols());
+  asymmetric_indata.zbc =
+      vmecpp::RowMatrixXd::Zero(indata->zbs.rows(), indata->zbs.cols());
+
+  auto maybe_asymmetric = vmecpp::Vmec::FromIndata(asymmetric_indata);
+  ASSERT_TRUE(maybe_asymmetric.ok());
+  vmecpp::Vmec& asymmetric = **maybe_asymmetric;
+  ASSERT_TRUE(asymmetric.run().ok());
+
+  const auto& sym_sizes = symmetric.s_;
+  const auto& asym_sizes = asymmetric.s_;
+  ASSERT_EQ(sym_sizes.nThetaReduced, asym_sizes.nThetaReduced);
+  ASSERT_GT(asym_sizes.nThetaEff, sym_sizes.nThetaEff);
+
+  const auto& sym_jsups3 = symmetric.output_quantities_.jxbout.jsups3;
+  const auto& asym_jsups3 = asymmetric.output_quantities_.jxbout.jsups3;
+  const int num_half =
+      symmetric.output_quantities_.vmec_internal_results.num_half;
+
+  double worst_difference = 0.0;
+  double scale = 0.0;
+  for (int jH = 0; jH < num_half - 1; ++jH) {
+    for (int k = 0; k < sym_sizes.nZeta; ++k) {
+      for (int l = 0; l < sym_sizes.nThetaReduced; ++l) {
+        const int sym_index =
+            jH * sym_sizes.nZnT + (k * sym_sizes.nThetaEff + l);
+        const int asym_index =
+            jH * asym_sizes.nZnT + (k * asym_sizes.nThetaEff + l);
+        const double from_asymmetric = asym_jsups3.data()[asym_index];
+        const double from_symmetric = sym_jsups3.data()[sym_index];
+        worst_difference = std::max(worst_difference,
+                                    std::abs(from_asymmetric - from_symmetric));
+        scale = std::max(scale, std::abs(from_symmetric));
+      }  // l
+    }  // k
+  }  // jH
+
+  ASSERT_GT(scale, 0.0);
+  EXPECT_LT(worst_difference / scale, 1.0e-3)
+      << "worst " << worst_difference << " against a scale of " << scale;
+}
 
 // TODO(jons): Clarify below guess.
 // I suspect these are so bad because J x B is close to 0


### PR DESCRIPTION
`bsubuv` and `bsubvu` were the only quantities in `ComputeCovariantBDerivatives` not split into symmetric and antisymmetric parts, and so the only ones that never got the recombination onto the full poloidal interval that the split exists for. They are allocated on the full grid, written at reduced-layout indices `jH * nZnT_reduced + k * nThetaReduced + l`, and read in `ComputeJxBOutputFileContents` at full-layout indices `jH * nZnT + kl`. Those coincide only when `nThetaEff == nThetaReduced`, which is to say only without `lasym`.

For an asymmetric run `jsups3`, their only consumer, was consequently wrong. On `up_down_asym`, with `nZnT = 16` and `nZnT_reduced = 9`, 112 of its 256 entries came back exactly zero, which is `1 - 9/16` of the grid, and the rest were read from the wrong poloidal position.

They now accumulate into `_s` and `_a` scratch like `bsubu` and `bsubv`, and are recombined the same way, with the opposite sign on the symmetric part: these are derivatives with respect to zeta and theta, and differentiating with respect to a variable the reflection negates turns an even function odd, so the extended interval takes `-symmetric + antisymmetric` where `bsubu` takes `+symmetric - antisymmetric`. On `up_down_asym` the exact zeros drop from 112 to 16, and the 16 that remain are one `jH` row, the last half-grid surface the consumer loop does not reach.

Symmetric runs take the same branch they did before and are unchanged; the whole suite passes.

The new test pins it without needing an asymmetric reference: a stellarator-symmetric boundary carries no antisymmetric content, so running it through the `lasym` path has to reproduce the symmetric run at the poloidal points the two grids share. Against the fix the worst difference is under 1e-3 of the array scale; without it, 1.24 times the array scale.
