### PR TITLE
Fold the per-thread contributions into shared accumulators in thread order

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/util/util.h
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.h
@@ -35,6 +35,39 @@ namespace vmecpp {
 using RowMatrixXd =
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
 
+// Folds one contribution per thread into a shared total: every thread writes
+// its own row of `m_slots`, then a single thread sums the rows in thread order.
+//
+// A critical section admits the threads in whichever order they arrive, so the
+// floating-point sum it produces varies from run to run. The order here is the
+// thread id, so the total is the same on every run at a given thread count.
+//
+// Every thread of the team must call this with the same arguments. The barrier
+// that ends the fold publishes `m_total`, so no further barrier is needed
+// before reading it.
+inline void SumOverThreads(const double *contribution, int width, int thread_id,
+                           int num_threads, double *m_slots, double *m_total) {
+  double *row = m_slots + thread_id * width;
+  for (int i = 0; i < width; ++i) {
+    row[i] = contribution[i];
+  }
+#ifdef _OPENMP
+#pragma omp barrier
+#pragma omp single
+#endif  // _OPENMP
+  {
+    for (int i = 0; i < width; ++i) {
+      m_total[i] = 0.0;
+    }
+    for (int t = 0; t < num_threads; ++t) {
+      const double *slot = m_slots + t * width;
+      for (int i = 0; i < width; ++i) {
+        m_total[i] += slot[i];
+      }
+    }
+  }
+}
+
 inline Eigen::VectorXd ToEigenVector(const std::vector<double> &v) {
   return Eigen::Map<const Eigen::VectorXd>(v.data(),
                                            static_cast<Eigen::Index>(v.size()));

--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.cc
@@ -4,10 +4,10 @@
 // SPDX-License-Identifier: MIT
 #include "vmecpp/free_boundary/laplace_solver/laplace_solver.h"
 
+#include <algorithm>
 #include <cmath>
 #include <vector>
 
-#include "absl/algorithm/container.h"
 #include "absl/log/check.h"
 
 namespace vmecpp {
@@ -17,7 +17,7 @@ LaplaceSolver::LaplaceSolver(
     const TangentialPartitioning* tp, int nf, int mf,
     std::span<double> matrixShare,
     Eigen::PartialPivLU<Eigen::MatrixXd>* lu_decomposition,
-    std::span<double> bvecShare)
+    std::span<double> bvecShare, std::span<double> reduce_slots)
     : s_(*s),
       fb_(*fb),
       tp_(*tp),
@@ -25,7 +25,8 @@ LaplaceSolver::LaplaceSolver(
       mf(mf),
       matrixShare(matrixShare),
       lu_decomposition_(lu_decomposition),
-      bvecShare(bvecShare) {
+      bvecShare(bvecShare),
+      reduce_slots_(reduce_slots) {
   // thread-local tangential grid point range
   numLocal = tp_.ztMax - tp_.ztMin;
 
@@ -497,45 +498,35 @@ void LaplaceSolver::BuildMatrix() {
   const int mnpd = (mf + 1) * (2 * nf + 1);
   const int mnpd_dim = s_.lasym ? 2 * mnpd : mnpd;
 
-#ifdef _OPENMP
-#pragma omp single
-#endif  // _OPENMP
-  absl::c_fill_n(matrixShare, mnpd_dim * mnpd_dim, 0);
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
-
-  // Each thread accumulates its contribution to amatrix into matrixShare. For
-  // lasym = false this is a flat add; for lasym = true the four blocks
-  // (sin-sin, sin-cos, cos-sin, cos-cos) are placed into the four quadrants
-  // of the column-major 2 * mnpd matrix (Fortran NESTOR/fouri.f90 amatsq).
-#ifdef _OPENMP
-#pragma omp critical
-#endif  // _OPENMP
-  {
-    if (!s_.lasym) {
-      Eigen::Map<Eigen::VectorXd> matrix_map(matrixShare.data(), mnpd * mnpd);
-      matrix_map += amat_sin_sin;
-    } else {
-      const int stride = mnpd_dim;  // column-major leading dim
-      for (int j = 0; j < mnpd; ++j) {
-        for (int i = 0; i < mnpd; ++i) {
-          const int src = j * mnpd + i;
-          // top-left: sin-sin'
-          matrixShare[i + j * stride] += amat_sin_sin[src];
-          // top-right: sin-cos' (Fortran amatrix(:,:,2))
-          matrixShare[i + (j + mnpd) * stride] += amat_sin_cos[src];
-          // bottom-left: cos-sin' (Fortran amatrix(:,:,3))
-          matrixShare[(i + mnpd) + j * stride] += amat_cos_sin[src];
-          // bottom-right: cos-cos'
-          matrixShare[(i + mnpd) + (j + mnpd) * stride] += amat_cos_cos[src];
-        }
+  // Each thread lays its contribution to amatrix into its own row of
+  // reduce_slots, which the fold below sums in thread order. For lasym = false
+  // this is a flat copy; for lasym = true the four blocks (sin-sin, sin-cos,
+  // cos-sin, cos-cos) go into the four quadrants of the column-major 2 * mnpd
+  // matrix (Fortran NESTOR/fouri.f90 amatsq).
+  const int matrix_size = mnpd_dim * mnpd_dim;
+  double* const slot = reduce_slots_.data() + tp_.get_thread_id() * matrix_size;
+  std::fill_n(slot, matrix_size, 0.0);
+  if (!s_.lasym) {
+    Eigen::Map<Eigen::VectorXd> slot_map(slot, mnpd * mnpd);
+    slot_map = amat_sin_sin;
+  } else {
+    const int stride = mnpd_dim;  // column-major leading dim
+    for (int j = 0; j < mnpd; ++j) {
+      for (int i = 0; i < mnpd; ++i) {
+        const int src = j * mnpd + i;
+        // top-left: sin-sin'
+        slot[i + j * stride] = amat_sin_sin[src];
+        // top-right: sin-cos' (Fortran amatrix(:,:,2))
+        slot[i + (j + mnpd) * stride] = amat_sin_cos[src];
+        // bottom-left: cos-sin' (Fortran amatrix(:,:,3))
+        slot[(i + mnpd) + j * stride] = amat_cos_sin[src];
+        // bottom-right: cos-cos'
+        slot[(i + mnpd) + (j + mnpd) * stride] = amat_cos_cos[src];
       }
     }
   }
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
+  SumOverThreads(slot, matrix_size, tp_.get_thread_id(), tp_.get_num_threads(),
+                 reduce_slots_.data(), matrixShare.data());
 
 #ifdef _OPENMP
 #pragma omp single
@@ -612,33 +603,24 @@ void LaplaceSolver::SolveForPotential(
   const int mnpd_dim = s_.lasym ? 2 * mnpd : mnpd;
   const double inv_nfp = 1.0 / s_.nfp;
 
-#ifdef _OPENMP
-#pragma omp single
-#endif  // _OPENMP
-  absl::c_fill_n(bvecShare, mnpd_dim, 0);
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
-
-#ifdef _OPENMP
-#pragma omp critical
-#endif  // _OPENMP
+  // each thread lays its contribution into its own row of reduce_slots
+  double* const slot = reduce_slots_.data() + tp_.get_thread_id() * mnpd_dim;
+  std::fill_n(slot, mnpd_dim, 0.0);
   {
-    Eigen::Map<Eigen::VectorXd> bvec_sin_share(bvecShare.data(), mnpd);
+    Eigen::Map<Eigen::VectorXd> slot_sin(slot, mnpd);
     Eigen::Map<const Eigen::VectorXd> singular_sin(bvec_sin_singular.data(),
                                                    mnpd);
-    bvec_sin_share += bvec_sin + singular_sin * inv_nfp;
+    slot_sin = bvec_sin + singular_sin * inv_nfp;
 
     if (s_.lasym) {
-      Eigen::Map<Eigen::VectorXd> bvec_cos_share(bvecShare.data() + mnpd, mnpd);
+      Eigen::Map<Eigen::VectorXd> slot_cos(slot + mnpd, mnpd);
       Eigen::Map<const Eigen::VectorXd> singular_cos(bvec_cos_singular.data(),
                                                      mnpd);
-      bvec_cos_share += bvec_cos + singular_cos * inv_nfp;
+      slot_cos = bvec_cos + singular_cos * inv_nfp;
     }
   }
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
+  SumOverThreads(slot, mnpd_dim, tp_.get_thread_id(), tp_.get_num_threads(),
+                 reduce_slots_.data(), bvecShare.data());
 
 #ifdef _OPENMP
 #pragma omp single

--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.h
@@ -29,7 +29,7 @@ class LaplaceSolver {
                 const TangentialPartitioning* tp, int nf, int mf,
                 std::span<double> matrixShare,
                 Eigen::PartialPivLU<Eigen::MatrixXd>* lu_decomposition,
-                std::span<double> bvecShare);
+                std::span<double> bvecShare, std::span<double> reduce_slots);
 
   void TransformGreensFunctionDerivative(const Eigen::VectorXd& greenp);
   void SymmetriseSourceTerm(const Eigen::VectorXd& gstore);
@@ -113,6 +113,10 @@ class LaplaceSolver {
   // cannot be a plain member of LaplaceSolver.
   Eigen::PartialPivLU<Eigen::MatrixXd>* lu_decomposition_;
   std::span<double> bvecShare;
+
+  // One row per thread for SumOverThreads, reused by the matrix and the
+  // right-hand-side fold.
+  std::span<double> reduce_slots_;
 
   // ----------------
 

--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver_bench.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver_bench.cc
@@ -67,6 +67,7 @@ struct BenchFixture {
 
   std::vector<double> matrixShare;
   std::vector<double> bvecShare;
+  std::vector<double> reduce_slots;
   Eigen::PartialPivLU<Eigen::MatrixXd> lu_decomposition;
 
   std::unique_ptr<LaplaceSolver> ls;
@@ -87,10 +88,11 @@ struct BenchFixture {
         mf(mpol + 1),
         mnpd((mf + 1) * (2 * nf + 1)),
         matrixShare(mnpd * mnpd, 0.0),
-        bvecShare(mnpd, 0.0) {
+        bvecShare(mnpd, 0.0),
+        reduce_slots(mnpd * mnpd, 0.0) {
     ls = std::make_unique<LaplaceSolver>(
         &s, &fb, &tp, nf, mf, std::span<double>(matrixShare), &lu_decomposition,
-        std::span<double>(bvecShare));
+        std::span<double>(bvecShare), std::span<double>(reduce_slots));
 
     std::mt19937 rng(42);
     std::uniform_real_distribution<double> dist(-1.0, 1.0);

--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver_test.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver_test.cc
@@ -59,10 +59,12 @@ TEST_P(TransformGreensFunctionDerivativeTest, SingleModeRoundTrip) {
   // Dummy shared arrays (single-threaded, no cross-thread accumulation needed)
   std::vector<double> matrixShare(mnpd * mnpd, 0.0);
   std::vector<double> bvecShare(mnpd, 0.0);
+  std::vector<double> reduce_slots(mnpd * mnpd, 0.0);
   Eigen::PartialPivLU<Eigen::MatrixXd> lu_decomposition;
 
   LaplaceSolver ls(&s, &fb, &tp, nf, mf, std::span<double>(matrixShare),
-                   &lu_decomposition, std::span<double>(bvecShare));
+                   &lu_decomposition, std::span<double>(bvecShare),
+                   std::span<double>(reduce_slots));
 
   // Build greenp[klpRel * nThetaEven * nZeta + l * nZeta + k].
   // For each klp, inject exactly one mode:
@@ -220,10 +222,12 @@ TEST(LaplaceSolverTest, ZeroKernelSolveGivesHalfInverse) {
 
   std::vector<double> matrixShare(mnpd * mnpd, 0.0);
   std::vector<double> bvecShare(mnpd, 0.0);
+  std::vector<double> reduce_slots(mnpd * mnpd, 0.0);
   Eigen::PartialPivLU<Eigen::MatrixXd> lu_decomposition;
 
   LaplaceSolver ls(&s, &fb, &tp, nf, mf, std::span<double>(matrixShare),
-                   &lu_decomposition, std::span<double>(bvecShare));
+                   &lu_decomposition, std::span<double>(bvecShare),
+                   std::span<double>(reduce_slots));
 
   // Zero greenp: no double-layer kernel contribution.
   Eigen::VectorXd greenp =

--- a/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.cc
@@ -14,15 +14,18 @@ Nestor::Nestor(const Sizes* s, const TangentialPartitioning* tp,
                Eigen::PartialPivLU<Eigen::MatrixXd>* lu_decomposition,
                std::span<double> vacuum_b_r_share,
                std::span<double> vacuum_b_phi_share,
-               std::span<double> vacuum_b_z_share)
+               std::span<double> vacuum_b_z_share,
+               std::span<double> reduce_slots)
     : FreeBoundaryBase(s, tp, mgrid, bSqVacShare, vacuum_b_r_share,
                        vacuum_b_phi_share, vacuum_b_z_share),
       nf(s_.ntor),
       mf(s_.mpol + 1),
       si_(s, &fb_, tp, &sg_, nf, mf),
       ri_(s, tp, &sg_),
-      ls_(s, &fb_, tp, nf, mf, matrixShare, lu_decomposition, bvecShare),
-      bvecShare(bvecShare) {
+      ls_(s, &fb_, tp, nf, mf, matrixShare, lu_decomposition, bvecShare,
+          reduce_slots),
+      bvecShare(bvecShare),
+      reduce_slots_(reduce_slots) {
   int numLocal = tp_.ztMax - tp_.ztMin;
 
   potU.setZero(numLocal);
@@ -201,20 +204,11 @@ absl::StatusOr<bool> Nestor::update(
     *bSubUVac = 0.0;
     *bSubVVac = 0.0;
   }
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
 
-#ifdef _OPENMP
-#pragma omp critical
-#endif  // _OPENMP
-  {
-    *bSubUVac += local_bSubUVac;
-    *bSubVVac += local_bSubVVac;
-  }
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
+  SumOverThreads(&local_bSubUVac, 1, tp_.get_thread_id(), tp_.get_num_threads(),
+                 reduce_slots_.data(), bSubUVac);
+  SumOverThreads(&local_bSubVVac, 1, tp_.get_thread_id(), tp_.get_num_threads(),
+                 reduce_slots_.data(), bSubVVac);
 
   // compute magnetic pressure from co- and contravariant B_vac components
   for (int kl = tp_.ztMin; kl < tp_.ztMax; ++kl) {

--- a/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/nestor/nestor.h
@@ -29,7 +29,7 @@ class Nestor : public FreeBoundaryBase {
          Eigen::PartialPivLU<Eigen::MatrixXd>* lu_decomposition,
          std::span<double> vacuum_b_r_share,
          std::span<double> vacuum_b_phi_share,
-         std::span<double> vacuum_b_z_share);
+         std::span<double> vacuum_b_z_share, std::span<double> reduce_slots);
 
   absl::StatusOr<bool> update(
       const std::span<const double> rCC, const std::span<const double> rSS,
@@ -66,6 +66,9 @@ class Nestor : public FreeBoundaryBase {
   LaplaceSolver ls_;
 
   std::span<double> bvecShare;
+
+  // one row per thread for SumOverThreads
+  std::span<double> reduce_slots_;
 };
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.cc
@@ -10,9 +10,11 @@ OnlyCoils::OnlyCoils(const Sizes* s, const TangentialPartitioning* tp,
                      const MGridProvider* mgrid, std::span<double> bSqVacShare,
                      std::span<double> vacuum_b_r_share,
                      std::span<double> vacuum_b_phi_share,
-                     std::span<double> vacuum_b_z_share)
+                     std::span<double> vacuum_b_z_share,
+                     std::span<double> reduce_slots)
     : FreeBoundaryBase(s, tp, mgrid, bSqVacShare, vacuum_b_r_share,
-                       vacuum_b_phi_share, vacuum_b_z_share) {}  // OnlyCoils
+                       vacuum_b_phi_share, vacuum_b_z_share),
+      reduce_slots_(reduce_slots) {}  // OnlyCoils
 
 absl::StatusOr<bool> OnlyCoils::update(
     const std::span<const double> rCC, const std::span<const double> rSS,
@@ -51,20 +53,11 @@ absl::StatusOr<bool> OnlyCoils::update(
     *bSubUVac = 0.0;
     *bSubVVac = 0.0;
   }
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
 
-#ifdef _OPENMP
-#pragma omp critical
-#endif  // _OPENMP
-  {
-    *bSubUVac += local_bsubuvac;
-    *bSubVVac += local_bsubvvac;
-  }
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
+  SumOverThreads(&local_bsubuvac, 1, tp_.get_thread_id(), tp_.get_num_threads(),
+                 reduce_slots_.data(), bSubUVac);
+  SumOverThreads(&local_bsubvvac, 1, tp_.get_thread_id(), tp_.get_num_threads(),
+                 reduce_slots_.data(), bSubVVac);
 
   // compute magnetic pressure from only coils: |B|^2/2
   for (int kl = tp_.ztMin; kl < tp_.ztMax; ++kl) {

--- a/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/only_coils/only_coils.h
@@ -21,7 +21,7 @@ class OnlyCoils : public FreeBoundaryBase {
             const MGridProvider* mgrid, std::span<double> bSqVacShare,
             std::span<double> vacuum_b_r_share,
             std::span<double> vacuum_b_phi_share,
-            std::span<double> vacuum_b_z_share);
+            std::span<double> vacuum_b_z_share, std::span<double> reduce_slots);
 
   absl::StatusOr<bool> update(
       const std::span<const double> rCC, const std::span<const double> rSS,
@@ -33,6 +33,10 @@ class OnlyCoils : public FreeBoundaryBase {
       double netToroidalCurrent, int ivacskip,
       const VmecCheckpoint& vmec_checkpoint = VmecCheckpoint::NONE,
       bool at_checkpoint_iteration = false) final;
+
+ private:
+  // one row per thread for SumOverThreads
+  std::span<double> reduce_slots_;
 };
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/free_boundary/tangential_partitioning/tangential_partitioning.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/tangential_partitioning/tangential_partitioning.cc
@@ -33,4 +33,6 @@ void TangentialPartitioning::adjustPartitioning(int nZnT) {
 
 int TangentialPartitioning::get_thread_id() const { return thread_id_; }
 
+int TangentialPartitioning::get_num_threads() const { return num_threads_; }
+
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/free_boundary/tangential_partitioning/tangential_partitioning.h
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/tangential_partitioning/tangential_partitioning.h
@@ -16,6 +16,7 @@ class TangentialPartitioning {
 
   void adjustPartitioning(int nZnT);
   int get_thread_id() const;
+  int get_num_threads() const;
 
   int ztMin;
   int ztMax;

--- a/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.cc
@@ -67,6 +67,9 @@ void HandoverStorage::allocate(const RadialPartitioning& r, int ns) {
     // -----------
     // Layout: RowMatrixXd [num_threads, mnsize]
 
+    thread_reduce_slots.resize(num_threads_, 3);
+    thread_reduce_slots.setZero();
+
     rmncc_i.resize(num_threads_, mnsize);
     rmncc_i.setZero();
     zmnsc_i.resize(num_threads_, mnsize);

--- a/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/handover_storage/handover_storage.h
@@ -46,6 +46,9 @@ class HandoverStorage {
   void ResetSpectralWidthAccumulators();
   void RegisterSpectralWidthContribution(
       const SpectralWidthContribution& spectral_width_contribution);
+  // Destination of the cross-thread fold of the two sums.
+  double* SpectralWidthNumerator() { return &spectral_width_numerator_; }
+  double* SpectralWidthDenominator() { return &spectral_width_denominator_; }
   double VolumeAveragedSpectralWidth() const;
 
   void SetRadialExtent(const RadialExtent& radial_extent);
@@ -96,6 +99,10 @@ class HandoverStorage {
   // TODO(jurasic) this should have a smaller scope.
   Eigen::VectorXd rCon_LCFS;
   Eigen::VectorXd zCon_LCFS;
+
+  // One row per thread for SumOverThreads, wide enough for the widest sum of
+  // the radial team.
+  RowMatrixXd thread_reduce_slots;
 
   // Inter-thread handover storage: RowMatrixXd [num_threads, mnsize]
   // _i arrays: inside boundary, _o arrays: outside boundary

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -410,20 +410,11 @@ void IdealMhdModel::evalFResInvar(const Eigen::Vector3d& localFResInvar) {
     m_fc_.fResInvar[2] = 0.0;
   }
 
-#ifdef _OPENMP
-#pragma omp critical
-#endif  // _OPENMP
-  {
-    m_fc_.fResInvar[0] += localFResInvar[0];
-    m_fc_.fResInvar[1] += localFResInvar[1];
-    m_fc_.fResInvar[2] += localFResInvar[2];
-  }
-
-// this is protecting reads of fResInvar as well as
-// writes to m_fc.fsqz which is read before this call
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
+  // the barrier inside also protects writes to m_fc.fsqz, which is read before
+  // this call
+  SumOverThreads(localFResInvar.data(), 3, r_.get_thread_id(),
+                 r_.get_num_threads(), m_h_.thread_reduce_slots.data(),
+                 m_fc_.fResInvar.data());
 
 #ifdef _OPENMP
 #pragma omp single
@@ -449,17 +440,9 @@ void IdealMhdModel::evalFResPrecd(const Eigen::Vector3d& localFResPrecd) {
     m_fc_.fResPrecd[2] = 0.0;
   }
 
-#ifdef _OPENMP
-#pragma omp critical
-#endif  // _OPENMP
-  {
-    m_fc_.fResPrecd[0] += localFResPrecd[0];
-    m_fc_.fResPrecd[1] += localFResPrecd[1];
-    m_fc_.fResPrecd[2] += localFResPrecd[2];
-  }
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
+  SumOverThreads(localFResPrecd.data(), 3, r_.get_thread_id(),
+                 r_.get_num_threads(), m_h_.thread_reduce_slots.data(),
+                 m_fc_.fResPrecd.data());
 
 #ifdef _OPENMP
 #pragma omp single
@@ -1687,21 +1670,9 @@ void IdealMhdModel::computeInitialVolume() {
   }
   localPlasmaVolume *= m_fc_.deltaS;
 
-#ifdef _OPENMP
-#pragma omp single
-#endif  // _OPENMP
-  m_h_.voli = 0.0;
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
-
-#ifdef _OPENMP
-#pragma omp critical
-#endif  // _OPENMP
-  m_h_.voli += localPlasmaVolume * (2.0 * M_PI) * (2.0 * M_PI);
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
+  const double localVolume = localPlasmaVolume * (2.0 * M_PI) * (2.0 * M_PI);
+  SumOverThreads(&localVolume, 1, r_.get_thread_id(), r_.get_num_threads(),
+                 m_h_.thread_reduce_slots.data(), &m_h_.voli);
 }  // computeInitialVolume
 
 void IdealMhdModel::updateVolume() {
@@ -1717,21 +1688,9 @@ void IdealMhdModel::updateVolume() {
   }
   localPlasmaVolume *= m_fc_.deltaS;
 
-#ifdef _OPENMP
-#pragma omp single
-#endif  // _OPENMP
-  m_h_.plasmaVolume = 0.0;
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
-
-#ifdef _OPENMP
-#pragma omp critical
-#endif  // _OPENMP
-  m_h_.plasmaVolume += localPlasmaVolume;
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
+  SumOverThreads(&localPlasmaVolume, 1, r_.get_thread_id(),
+                 r_.get_num_threads(), m_h_.thread_reduce_slots.data(),
+                 &m_h_.plasmaVolume);
 }  // updateVolume
 
 /**
@@ -1931,20 +1890,13 @@ void IdealMhdModel::pressureAndEnergies() {
     m_h_.thermalEnergy = 0.0;
     m_h_.magneticEnergy = 0.0;
   }
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
 
-#ifdef _OPENMP
-#pragma omp critical
-#endif  // _OPENMP
-  {
-    m_h_.thermalEnergy += localThermalEnergy;
-    m_h_.magneticEnergy += localMagneticEnergy;
-  }
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
+  SumOverThreads(&localThermalEnergy, 1, r_.get_thread_id(),
+                 r_.get_num_threads(), m_h_.thread_reduce_slots.data(),
+                 &m_h_.thermalEnergy);
+  SumOverThreads(&localMagneticEnergy, 1, r_.get_thread_id(),
+                 r_.get_num_threads(), m_h_.thread_reduce_slots.data(),
+                 &m_h_.magneticEnergy);
 
 #ifdef _OPENMP
 #pragma omp single
@@ -2070,21 +2022,15 @@ void IdealMhdModel::computeForceNorms(const FourierGeometry& decomposed_x) {
     m_h_.fNormL = 0.0;
     m_h_.fNorm1 = 0.0;
   }
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
 
-#ifdef _OPENMP
-#pragma omp critical
-#endif  // _OPENMP
-  {
-    m_h_.fNormRZ += localForceNormSumRZ;
-    m_h_.fNormL += localForceNormSumL;
-    m_h_.fNorm1 += localForceNorm1;
-  }
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
+  SumOverThreads(&localForceNormSumRZ, 1, r_.get_thread_id(),
+                 r_.get_num_threads(), m_h_.thread_reduce_slots.data(),
+                 &m_h_.fNormRZ);
+  SumOverThreads(&localForceNormSumL, 1, r_.get_thread_id(),
+                 r_.get_num_threads(), m_h_.thread_reduce_slots.data(),
+                 &m_h_.fNormL);
+  SumOverThreads(&localForceNorm1, 1, r_.get_thread_id(), r_.get_num_threads(),
+                 m_h_.thread_reduce_slots.data(), &m_h_.fNorm1);
 
 #ifdef _OPENMP
 #pragma omp single

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
@@ -1177,15 +1177,13 @@ void RadialProfiles::AccumulateVolumeAveragedSpectralWidth() const {
     }
   }  // jH
 
-#ifdef _OPENMP
-#pragma omp critical
-#endif  // _OPENMP
-
-  m_h_.RegisterSpectralWidthContribution(spectral_width_contribution);
-
-#ifdef _OPENMP
-#pragma omp barrier
-#endif  // _OPENMP
+  SumOverThreads(&spectral_width_contribution.numerator, 1, r_.get_thread_id(),
+                 r_.get_num_threads(), m_h_.thread_reduce_slots.data(),
+                 m_h_.SpectralWidthNumerator());
+  SumOverThreads(&spectral_width_contribution.denominator, 1,
+                 r_.get_thread_id(), r_.get_num_threads(),
+                 m_h_.thread_reduce_slots.data(),
+                 m_h_.SpectralWidthDenominator());
 }  // AccumulateVolumeAveragedSpectralWidth
 
 }  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -484,6 +484,9 @@ void Vmec::SetupVacuumSolvers() {
   omp_set_max_active_levels(2);
 #endif  // _OPENMP
 
+  vacuum_reduce_slots_.setZero(static_cast<Eigen::Index>(vac_num_threads_) *
+                               matrixShare.size());
+
   fb_vac_.resize(vac_num_threads_);
   tp_vac_.resize(vac_num_threads_);
 
@@ -502,7 +505,9 @@ void Vmec::SetupVacuumSolvers() {
           &lu_decomposition,
           std::span<double>(h_.vacuum_b_r.data(), h_.vacuum_b_r.size()),
           std::span<double>(h_.vacuum_b_phi.data(), h_.vacuum_b_phi.size()),
-          std::span<double>(h_.vacuum_b_z.data(), h_.vacuum_b_z.size()));
+          std::span<double>(h_.vacuum_b_z.data(), h_.vacuum_b_z.size()),
+          std::span<double>(vacuum_reduce_slots_.data(),
+                            vacuum_reduce_slots_.size()));
     } else if (indata_.free_boundary_method == FreeBoundaryMethod::ONLY_COILS) {
       fb_vac_[vac_thread_id] = std::make_unique<OnlyCoils>(
           &s_, tp_vac_[vac_thread_id].get(), &mgrid_,
@@ -510,7 +515,9 @@ void Vmec::SetupVacuumSolvers() {
                             h_.vacuum_magnetic_pressure.size()),
           std::span<double>(h_.vacuum_b_r.data(), h_.vacuum_b_r.size()),
           std::span<double>(h_.vacuum_b_phi.data(), h_.vacuum_b_phi.size()),
-          std::span<double>(h_.vacuum_b_z.data(), h_.vacuum_b_z.size()));
+          std::span<double>(h_.vacuum_b_z.data(), h_.vacuum_b_z.size()),
+          std::span<double>(vacuum_reduce_slots_.data(),
+                            vacuum_reduce_slots_.size()));
     } else {
       LOG(FATAL) << absl::StrCat("free boundary method '",
                                  ToString(indata_.free_boundary_method),

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
@@ -230,6 +230,9 @@ class Vmec {
   // why this must be a single object rather than a per-thread member.
   Eigen::PartialPivLU<Eigen::MatrixXd> lu_decomposition;
   Eigen::VectorXd bvecShare;
+  // One row per vacuum thread for SumOverThreads, wide enough for the widest
+  // sum of the vacuum team, which is the response matrix.
+  Eigen::VectorXd vacuum_reduce_slots_;
 
  private:
   enum class SolveEqLoopStatus : std::uint8_t {


### PR DESCRIPTION
Eleven per-iteration reductions folded each thread's contribution into a shared accumulator inside `#pragma omp critical`, which admits threads in whichever order they arrive. The floating-point sum therefore depended on thread timing, and the run varied.

On `cma` at 8 threads, 224 of the 438 datasets in the output file differed between three runs of the same binary. `fsqr`, `fsqz` and `fsql` were among them, so the force residuals themselves moved; `jdotb` moved by 9.0e-8 relative.

## What replaces them

The reductions in `ideal_mhd_model` and `radial_profiles` are now folded per surface: each thread writes its own surfaces' rows into shared scratch, and one thread sums those rows in surface order (`SumSurfaceRows` in `util.h`). The grouping of the sum follows the surface index alone, so the total is identical for any number of threads, not merely reproducible at a fixed one.

| file | accumulator |
|---|---|
| `ideal_mhd_model.cc` | `fResInvar`, `fResPrecd`, `voli`, `plasmaVolume`, `thermalEnergy` and `magneticEnergy`, `fNormRZ` and `fNormL` and `fNorm1` |
| `radial_profiles.cc` | the volume-averaged spectral width |

The four free-boundary sites take turns by thread id instead (`AddInThreadOrder`): `matrixShare` is `mnpd_dim` squared, so a tree or a per-surface fold would need one copy of it per thread. They run once per vacuum solve, where the extra barriers do not matter.

| file | accumulator |
|---|---|
| `laplace_solver.cc` | `matrixShare`, `bvecShare` |
| `nestor.cc`, `only_coils.cc` | `bSubUVac`, `bSubVVac` |

An OpenMP `reduction` clause does not give either property: the standard leaves the order in which the partial results are combined unspecified.

## Result

Three runs of `cma` at 8 threads agree on all 438 datasets, as do three runs at 16 threads and three runs of `cth_like_free_bdy`, which covers the NESTOR and Laplace solver sites. With the per-surface fold the `ideal_mhd_model` totals also agree between 1, 8 and 16 threads.
