### PR TITLE
Serialize the whole non-stellarator-symmetric axis and boundary arrays

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/BUILD.bazel
@@ -47,6 +47,7 @@ cc_test(
         "//vmecpp/test_data:cth_like_fixed_bdy_nzeta_37",
         "//vmecpp/test_data:cma",
         "//vmecpp/test_data:cth_like_free_bdy",
+        "//vmecpp/test_data:up_down_asym",
     ],
     deps = [
         ":vmec_indata",

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -373,8 +373,8 @@ absl::Status VmecINDATA::WriteTo(H5::H5File& file) const {
   WriteH5Dataset(raxis_c, "/indata/raxis_c", file);
   WriteH5Dataset(zaxis_s, "/indata/zaxis_s", file);
   if (lasym) {
-    WriteH5Dataset(raxis_s->value(), "/indata/raxis_s", file);
-    WriteH5Dataset(zaxis_c->value(), "/indata/zaxis_c", file);
+    WriteH5Dataset(*raxis_s, "/indata/raxis_s", file);
+    WriteH5Dataset(*zaxis_c, "/indata/zaxis_c", file);
   }
 
   // 2D matrices
@@ -382,8 +382,8 @@ absl::Status VmecINDATA::WriteTo(H5::H5File& file) const {
   WriteH5Dataset(rbc, "/indata/rbc", file);
   WriteH5Dataset(zbs, "/indata/zbs", file);
   if (lasym) {
-    WriteH5Dataset(rbs->value(), "/indata/rbs", file);
-    WriteH5Dataset(zbc->value(), "/indata/zbc", file);
+    WriteH5Dataset(*rbs, "/indata/rbs", file);
+    WriteH5Dataset(*zbc, "/indata/zbc", file);
   }
 
   return absl::OkStatus();
@@ -1261,8 +1261,8 @@ absl::StatusOr<std::string> VmecINDATA::ToJson() const {
   output["raxis_c"] = raxis_c;
   output["zaxis_s"] = zaxis_s;
   if (lasym) {
-    output["raxis_s"] = raxis_s->value();
-    output["zaxis_c"] = zaxis_c->value();
+    output["raxis_s"] = *raxis_s;
+    output["zaxis_c"] = *zaxis_c;
   }
 
   // (Initial Guess for) Boundary Geometry

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
@@ -359,10 +359,11 @@ TEST(TestVmecINDATA, OverlongAxisArraysAreRejected) {
               testing::HasSubstr("exceeds ntor+1"));
 }  // OverlongAxisArraysAreRejected
 
-TEST(TestVmecINDATA, HDF5IO) {
+// The asymmetric coefficients are only populated when lasym is set, so the
+// round trip has to be checked for both symmetry classes.
+void CheckHdf5RoundTrip(const std::string& filename) {
   // setup
-  absl::StatusOr<std::string> indata_json =
-      ReadFile("vmecpp/test_data/cth_like_free_bdy.json");
+  absl::StatusOr<std::string> indata_json = ReadFile(filename);
   ASSERT_TRUE(indata_json.ok());
 
   const absl::StatusOr<VmecINDATA> maybe_indata =
@@ -434,7 +435,49 @@ TEST(TestVmecINDATA, HDF5IO) {
   EXPECT_EQ(indata.zbs, indata_from_file.zbs);
   EXPECT_EQ(indata.rbs, indata_from_file.rbs);
   EXPECT_EQ(indata.zbc, indata_from_file.zbc);
+}  // CheckHdf5RoundTrip
+
+TEST(TestVmecINDATA, HDF5IO) {
+  CheckHdf5RoundTrip("vmecpp/test_data/cth_like_free_bdy.json");
 }  // HDF5IO
+
+TEST(TestVmecINDATA, HDF5IOAsymmetric) {
+  CheckHdf5RoundTrip("vmecpp/test_data/up_down_asym.json");
+}  // HDF5IOAsymmetric
+
+// ToJson has to emit what FromJson accepts, for both symmetry classes.
+void CheckJsonRoundTrip(const std::string& filename) {
+  const absl::StatusOr<std::string> indata_json = ReadFile(filename);
+  ASSERT_TRUE(indata_json.ok());
+  const absl::StatusOr<VmecINDATA> maybe_indata =
+      VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(maybe_indata.ok()) << maybe_indata.status();
+  const VmecINDATA& indata = *maybe_indata;
+
+  const absl::StatusOr<std::string> written = indata.ToJson();
+  ASSERT_TRUE(written.ok()) << written.status();
+
+  const absl::StatusOr<VmecINDATA> read_back = VmecINDATA::FromJson(*written);
+  ASSERT_TRUE(read_back.ok()) << read_back.status();
+
+  EXPECT_EQ(indata.lasym, read_back->lasym);
+  EXPECT_EQ(indata.raxis_c, read_back->raxis_c);
+  EXPECT_EQ(indata.zaxis_s, read_back->zaxis_s);
+  EXPECT_EQ(indata.raxis_s, read_back->raxis_s);
+  EXPECT_EQ(indata.zaxis_c, read_back->zaxis_c);
+  EXPECT_EQ(indata.rbc, read_back->rbc);
+  EXPECT_EQ(indata.zbs, read_back->zbs);
+  EXPECT_EQ(indata.rbs, read_back->rbs);
+  EXPECT_EQ(indata.zbc, read_back->zbc);
+}  // CheckJsonRoundTrip
+
+TEST(TestVmecINDATA, JsonRoundTrip) {
+  CheckJsonRoundTrip("vmecpp/test_data/cth_like_free_bdy.json");
+}  // JsonRoundTrip
+
+TEST(TestVmecINDATA, JsonRoundTripAsymmetric) {
+  CheckJsonRoundTrip("vmecpp/test_data/up_down_asym.json");
+}  // JsonRoundTripAsymmetric
 
 TEST(TestVmecINDATA, SetMpolNtor) {
   VmecINDATA indata =


### PR DESCRIPTION
`raxis_s`, `zaxis_c`, `rbs` and `zbc` are `std::optional`. `WriteTo` and `ToJson` reached them as `raxis_s->value()`, which dereferences the optional and then calls `Eigen::DenseBase::value()`. That returns `coeff(0, 0)`, so each array collapsed to its first element.

`OutputQuantities::Save` writes the INDATA into every output `.h5`, so a `lasym` run stored the antisymmetric axis and boundary as four scalars. `LoadInto` reads them back as arrays: the dataspace is scalar, `getSimpleExtentDims` writes nothing, and the shape comes from the uninitialized `dims`. On `up_down_asym`:

```
rbs in:   0  0.6  0.12  0            0
rbs out:  0  0     0    0  2.37152e-322
```

`ToJson` emits `"raxis_s":0.0`, and `FromJson` rejects that with `JSON element 'raxis_s' is not an array`, so a `lasym` INDATA does not survive its own JSON round trip either. `VmecInput.to_json` in the Python layer uses the same path.

Both sites now take `*raxis_s`. The HDF5 and JSON round-trip tests run for both symmetry classes and are instantiated for `up_down_asym`; all four assert on the axis and boundary arrays.
