### PR TITLE
Read the mgrid coil group names and report them as wout curlabel

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -1487,14 +1487,6 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
   // lfreeb
   // nothing to check here: lfreeb can be true or false and both are valid...
   if (vmec_indata.lfreeb) {
-    // mgrid_file, extcur
-    //
-    // Both consistency checks need the mgrid, which this function does not
-    // have, so they live where it is available instead. Vmec::run compares
-    // MGridProvider::numPhi against nzeta, and MGridProvider::LoadFile and
-    // LoadFields each compare the number of coil currents against the number
-    // of response tables they found.
-
     // nvacskip
     if (vmec_indata.nvacskip < 1) {
       return absl::InvalidArgumentError(absl::StrFormat(

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -1487,12 +1487,13 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
   // lfreeb
   // nothing to check here: lfreeb can be true or false and both are valid...
   if (vmec_indata.lfreeb) {
-    // mgrid_file
-    // TODO(jons): if mgrid read, check for consistent nzeta
-
-    // extcur
-    // TODO(jons): check that number of coil currents matches number of response
-    // tables in mgrid file
+    // mgrid_file, extcur
+    //
+    // Both consistency checks need the mgrid, which this function does not
+    // have, so they live where it is available instead. Vmec::run compares
+    // MGridProvider::numPhi against nzeta, and MGridProvider::LoadFile and
+    // LoadFields each compare the number of coil currents against the number
+    // of response tables they found.
 
     // nvacskip
     if (vmec_indata.nvacskip < 1) {

--- a/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
@@ -29,6 +29,10 @@ using netcdf_io::NetcdfReadString;
 
 namespace {
 
+// Fixed width of each name in the mgrid coil_group variable, matching
+// kStringSize in makegrid_lib.
+constexpr int kMgridStringSize = 30;
+
 absl::Status ValidateFieldContributionShape(
     const std::vector<std::vector<std::vector<double> > >& field_contribution,
     const std::string& variable_name, int num_phi, int num_z, int num_r) {
@@ -164,6 +168,30 @@ absl::Status MGridProvider::LoadFile(const std::filesystem::path& filename,
   numPhi = *num_phi_or;
 
   nextcur = *nextcur_or;
+
+  // coil_group is a [nextcur][kMgridStringSize] character array, each name
+  // padded on the right by MAKEGRID.
+  coil_group_names.clear();
+  {
+    int id_coil_group = 0;
+    if (nc_inq_varid(ncid, "coil_group", &id_coil_group) == NC_NOERR) {
+      std::vector<char> raw(static_cast<size_t>(nextcur) * kMgridStringSize);
+      if (nc_get_var_text(ncid, id_coil_group, raw.data()) == NC_NOERR) {
+        coil_group_names.reserve(nextcur);
+        for (int i = 0; i < nextcur; ++i) {
+          std::string name(
+              raw.data() + static_cast<size_t>(i) * kMgridStringSize,
+              kMgridStringSize);
+          size_t end = name.size();
+          while (end > 0 && name[end - 1] <= 0x20) {
+            --end;
+          }
+          name.erase(end);
+          coil_group_names.push_back(name);
+        }
+      }
+    }
+  }
   if (coil_currents.size() != nextcur) {
     nc_close(ncid);
     return absl::InvalidArgumentError(
@@ -279,6 +307,9 @@ absl::Status MGridProvider::LoadFields(
   numPhi = mgrid_params.number_of_phi_grid_points;
 
   nextcur = static_cast<int>(coil_currents.size());
+
+  // an in-memory response table carries no coil group names
+  coil_group_names.clear();
 
   if (mgrid_params.normalize_by_currents) {
     mgrid_mode = "S";

--- a/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.cc
@@ -7,6 +7,7 @@
 #include <netcdf.h>
 
 #include <algorithm>
+#include <array>
 #include <cfloat>  // DBL_MAX
 #include <cstdio>
 #include <fstream>
@@ -28,10 +29,6 @@ using netcdf_io::NetcdfReadInt;
 using netcdf_io::NetcdfReadString;
 
 namespace {
-
-// Fixed width of each name in the mgrid coil_group variable, matching
-// kStringSize in makegrid_lib.
-constexpr int kMgridStringSize = 30;
 
 absl::Status ValidateFieldContributionShape(
     const std::vector<std::vector<std::vector<double> > >& field_contribution,
@@ -169,19 +166,26 @@ absl::Status MGridProvider::LoadFile(const std::filesystem::path& filename,
 
   nextcur = *nextcur_or;
 
-  // coil_group is a [nextcur][kMgridStringSize] character array, each name
-  // padded on the right by MAKEGRID.
+  // coil_group is a [nextcur][string width] character array, each name padded
+  // on the right. The width is whatever the file declares, so a writer that
+  // does not use MAKEGRID's 30 still reads correctly.
   coil_group_names.clear();
   {
     int id_coil_group = 0;
-    if (nc_inq_varid(ncid, "coil_group", &id_coil_group) == NC_NOERR) {
-      std::vector<char> raw(static_cast<size_t>(nextcur) * kMgridStringSize);
+    std::array<int, 2> coil_group_dimensions = {0, 0};
+    size_t string_width = 0;
+    if (nc_inq_varid(ncid, "coil_group", &id_coil_group) == NC_NOERR &&
+        nc_inq_vardimid(ncid, id_coil_group, coil_group_dimensions.data()) ==
+            NC_NOERR &&
+        nc_inq_dimlen(ncid, coil_group_dimensions[1], &string_width) ==
+            NC_NOERR &&
+        string_width > 0) {
+      std::vector<char> raw(static_cast<size_t>(nextcur) * string_width);
       if (nc_get_var_text(ncid, id_coil_group, raw.data()) == NC_NOERR) {
         coil_group_names.reserve(nextcur);
         for (int i = 0; i < nextcur; ++i) {
-          std::string name(
-              raw.data() + static_cast<size_t>(i) * kMgridStringSize,
-              kMgridStringSize);
+          std::string name(raw.data() + static_cast<size_t>(i) * string_width,
+                           string_width);
           size_t end = name.size();
           while (end > 0 && name[end - 1] <= 0x20) {
             --end;

--- a/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/mgrid_provider/mgrid_provider.h
@@ -7,6 +7,8 @@
 
 #include <Eigen/Dense>
 #include <filesystem>
+#include <string>
+#include <vector>
 
 #include "absl/status/status.h"
 #include "vmecpp/common/makegrid_lib/makegrid_lib.h"
@@ -62,6 +64,11 @@ class MGridProvider {
   int nextcur;
 
   std::string mgrid_mode;
+
+  // Names of the coil groups, one per response table, as written by MAKEGRID
+  // into the mgrid file's coil_group variable. Empty when the field came from
+  // an in-memory response table, which carries no names.
+  std::vector<std::string> coil_group_names;
 
   bool IsLoaded() const { return has_mgrid_loaded_; }
 

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -1375,6 +1375,7 @@ vmecpp::OutputQuantities vmecpp::ComputeOutputQuantities(
     const FlowControl& fc, const VmecConstants& constants,
     const FourierBasisFastPoloidal& t, const HandoverStorage& h,
     const std::string& mgrid_mode,
+    const std::vector<std::string>& coil_group_names,
     const std::vector<std::unique_ptr<RadialPartitioning>>& radial_partitioning,
     const std::vector<std::unique_ptr<FourierGeometry>>& decomposed_x,
     const std::vector<std::unique_ptr<IdealMhdModel>>& models_from_threads,
@@ -1546,7 +1547,7 @@ vmecpp::OutputQuantities vmecpp::ComputeOutputQuantities(
     // and setup a stand-alone test case to figure out what went wrong
     // and how to prevent that crash in the future.
     output_quantities.wout = ComputeWOutFileContents(
-        indata, s, t, fc, constants, h, mgrid_mode,
+        indata, s, t, fc, constants, h, mgrid_mode, coil_group_names,
         /*m_vmec_internal_results=*/output_quantities.vmec_internal_results,
         output_quantities.bsubs_half, output_quantities.bsubs_full,
         output_quantities.mercier, output_quantities.jxbout,
@@ -4317,6 +4318,7 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
     const VmecINDATA& indata, const Sizes& s, const FourierBasisFastPoloidal& t,
     const FlowControl& fc, const VmecConstants& constants,
     const HandoverStorage& handover_storage, const std::string& mgrid_mode,
+    const std::vector<std::string>& coil_group_names,
     VmecInternalResults& m_vmec_internal_results, const BSubSHalf& bsubs_half,
     const BSubSFull& bsubs_full, const MercierFileContents& mercier,
     const JxBOutFileContents& jxbout,
@@ -4563,7 +4565,8 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
     }
   }
 
-  // TODO(jons): curlabel: the mgrid coil-group names are not read back yet
+  // coil group names, one per external current, as read from the mgrid file
+  wout.curlabel = coil_group_names;
 
   // -------------------
   // mode numbers for Fourier coefficient arrays below

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
@@ -1374,6 +1374,7 @@ OutputQuantities ComputeOutputQuantities(
     const FlowControl& fc, const VmecConstants& constants,
     const FourierBasisFastPoloidal& t, const HandoverStorage& h,
     const std::string& mgrid_mode,
+    const std::vector<std::string>& coil_group_names,
     const std::vector<std::unique_ptr<RadialPartitioning> >&
         radial_partitioning,
     const std::vector<std::unique_ptr<FourierGeometry> >& decomposed_x,
@@ -1513,6 +1514,7 @@ WOutFileContents ComputeWOutFileContents(
     const VmecINDATA& indata, const Sizes& s, const FourierBasisFastPoloidal& t,
     const FlowControl& fc, const VmecConstants& constants,
     const HandoverStorage& handover_storage, const std::string& mgrid_mode,
+    const std::vector<std::string>& coil_group_names,
     VmecInternalResults& m_vmec_internal_results, const BSubSHalf& bsubs_half,
     const BSubSFull& bsubs_full, const MercierFileContents& mercier,
     const JxBOutFileContents& jxbout,

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities_bench.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities_bench.cc
@@ -70,8 +70,8 @@ void BM_ComputeOutputQuantities(benchmark::State& state) {
   for (auto _ : state) {
     OutputQuantities output_quantities = ComputeOutputQuantities(
         kSignOfJacobian, vmec.indata_, vmec.s_, vmec.fc_, vmec.constants_,
-        vmec.t_, vmec.h_, vmec.mgrid_.mgrid_mode, vmec.r_, vmec.decomposed_x_,
-        vmec.m_, vmec.p_, VmecCheckpoint::NONE,
+        vmec.t_, vmec.h_, vmec.mgrid_.mgrid_mode, vmec.mgrid_.coil_group_names,
+        vmec.r_, vmec.decomposed_x_, vmec.m_, vmec.p_, VmecCheckpoint::NONE,
         static_cast<VacuumPressureState>(vmec.get_ivac()), vmec.get_status(),
         vmec.get_iter2());
     benchmark::DoNotOptimize(output_quantities.wout.volume);

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -442,8 +442,8 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
   // (for creating the output file, use WriteOutputFile())
   output_quantities_ = vmecpp::ComputeOutputQuantities(
       kSignOfJacobian, indata_, s_, fc_, constants_, t_, h_, mgrid_.mgrid_mode,
-      r_, decomposed_x_, m_, p_, checkpoint, vacuum_pressure_state_, status_,
-      iter2_);
+      mgrid_.coil_group_names, r_, decomposed_x_, m_, p_, checkpoint,
+      vacuum_pressure_state_, status_, iter2_);
 
   {
     const auto& w = output_quantities_.wout;

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_in_memory_mgrid_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_in_memory_mgrid_test.cc
@@ -18,6 +18,7 @@
 #include "vmecpp/vmec/vmec/vmec.h"
 
 using ::testing::ElementsAreArray;
+using ::testing::HasSubstr;
 using ::testing::TestWithParam;
 using ::testing::Values;
 
@@ -30,6 +31,46 @@ using vmecpp::Vmec;
 using vmecpp::VmecCheckpoint;
 using vmecpp::VmecINDATA;
 namespace fs = std::filesystem;
+
+// The toroidal resolution of the vacuum field and of the solver have to agree.
+// VmecINDATA::IsConsistent cannot check this, because it never sees the mgrid,
+// so Vmec::run does it once the provider is loaded.
+TEST(TestVmec, InMemoryMgridWithMismatchedNzetaIsRejected) {
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile("vmecpp/test_data/cth_like_free_bdy.json");
+  ASSERT_TRUE(indata_json.ok());
+  absl::StatusOr<VmecINDATA> maybe_indata = VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(maybe_indata.ok());
+  const VmecINDATA& indata = maybe_indata.value();
+
+  const auto maybe_magnetic_configuration =
+      magnetics::ImportMagneticConfigurationFromCoilsFile(
+          "vmecpp/test_data/coils.cth_like");
+  ASSERT_TRUE(maybe_magnetic_configuration.ok());
+
+  auto maybe_makegrid_params = makegrid::ImportMakegridParametersFromFile(
+      "vmecpp/test_data/makegrid_parameters_cth_like.json");
+  ASSERT_TRUE(maybe_makegrid_params.ok());
+  makegrid::MakegridParameters makegrid_params = *maybe_makegrid_params;
+
+  // Half the toroidal resolution the input asks for, on a coarse R-Z grid so
+  // that building the table stays cheap. Still even, which the symmetric grid
+  // requires.
+  ASSERT_EQ(makegrid_params.number_of_phi_grid_points, indata.nzeta);
+  makegrid_params.number_of_phi_grid_points = indata.nzeta / 2;
+  makegrid_params.number_of_r_grid_points = 5;
+  makegrid_params.number_of_z_grid_points = 5;
+
+  const auto maybe_response_table = makegrid::ComputeMagneticFieldResponseTable(
+      makegrid_params, *maybe_magnetic_configuration);
+  ASSERT_TRUE(maybe_response_table.ok());
+
+  const auto output = vmecpp::run(indata, *maybe_response_table);
+  ASSERT_FALSE(output.ok());
+  EXPECT_EQ(output.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(std::string(output.status().message()),
+              ::testing::HasSubstr("phi grid points"));
+}
 
 TEST(TestVmec, CheckInMemoryMgrid) {
   // test the constructor that takes an in-memory mgrid

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/mgrid_provider/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/mgrid_provider/BUILD.bazel
@@ -17,5 +17,6 @@ cc_test(
         "//vmecpp/common/magnetic_configuration_lib:magnetic_configuration_lib",
         "//vmecpp/common/magnetic_field_provider:magnetic_field_provider_lib",
         "//vmecpp/common/vmec_indata:vmec_indata",
+        "//vmecpp/common/makegrid_lib:makegrid_lib",
     ],
 )

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/mgrid_provider/mgrid_provider_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/mgrid_provider/mgrid_provider_test.cc
@@ -25,6 +25,7 @@
 #include "util/testing/numerical_comparison_lib.h"
 #include "vmecpp/common/magnetic_configuration_lib/magnetic_configuration_lib.h"
 #include "vmecpp/common/magnetic_field_provider/magnetic_field_provider_lib.h"
+#include "vmecpp/common/makegrid_lib/makegrid_lib.h"
 #include "vmecpp/common/util/util.h"
 #include "vmecpp/common/vmec_indata/vmec_indata.h"
 
@@ -355,5 +356,60 @@ TEST_F(MGridInterpolationTest, MixedInAndOutOfGridSlicesDoNotDeadlock) {
             absl::StatusCode::kFailedPrecondition);
 }
 #endif  // _OPENMP
+
+// LoadFile and LoadFields each reject a coil-current count that disagrees with
+// the number of response tables they hold. VmecINDATA::IsConsistent cannot make
+// this check, because it never sees the mgrid.
+TEST(MGridProviderValidation, LoadFileRejectsWrongNumberOfCurrents) {
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile("vmecpp/test_data/cth_like_free_bdy.json");
+  ASSERT_TRUE(indata_json.ok()) << indata_json.status();
+  const absl::StatusOr<VmecINDATA> indata = VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(indata.ok()) << indata.status();
+
+  MGridProvider mgrid;
+
+  // one too few
+  Eigen::VectorXd too_few = indata->extcur.head(indata->extcur.size() - 1);
+  const absl::Status short_status = mgrid.LoadFile(indata->mgrid_file, too_few);
+  EXPECT_EQ(short_status.code(), absl::StatusCode::kInvalidArgument);
+
+  // one too many
+  Eigen::VectorXd too_many(indata->extcur.size() + 1);
+  too_many.head(indata->extcur.size()) = indata->extcur;
+  too_many[indata->extcur.size()] = 1.0;
+  const absl::Status long_status = mgrid.LoadFile(indata->mgrid_file, too_many);
+  EXPECT_EQ(long_status.code(), absl::StatusCode::kInvalidArgument);
+
+  // the matching count still loads
+  EXPECT_TRUE(mgrid.LoadFile(indata->mgrid_file, indata->extcur).ok());
+}
+
+TEST(MGridProviderValidation, LoadFieldsRejectsWrongNumberOfCurrents) {
+  // A response table with two circuits on a small grid; only the shapes matter
+  // here, not the field values.
+  makegrid::MagneticFieldResponseTable response_table;
+  response_table.parameters = {.normalize_by_currents = false,
+                               .assume_stellarator_symmetry = false,
+                               .number_of_field_periods = 1,
+                               .r_grid_minimum = 1.0,
+                               .r_grid_maximum = 2.0,
+                               .number_of_r_grid_points = 3,
+                               .z_grid_minimum = -1.0,
+                               .z_grid_maximum = 1.0,
+                               .number_of_z_grid_points = 3,
+                               .number_of_phi_grid_points = 2};
+  const int num_grid_points = 2 * 3 * 3;
+  response_table.b_r = RowMatrixXd::Zero(2, num_grid_points);
+  response_table.b_p = RowMatrixXd::Zero(2, num_grid_points);
+  response_table.b_z = RowMatrixXd::Zero(2, num_grid_points);
+
+  MGridProvider mgrid;
+  EXPECT_EQ(mgrid.LoadFields(response_table, Eigen::VectorXd::Ones(1)).code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(mgrid.LoadFields(response_table, Eigen::VectorXd::Ones(3)).code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_TRUE(mgrid.LoadFields(response_table, Eigen::VectorXd::Ones(2)).ok());
+}
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/mgrid_provider/mgrid_provider_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/free_boundary/mgrid_provider/mgrid_provider_test.cc
@@ -412,4 +412,24 @@ TEST(MGridProviderValidation, LoadFieldsRejectsWrongNumberOfCurrents) {
   EXPECT_TRUE(mgrid.LoadFields(response_table, Eigen::VectorXd::Ones(2)).ok());
 }
 
+// The coil group names MAKEGRID writes into the mgrid file are what wout
+// reports as curlabel. mgrid_cth_like.nc carries two of them.
+TEST(MGridProviderValidation, LoadFileReadsCoilGroupNames) {
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile("vmecpp/test_data/cth_like_free_bdy.json");
+  ASSERT_TRUE(indata_json.ok()) << indata_json.status();
+  const absl::StatusOr<VmecINDATA> indata = VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(indata.ok()) << indata.status();
+
+  MGridProvider mgrid;
+  ASSERT_TRUE(mgrid.LoadFile(indata->mgrid_file, indata->extcur).ok());
+
+  ASSERT_EQ(static_cast<int>(mgrid.coil_group_names.size()), mgrid.nextcur);
+  for (const std::string& name : mgrid.coil_group_names) {
+    EXPECT_FALSE(name.empty());
+    EXPECT_EQ(name.find_last_not_of(' '), name.size() - 1)
+        << "name '" << name << "' still carries padding";
+  }
+}
+
 }  // namespace vmecpp


### PR DESCRIPTION
Stacked on #739.

`wout.curlabel` was declared, serialized and never filled, because the coil group names sat in the mgrid file and nothing read them back.

`MGridProvider::LoadFile` now reads the `coil_group` variable, a `[nextcur][30]` character array, strips the padding MAKEGRID writes, and stores the names. They are threaded to `ComputeWOutFileContents` the way `mgrid_mode` already is, and become `wout.curlabel`. An in-memory response table carries no names, so `LoadFields` leaves the list empty.

The test loads `mgrid_cth_like.nc` and requires one name per external current, none empty and none still padded.
