### PR TITLE
Say what is actually missing behind the unimplemented markers

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -883,15 +883,13 @@ absl::StatusOr<bool> IdealMhdModel::update(
           delBSq[kl] = fabs(outsideEdgePressure - insideTotalPressure[kl]);
         }
 
-        if (m_vacuum_pressure_state_ == VacuumPressureState::kInitialized) {
-          // TODO(jons): implement this !!!
-
-          // initial magnetic field at boundary
-          // bsqsav(:nznt,1) = bzmn_o(ns:nrzt:ns)
-
-          // initial NESTOR |B|^2 at boundary
-          // bsqsav(:nznt,2) = bsqvac(:nznt)
-        }
+        // Fortran funct3d.f90 saves two arrays at this point,
+        //   bsqsav(:,1) = bzmn_o(ns:nrzt:ns)   initial |B|^2 from the plasma
+        //   bsqsav(:,2) = bsqvac(:)            initial NESTOR |B|^2
+        // and then never reads either of them. The only column that is read is
+        // bsqsav(:,3), for the delbsq diagnostic in printout.f90, which is the
+        // extrapolation computed above and already reported through delBSq.
+        // So there is nothing here to carry over.
       }
 
       if (checkpoint == VmecCheckpoint::RBSQ &&
@@ -2022,7 +2020,10 @@ void IdealMhdModel::computeForceNorms(const FourierGeometry& decomposed_x) {
     }  // kl
   }  // j
 
-  // TODO(jons): exclude axis --> mimic PARVMEC
+  // PARVMEC excludes the axis from this norm. Adopting that changes the force
+  // normalization, hence the residuals, hence where every run stops, so it
+  // needs the reference outputs regenerated with it rather than being a local
+  // change.
   // only unique radial points here;
   // decomposed_x is over nsMinF1 ... nsMaxF1 --> would count overlapping
   // elements twice !!!

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -1556,8 +1556,11 @@ vmecpp::OutputQuantities vmecpp::ComputeOutputQuantities(
         output_quantities.threed1_axis, output_quantities.threed1_betas,
         vmec_status, iter2);
 
-    // TODO(jons): freeb_data output to be implemented when free-boundary test
-    // case is set up
+    // The free-boundary cases the marker was waiting on now exist. What
+    // Fortran freeb_data.f90 writes is the edge field, brv, bphiv and bzv,
+    // together with the vacuum potential, to a legacy unit-number file. The
+    // potential half of that landed here as potvac, xmpot and xnpot; the edge
+    // field components are what is still missing.
   }
 
   output_quantities.indata = indata;
@@ -4335,6 +4338,8 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
   WOutFileContents wout;
 
   // take version from educational_VMEC for now
+  // Bumping this means matching PARVMEC, not editing the string; left until
+  // that is true.
   // TODO(jons): Upgrade VMEC++ to match PARVMEC and then change version to
   // "9.0".
   wout.version_ = 8.52;
@@ -4563,7 +4568,10 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
     }
   }
 
-  // TODO(jons): curlabel: the mgrid coil-group names are not read back yet
+  // curlabel would be the mgrid coil-group names, which MGridProvider does
+  // not read back out of the file. That is the reading half of the same gap
+  // the writing side has in makegrid_lib: the names live in the coils file and
+  // reach neither end.
 
   // -------------------
   // mode numbers for Fourier coefficient arrays below

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -385,7 +385,10 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
         break;
       }
 
-      // TODO(jons): insert lgiveup/fgiveup logic here
+      // lgiveup/fgiveup, the early-abandonment heuristic, does not exist in
+      // educational_VMEC, which is what the outputs here are validated
+      // against. Adding it would introduce a termination rule with no
+      // reference to match it to.
 
       // If this point is reached, the current multi-grid step should have
       // properly converged.


### PR DESCRIPTION
Six markers for unimplemented features, each replaced by what is actually missing and why. Comments only.

**`bsqsav(:,1)` and `(:,2)`, "implement this !!!"** Nothing to carry over. Fortran `funct3d.f90` assigns both at that point and never reads either; the only column read anywhere is `bsqsav(:,3)`, for the `delbsq` diagnostic in `printout.f90`, and that is the extrapolation already computed a few lines above and reported through `delBSq`.

**`lgiveup`/`fgiveup`.** Absent from `educational_VMEC` altogether, which is what these outputs are validated against. Adding the heuristic would introduce a termination rule with nothing to match it to.

**`freeb_data`.** The free-boundary cases it was waiting on now exist. What `freeb_data.f90` writes is the edge field, `brv`, `bphiv`, `bzv`, together with the vacuum potential, to a legacy unit-number file. The potential half of that has since landed as `potvac`, `xmpot` and `xnpot`; the edge field components are what is still missing.

**`curlabel`.** Blocked on `MGridProvider` not reading `coil_group` back out of the mgrid file. That is the reading half of the same gap the writing side has in `makegrid_lib`, where the group names sit in the coils file and reach neither end.

**Excluding the axis from the force norm.** PARVMEC does; adopting it changes the force normalization, hence the residuals, hence where every run stops. It needs the reference outputs regenerated rather than being a local edit.

**The version string.** Bumping it means matching PARVMEC, not editing the string, so the marker stays until that is true.
