### PR TITLE
Validate the only_coils current and pressure with the other input checks

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -1512,6 +1512,16 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
                           "'nestor' or 'only_coils', but is %s\n",
                           ToString(vmec_indata.free_boundary_method)));
     }
+
+    // 'only_coils' takes the field from the coils alone, so the plasma must
+    // carry neither current nor pressure.
+    if (vmec_indata.free_boundary_method == FreeBoundaryMethod::ONLY_COILS &&
+        (vmec_indata.curtor != 0.0 || vmec_indata.pres_scale != 0.0)) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "input variables 'curtor' and 'pres_scale' must be zero when "
+          "'free_boundary_method' is 'only_coils', but are %g and %g\n",
+          vmec_indata.curtor, vmec_indata.pres_scale));
+    }
   }
 
   /* --------------------------------- */

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
@@ -566,4 +566,28 @@ TEST(TestVmecINDATA, CopyMethod) {
   EXPECT_EQ(copy.zbc, indata.zbc);
 }  // CopyMethod
 
+TEST(TestVmecINDATA, CheckOnlyCoilsRejectsCurrentAndPressure) {
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile("vmecpp/test_data/cth_like_free_bdy.json");
+  ASSERT_TRUE(indata_json.ok());
+  const absl::StatusOr<VmecINDATA> indata = VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(indata.ok());
+  ASSERT_TRUE(indata->lfreeb);
+
+  VmecINDATA only_coils = *indata;
+  only_coils.free_boundary_method = FreeBoundaryMethod::ONLY_COILS;
+  only_coils.curtor = 0.0;
+  only_coils.pres_scale = 0.0;
+  EXPECT_TRUE(IsConsistent(only_coils, /*enable_info_messages=*/false).ok());
+
+  only_coils.curtor = 1.0e3;
+  EXPECT_EQ(IsConsistent(only_coils, /*enable_info_messages=*/false).code(),
+            absl::StatusCode::kInvalidArgument);
+
+  only_coils.curtor = 0.0;
+  only_coils.pres_scale = 1.0;
+  EXPECT_EQ(IsConsistent(only_coils, /*enable_info_messages=*/false).code(),
+            absl::StatusCode::kInvalidArgument);
+}
+
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -208,15 +208,6 @@ Vmec::Vmec(const VmecINDATA& indata, std::optional<int> max_threads,
     h_.vacuum_b_r.setZero(s_.nZnT);
     h_.vacuum_b_phi.setZero(s_.nZnT);
     h_.vacuum_b_z.setZero(s_.nZnT);
-
-    // TODO(jons): move this check to better-suited place
-    if (indata_.free_boundary_method == FreeBoundaryMethod::ONLY_COILS &&
-        (indata_.curtor != 0.0 || indata_.pres_scale != 0.0)) {
-      throw std::invalid_argument(
-          absl::StrCat("curtor and pres_scale must be zero when using "
-                       "'only_coils' free boundary method, but were ",
-                       indata_.curtor, " and ", indata_.pres_scale));
-    }  // check that cutor==0 and pres_scale==0 for only_coils
   }
 }
 


### PR DESCRIPTION
The `only_coils` check sat in the `Vmec` constructor's free-boundary allocation block and threw `std::invalid_argument` instead of returning a status.

It is input validation, so it now lives in `VmecINDATA::IsConsistent` beside the `free_boundary_method` check it belongs with, and returns `InvalidArgumentError`. It runs before construction rather than partway through it.

The test covers both halves of the condition and the case that should pass.
