### PR TITLE
Report the free-boundary edge quantities as a threed1 section

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
@@ -168,6 +168,19 @@ class HandoverStorage {
   // [nZnT] vacuum magnetic pressure |B_vac^2|/2 at the plasma boundary
   Eigen::VectorXd vacuum_magnetic_pressure;
 
+  // [nZnT] total pressure of the plasma at the boundary at the moment the
+  // vacuum solution was first established, bsqsav(:,1) in Fortran VMEC.
+  // Fast-poloidal layout, like totalPressure.
+  Eigen::VectorXd initial_plasma_pressure_at_boundary;
+
+  // [nZnT] Nestor's vacuum magnetic pressure at that same moment,
+  // bsqsav(:,2). Fast-toroidal layout, like vacuum_magnetic_pressure.
+  Eigen::VectorXd initial_vacuum_pressure_at_boundary;
+
+  // [nZnT] total pressure extrapolated from inside onto the boundary,
+  // bsqsav(:,3). Fast-poloidal layout.
+  Eigen::VectorXd edge_total_pressure;
+
   // [nZnT] cylindrical B^R of Nestor's vacuum magnetic field
   Eigen::VectorXd vacuum_b_r;
 

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -881,16 +881,23 @@ absl::StatusOr<bool> IdealMhdModel::update(
 
           // for printout: global mismatch between inside and outside pressure
           delBSq[kl] = fabs(outsideEdgePressure - insideTotalPressure[kl]);
+
+          // bsqsav(:,3): the extrapolated edge pressure, reported by
+          // freeb_data
+          m_h_.edge_total_pressure[kl] = insideTotalPressure[kl];
         }
 
         if (m_vacuum_pressure_state_ == VacuumPressureState::kInitialized) {
-          // TODO(jons): implement this !!!
-
-          // initial magnetic field at boundary
-          // bsqsav(:nznt,1) = bzmn_o(ns:nrzt:ns)
-
-          // initial NESTOR |B|^2 at boundary
-          // bsqsav(:nznt,2) = bsqvac(:nznt)
+          // bsqsav(:,1) and bsqsav(:,2): the plasma-side and vacuum-side
+          // pressures at the boundary as they stood when the vacuum solution
+          // was first established. freeb_data reports them beside the final
+          // ones, so they are snapshotted once here.
+          for (int kl = 0; kl < s_.nZnT; ++kl) {
+            m_h_.initial_plasma_pressure_at_boundary[kl] =
+                totalPressure[(r_.nsMaxH - 1 - r_.nsMinH) * s_.nZnT + kl];
+            m_h_.initial_vacuum_pressure_at_boundary[kl] =
+                m_h_.vacuum_magnetic_pressure[kl];
+          }  // kl
         }
       }
 

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -741,6 +741,47 @@ absl::Status vmecpp::Threed1AxisGeometry::LoadInto(Threed1AxisGeometry& m_obj,
   return absl::OkStatus();
 }
 
+absl::Status vmecpp::Threed1FreeBoundary::WriteTo(H5::H5File& file) const {
+  file.createGroup(this->H5key);
+  WRITEMEMBER(rb);
+  WRITEMEMBER(phib);
+  WRITEMEMBER(zb);
+  WRITEMEMBER(bsqmhdi);
+  WRITEMEMBER(bsqvaci);
+  WRITEMEMBER(bsqmhdf);
+  WRITEMEMBER(bsqvacf);
+  WRITEMEMBER(bredge);
+  WRITEMEMBER(bpedge);
+  WRITEMEMBER(bzedge);
+  WRITEMEMBER(brv);
+  WRITEMEMBER(bphiv);
+  WRITEMEMBER(bzv);
+
+  return absl::OkStatus();
+}
+
+absl::Status vmecpp::Threed1FreeBoundary::LoadInto(Threed1FreeBoundary& m_obj,
+                                                   H5::H5File& from_file) {
+  // Files written before this group existed do not have it.
+  if (H5Lexists(from_file.getId(), H5key, 0) != 1) {
+    return absl::OkStatus();
+  }
+  READMEMBER(rb);
+  READMEMBER(phib);
+  READMEMBER(zb);
+  READMEMBER(bsqmhdi);
+  READMEMBER(bsqvaci);
+  READMEMBER(bsqmhdf);
+  READMEMBER(bsqvacf);
+  READMEMBER(bredge);
+  READMEMBER(bpedge);
+  READMEMBER(bzedge);
+  READMEMBER(brv);
+  READMEMBER(bphiv);
+  READMEMBER(bzv);
+  return absl::OkStatus();
+}
+
 absl::Status vmecpp::Threed1Betas::WriteTo(H5::H5File& file) const {
   file.createGroup(this->H5key);
   WRITEMEMBER(betatot);
@@ -1233,6 +1274,11 @@ absl::Status vmecpp::OutputQuantities::Save(
     return status;
   }
 
+  status = threed1_free_boundary.WriteTo(file);
+  if (!status.ok()) {
+    return status;
+  }
+
   status = threed1_betas.WriteTo(file);
   if (!status.ok()) {
     return status;
@@ -1346,6 +1392,12 @@ absl::StatusOr<vmecpp::OutputQuantities> vmecpp::OutputQuantities::Load(
     return status;
   }
 
+  status = decltype(oq.threed1_free_boundary)::LoadInto(
+      oq.threed1_free_boundary, file);
+  if (!status.ok()) {
+    return status;
+  }
+
   status = decltype(oq.threed1_betas)::LoadInto(oq.threed1_betas, file);
   if (!status.ok()) {
     return status;
@@ -1369,6 +1421,79 @@ absl::StatusOr<vmecpp::OutputQuantities> vmecpp::OutputQuantities::Load(
 
   return oq;
 }
+
+vmecpp::Threed1FreeBoundary vmecpp::ComputeThreed1FreeBoundary(
+    const Sizes& s, const FlowControl& fc,
+    const HandoverStorage& handover_storage,
+    const VmecInternalResults& vmec_internal_results,
+    const CylindricalComponentsOfB& b_cylindrical) {
+  Threed1FreeBoundary result;
+
+  const int num_zeta = s.nZeta;
+  const int num_theta = s.nThetaReduced;
+  result.rb = RowMatrixXd::Zero(num_zeta, num_theta);
+  result.phib = RowMatrixXd::Zero(num_zeta, num_theta);
+  result.zb = RowMatrixXd::Zero(num_zeta, num_theta);
+  result.bsqmhdi = RowMatrixXd::Zero(num_zeta, num_theta);
+  result.bsqvaci = RowMatrixXd::Zero(num_zeta, num_theta);
+  result.bsqmhdf = RowMatrixXd::Zero(num_zeta, num_theta);
+  result.bsqvacf = RowMatrixXd::Zero(num_zeta, num_theta);
+  result.bredge = RowMatrixXd::Zero(num_zeta, num_theta);
+  result.bpedge = RowMatrixXd::Zero(num_zeta, num_theta);
+  result.bzedge = RowMatrixXd::Zero(num_zeta, num_theta);
+  result.brv = RowMatrixXd::Zero(num_zeta, num_theta);
+  result.bphiv = RowMatrixXd::Zero(num_zeta, num_theta);
+  result.bzv = RowMatrixXd::Zero(num_zeta, num_theta);
+
+  // A fixed-boundary run has no vacuum side; the arrays stay allocated and
+  // zero, as potvac does.
+  if (handover_storage.vacuum_magnetic_pressure.size() != s.nZnT) {
+    return result;
+  }
+
+  const int last_full = fc.ns - 1;
+  const int last_half = fc.ns - 2;
+  const int previous_half = fc.ns - 3;
+
+  for (int k = 0; k < num_zeta; ++k) {
+    const double zeta = 2.0 * M_PI * k / (num_zeta * s.nfp);
+    for (int l = 0; l < num_theta; ++l) {
+      // fast-poloidal within-surface index, and the fast-toroidal one Nestor
+      // hands its results back in
+      const int kl = k * s.nThetaEff + l;
+      const int lk = l * num_zeta + k;
+
+      const int boundary = last_full * s.nZnT + kl;
+      result.rb(k, l) = vmec_internal_results.r_e(boundary) +
+                        vmec_internal_results.r_o(boundary);
+      result.zb(k, l) = vmec_internal_results.z_e(boundary) +
+                        vmec_internal_results.z_o(boundary);
+      result.phib(k, l) = zeta;
+
+      result.bsqmhdi(k, l) =
+          handover_storage.initial_plasma_pressure_at_boundary[kl];
+      result.bsqvaci(k, l) =
+          handover_storage.initial_vacuum_pressure_at_boundary[lk];
+      result.bsqmhdf(k, l) = handover_storage.edge_total_pressure[kl];
+      result.bsqvacf(k, l) = handover_storage.vacuum_magnetic_pressure[lk];
+
+      // the plasma-side field lives on the half grid, so extrapolate the two
+      // outermost surfaces onto the boundary
+      result.bredge(k, l) = 1.5 * b_cylindrical.b_r(last_half, kl) -
+                            0.5 * b_cylindrical.b_r(previous_half, kl);
+      result.bpedge(k, l) = 1.5 * b_cylindrical.b_phi(last_half, kl) -
+                            0.5 * b_cylindrical.b_phi(previous_half, kl);
+      result.bzedge(k, l) = 1.5 * b_cylindrical.b_z(last_half, kl) -
+                            0.5 * b_cylindrical.b_z(previous_half, kl);
+
+      result.brv(k, l) = handover_storage.vacuum_b_r[lk];
+      result.bphiv(k, l) = handover_storage.vacuum_b_phi[lk];
+      result.bzv(k, l) = handover_storage.vacuum_b_z[lk];
+    }  // l
+  }  // k
+
+  return result;
+}  // ComputeThreed1FreeBoundary
 
 vmecpp::OutputQuantities vmecpp::ComputeOutputQuantities(
     const int sign_of_jacobian, const VmecINDATA& indata, const Sizes& s,
@@ -1554,11 +1679,14 @@ vmecpp::OutputQuantities vmecpp::ComputeOutputQuantities(
         output_quantities.threed1_first_table,
         output_quantities.threed1_geometric_magnetic,
         output_quantities.threed1_axis, output_quantities.threed1_betas,
-        vmec_status, iter2);
+        output_quantities.threed1_free_boundary, vmec_status, iter2);
 
-    // TODO(jons): freeb_data output to be implemented when free-boundary test
-    // case is set up
+
   }
+
+  output_quantities.threed1_free_boundary = ComputeThreed1FreeBoundary(
+      s, fc, h, output_quantities.vmec_internal_results,
+      output_quantities.b_cylindrical);
 
   output_quantities.indata = indata;
 
@@ -4324,7 +4452,8 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
     const Threed1FirstTable& threed1_first_table,
     const Threed1GeometricAndMagneticQuantities& threed1_geomag,
     const Threed1AxisGeometry& threed1_axis, const Threed1Betas& threed1_betas,
-    VmecStatus vmec_status, int iter2) {
+    const Threed1FreeBoundary& threed1_free_boundary, VmecStatus vmec_status,
+    int iter2) {
   // THIS SUBROUTINE CREATES THE FILE WOUT.
   // IT CONTAINS THE CYLINDRICAL COORDINATE SPECTRAL COEFFICIENTS
   // RMN,ZMN (full), LMN (half_mesh - CONVERTED FROM INTERNAL full

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -1680,8 +1680,6 @@ vmecpp::OutputQuantities vmecpp::ComputeOutputQuantities(
         output_quantities.threed1_geometric_magnetic,
         output_quantities.threed1_axis, output_quantities.threed1_betas,
         output_quantities.threed1_free_boundary, vmec_status, iter2);
-
-
   }
 
   output_quantities.threed1_free_boundary = ComputeThreed1FreeBoundary(

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
@@ -930,8 +930,7 @@ struct Threed1FreeBoundary {
   static absl::Status LoadInto(Threed1FreeBoundary& m_obj,
                                H5::H5File& from_file);
 
-  // NOLINTNEXTLINE(modernize-avoid-c-arrays,readability-identifier-naming)
-  static constexpr char H5key[] = "/threed1_free_boundary";
+  static constexpr const char* H5key = "/threed1_free_boundary";
 };
 
 // beta values from volume averages over plasma

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
@@ -930,6 +930,7 @@ struct Threed1FreeBoundary {
   static absl::Status LoadInto(Threed1FreeBoundary& m_obj,
                                H5::H5File& from_file);
 
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays,readability-identifier-naming)
   static constexpr char H5key[] = "/threed1_free_boundary";
 };
 

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
@@ -930,6 +930,9 @@ struct Threed1FreeBoundary {
   static absl::Status LoadInto(Threed1FreeBoundary& m_obj,
                                H5::H5File& from_file);
 
+  // Named H5key like the other serializable structs here: WRITEMEMBER and
+  // READMEMBER expand the name unqualified.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   static constexpr const char* H5key = "/threed1_free_boundary";
 };
 

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
@@ -898,6 +898,41 @@ struct Threed1AxisGeometry {
   static constexpr char H5key[] = "/threed1_axis_geometry";
 };
 
+// Edge quantities reported for a free-boundary run: the boundary geometry, the
+// plasma-side and vacuum-side pressures both as first established and as
+// converged, and the cylindrical field components on either side of the
+// boundary. freeb_data in Fortran VMEC. Every array is (nZeta,
+// nThetaReduced), and all are zero for a fixed-boundary run.
+struct Threed1FreeBoundary {
+  RowMatrixXd rb;
+  RowMatrixXd phib;
+  RowMatrixXd zb;
+  RowMatrixXd bsqmhdi;
+  RowMatrixXd bsqvaci;
+  RowMatrixXd bsqmhdf;
+  RowMatrixXd bsqvacf;
+  RowMatrixXd bredge;
+  RowMatrixXd bpedge;
+  RowMatrixXd bzedge;
+  RowMatrixXd brv;
+  RowMatrixXd bphiv;
+  RowMatrixXd bzv;
+
+  bool operator==(const Threed1FreeBoundary&) const = default;
+  bool operator!=(const Threed1FreeBoundary& o) const { return !(*this == o); }
+
+  // Write object to the specified HDF5 file, under key this->H5key.
+  absl::Status WriteTo(H5::H5File& file) const;
+
+  // Load contents of `from_file` into the specified instance.
+  // The file is expected to have the same schema as the one produced by
+  // WriteTo.
+  static absl::Status LoadInto(Threed1FreeBoundary& m_obj,
+                               H5::H5File& from_file);
+
+  static constexpr char H5key[] = "/threed1_free_boundary";
+};
+
 // beta values from volume averages over plasma
 struct Threed1Betas {
   // beta total
@@ -1348,6 +1383,7 @@ struct OutputQuantities {
   Threed1Volumetrics threed1_volumetrics;
   Threed1AxisGeometry threed1_axis;
   Threed1Betas threed1_betas;
+  Threed1FreeBoundary threed1_free_boundary;
   Threed1ShafranovIntegrals threed1_shafranov_integrals;
   WOutFileContents wout;
   VmecINDATA indata;
@@ -1369,6 +1405,14 @@ struct OutputQuantities {
 // Compute the output quantities of VMEC++.
 // With respect to Fortran VMEC, this is equivalent to the fileout subroutine,
 // but without the actual file writing routines.
+// Assemble the free-boundary edge quantities. The arrays stay zero unless the
+// run is free-boundary.
+Threed1FreeBoundary ComputeThreed1FreeBoundary(
+    const Sizes& s, const FlowControl& fc,
+    const HandoverStorage& handover_storage,
+    const VmecInternalResults& vmec_internal_results,
+    const CylindricalComponentsOfB& b_cylindrical);
+
 OutputQuantities ComputeOutputQuantities(
     int sign_of_jacobian, const VmecINDATA& indata, const Sizes& s,
     const FlowControl& fc, const VmecConstants& constants,
@@ -1520,7 +1564,8 @@ WOutFileContents ComputeWOutFileContents(
     const Threed1FirstTable& threed1_first_table,
     const Threed1GeometricAndMagneticQuantities& threed1_geomag,
     const Threed1AxisGeometry& threed1_axis, const Threed1Betas& threed1_betas,
-    VmecStatus vmec_status, int iter2);
+    const Threed1FreeBoundary& threed1_free_boundary, VmecStatus vmec_status,
+    int iter2);
 
 // Compare the contents of a test wout object against a reference wout object,
 // exiting with an error in case of mismatches.

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -205,6 +205,9 @@ Vmec::Vmec(const VmecINDATA& indata, std::optional<int> max_threads,
     bvecShare.setZero(mnpd_dim);
 
     h_.vacuum_magnetic_pressure.setZero(s_.nZnT);
+    h_.initial_plasma_pressure_at_boundary.setZero(s_.nZnT);
+    h_.initial_vacuum_pressure_at_boundary.setZero(s_.nZnT);
+    h_.edge_total_pressure.setZero(s_.nZnT);
     h_.vacuum_b_r.setZero(s_.nZnT);
     h_.vacuum_b_phi.setZero(s_.nZnT);
     h_.vacuum_b_z.setZero(s_.nZnT);

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
@@ -1466,4 +1466,61 @@ TEST(TestOutputQuantities, CheckVacuumPotential) {
   }
 }
 
+// freeb_data in Fortran VMEC: the boundary geometry, the plasma-side and
+// vacuum-side pressures as first established and as converged, and the
+// cylindrical field on either side of the boundary.
+TEST(Threed1FreeBoundary, MatchesEducationalVmec) {
+  const std::string identifier = "cth_like_free_bdy";
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile(absl::StrFormat("vmecpp/test_data/%s.json", identifier));
+  ASSERT_TRUE(indata_json.ok());
+  const absl::StatusOr<VmecINDATA> indata = VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(indata.ok());
+  ASSERT_TRUE(indata->lfreeb);
+
+  auto maybe_vmec = Vmec::FromIndata(*indata);
+  ASSERT_TRUE(maybe_vmec.ok());
+  Vmec& vmec = **maybe_vmec;
+  ASSERT_TRUE(vmec.run().ok());
+
+  const std::string filename = absl::StrFormat(
+      "vmecpp_large_cpp_tests/test_data/%s/freeb_data/"
+      "freeb_data_%05d_000000_01.%s.json",
+      identifier, vmec.fc_.ns, identifier);
+  std::ifstream ifs(filename);
+  ASSERT_TRUE(ifs.is_open()) << "failed to open reference file: " << filename;
+  const json reference = json::parse(ifs);
+
+  const Threed1FreeBoundary& threed1_free_boundary =
+      vmec.output_quantities_.threed1_free_boundary;
+  const Sizes& s = vmec.s_;
+  ASSERT_EQ(threed1_free_boundary.rb.rows(), s.nZeta);
+  ASSERT_EQ(threed1_free_boundary.rb.cols(), s.nThetaReduced);
+
+  static constexpr double kTolerance = 1.0e-10;
+  const auto compare = [&](const char* name, const RowMatrixXd& value) {
+    for (int k = 0; k < s.nZeta; ++k) {
+      for (int l = 0; l < s.nThetaReduced; ++l) {
+        EXPECT_TRUE(IsCloseRelAbs(static_cast<double>(reference[name][k][l]),
+                                  value(k, l), kTolerance))
+            << name << " at zeta index " << k << ", theta index " << l;
+      }  // l
+    }  // k
+  };
+
+  compare("rb", threed1_free_boundary.rb);
+  compare("phib", threed1_free_boundary.phib);
+  compare("zb", threed1_free_boundary.zb);
+  compare("bsqmhdi", threed1_free_boundary.bsqmhdi);
+  compare("bsqvaci", threed1_free_boundary.bsqvaci);
+  compare("bsqmhdf", threed1_free_boundary.bsqmhdf);
+  compare("bsqvacf", threed1_free_boundary.bsqvacf);
+  compare("bredge", threed1_free_boundary.bredge);
+  compare("bpedge", threed1_free_boundary.bpedge);
+  compare("bzedge", threed1_free_boundary.bzedge);
+  compare("brv", threed1_free_boundary.brv);
+  compare("bphiv", threed1_free_boundary.bphiv);
+  compare("bzv", threed1_free_boundary.bzv);
+}
+
 }  // namespace vmecpp


### PR DESCRIPTION
`freeb_data` in Fortran VMEC reports the boundary geometry, the plasma-side and vacuum-side pressures both as first established and as converged, and the cylindrical field on either side of the boundary. VMEC++ had none of it, and the two markers behind it, the `freeb_data` one and the `implement this !!!` one on `bsqsav(:,1)` and `(:,2)`, turn out to be the same piece of work: those two arrays exist only to be reported here.

Added:

- `HandoverStorage` keeps the three pressure snapshots: the plasma-side and vacuum-side values at the boundary as they stood when the vacuum solution was first established, and the extrapolated edge pressure, which are `bsqsav(:,1)`, `(:,2)` and `(:,3)`.
- `Threed1FreeBoundary` holds the thirteen edge arrays and is written to the output file beside the other `threed1` sections. It stays allocated and zero for a fixed-boundary run, as `potvac` does, and loading tolerates files written before the group existed.

Everything else it needs was already there: the vacuum field and pressure in `HandoverStorage`, the boundary geometry in the converged state, and the cylindrical field components, which the plasma side reaches by the half-to-full extrapolation `1.5 * last - 0.5 * previous`.

All thirteen arrays match the `educational_VMEC` `freeb_data` dump for `cth_like_free_bdy` to 1e-10 or better, most of them to 1e-13.
