### PR TITLE
Record what sets the hot restart comparison tolerance

### DIFF
--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec_hot_restart_test/vmec_hot_restart_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec_hot_restart_test/vmec_hot_restart_test.cc
@@ -725,7 +725,11 @@ TEST(HotRestartIntegration, FreeBoundary) {
   ASSERT_TRUE(displaced_fromscratch_output.ok());
 
   // COMPARE RUN FROM SCRATCH AND HOT-RESTARTED RUN
-  // FIXME(jons): How realistic are these tolerances?
+  //
+  // The bound is set by jdotb, which differs by 2.8e-2 between the two runs,
+  // and jcuru at 1.6e-2. Everything else stays at or below 1.8e-3 (DMerc),
+  // with the geometry and field coefficients at 1e-5 and the integrated
+  // scalars at 1e-10 or tighter.
   const double tolerance = 0.1;
   const bool check_equal_maximum_iterations = false;
   vmecpp::CompareWOut(displaced_hotrestarted_output->wout,


### PR DESCRIPTION
`FIXME(jons): How realistic are these tolerances?` on the 0.1 passed to `CompareWOut` between the hot-restarted and from-scratch displaced-coil runs.

Measured, as the worst relative deviation between the two `wout` structures:

| quantity | deviation |
|---|---|
| `jdotb` | 2.8e-2 |
| `jcuru` | 1.6e-2 |
| `DMerc` | 1.8e-3 |
| `bsupumnc`, `lmns`, `specw` | 4.5e-4, 1.7e-4, 3.5e-4 |
| `rmnc`, `zmns`, `bmnc`, `gmnc`, `bsubumnc`, `bsubvmnc`, `iotaf`, `bdotb` | 5e-6 to 1.8e-5 |
| `aspect`, `rbtor`, `bvco`, `vp`, `chi`, `betatotal` | 4e-8 to 6e-7 |
| `wb`, `wp`, `jcurv`, `ctor`, `buco` | 3e-10 to 3e-17 |

`jdotb` sets the bound, so 0.1 is a factor of 3.6 above what the comparison needs. The number stays and the comment says what fixes it.

Tightening further is not available at this call site: `CompareWOut` applies `current_density_tolerance` to `jcuru` and `jcurv` only, so `jdotb` is bounded by the main tolerance. Moving `jdotb` into that group would let this call site drop to 1e-2, at the cost of loosening `jdotb` from 1e-7 to 2e-7 in the two `vmec_in_memory_mgrid_test` comparisons.
