### PR TITLE
Add proof-carrying equilibrium certificates via Stellarocq

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ Reference <api/vmecpp>
 Examples <examples_overview>
 Fourier Basis Details <fourier_basis_implementation>
 Benchmarks <benchmarks>
+Proof-Carrying Equilibria <proof_carrying_equilibria>
 ```
 
 ![MIT license](https://img.shields.io/badge/license-MIT-blue)

--- a/docs/proof_carrying_equilibria.md
+++ b/docs/proof_carrying_equilibria.md
@@ -2,25 +2,25 @@
 
 Rocq is a proof assistant: a program that checks mathematical proofs down to every inference step. It has been developed at Inria since 1984 under its former name, Coq, and received the ACM Software System Award in 2013. It is the system in which the four-color theorem was verified and in which CompCert, the first formally verified C compiler, was built. When Rocq accepts a theorem, what remains to be trusted is its small proof-checking kernel and the stated assumptions, not the author of the proof and not the code that produced the numbers.
 
-[Stellarocq](https://github.com/CharlesCNorton/stellarocq) uses that machinery to give a VMEC++ equilibrium a certificate. A converged wout ships with a small file, and an independent checker, extracted from a Rocq proof, validates it. The theorem behind the checker says: if the verdict is VALID, then the ideal-MHD force residual of the field reconstructed from these exact coefficients, by a reconstruction rule stated in the certificate, is a genuine real number at every certified point, with magnitude below the stated bound. A division by zero, an invalid square root, or an unlucky rounding anywhere in that evaluation makes the verdict INVALID, because the arithmetic is verified interval arithmetic (CoqInterval, proven against the Flocq formalization of IEEE-754).
+[Stellarocq](https://github.com/CharlesCNorton/stellarocq) uses that machinery to give a VMEC++ equilibrium a certificate. A converged wout ships with a small file, and an independent checker, extracted from a Rocq proof, validates it. The theorem behind the checker says: if the verdict is VALID, then the ideal-MHD force residual of the field reconstructed from these exact coefficients, by VMEC's own half-grid rule, is a genuine real number at every certified point, with magnitude below the stated bound. A division by zero, an invalid square root, or an unlucky rounding anywhere in that evaluation makes the verdict INVALID, because the arithmetic is verified interval arithmetic (CoqInterval, proven against the Flocq formalization of IEEE-754).
 
 The value is independence. "This wout satisfies force balance" normally means "VMEC++ says so, and VMEC++ agrees with Fortran VMEC." The checker shares no code with either and does not trust the generator that wrote the certificate: it recomputes everything from the coefficients with proven-sound arithmetic. A wout that passes cannot misstate its residual, whatever bug either solver might contain.
 
-What is certified: the mu0-scaled residual `J x B - grad p` of the smooth field defined by the wout Fourier coefficients under a fixed interpolation rule, evaluated at a stated grid of points, bounded per component. What is not: the continuum between the points, or anything about the solver's internals. The trust base is the Rocq kernel, the classical real axioms of its standard library, the primitive float and integer specifications, and a thin parsing driver, all listed in the Stellarocq README.
+What is certified: the mu0-scaled residual `J x B - grad p` of the field defined by the wout Fourier coefficients under VMEC's half-grid conventions (parity-aware averages of R and Z onto the half grid, the wout's half-grid lambda and iota, centered differences of the covariant field across the node), evaluated at a stated set of full-grid nodes and angles, bounded per component. What is not: the continuum between the points, or anything about the solver's internals. The trust base is the Rocq kernel, the classical real axioms of its standard library, the primitive float and integer specifications, and a thin parsing driver, all listed in the Stellarocq README.
 
 ## Usage
 
 ```sh
-python examples/make_equilibrium_certificate.py wout_solovev.nc cert.txt
-stellarocq-check cert.txt        # the checker binary, built from Stellarocq
+python examples/make_equilibrium_certificate.py wout_solovev.nc cert.txt   # --nodes 6 --nu 8 --nv 4 --prec 53
+stellarocq-check cert.txt        # the checker binary, built from Stellarocq; STELLAROCQ_JOBS=n workers
 ```
 
 ## Results
 
 | case | points | verdict |
 |---|---|---|
-| `wout_solovev` (axisymmetric, ns=55) | 48 | VALID, 146 s |
-| `wout_cma` (3D, nfp=2, 59 modes, ns=51) | 72 | VALID, 2025 s |
-| solovev with one `rmnc` coefficient perturbed by 0.1% | 48 | INVALID, 0.6 s |
+| `wout_solovev` (axisymmetric, ns=55) | 48 | VALID, 0.1 s |
+| `wout_cma` (3D, nfp=2, 59 modes, ns=51) | 192 | VALID, 2.8 s on 20 workers |
+| solovev with one `rmnc` coefficient of a certified stencil perturbed by 0.1% | 48 | INVALID, 0.1 s |
 
 Certification is offline and per-wout; nothing runs in CI.

--- a/docs/proof_carrying_equilibria.md
+++ b/docs/proof_carrying_equilibria.md
@@ -6,7 +6,9 @@ Rocq is a proof assistant: a program that checks mathematical proofs down to eve
 
 The value is independence. "This wout satisfies force balance" normally means "VMEC++ says so, and VMEC++ agrees with Fortran VMEC." The checker shares no code with either and does not trust the generator that wrote the certificate: it recomputes everything from the coefficients with proven-sound arithmetic. A wout that passes cannot misstate its residual, whatever bug either solver might contain.
 
-What is certified: the mu0-scaled residual `J x B - grad p` of the field defined by the wout Fourier coefficients under VMEC's half-grid conventions (parity-aware averages of R and Z onto the half grid, the wout's half-grid lambda and iota, centered differences of the covariant field across the node), at a stated set of full-grid nodes, bounded per component. What is not: anything about the solver's internals. The trust base is the Rocq kernel, the classical real axioms of its standard library, the primitive float and integer specifications, and a thin parsing driver, all listed in the Stellarocq README.
+What is certified: the mu0-scaled residual `J x B - grad p` of the field defined by the wout Fourier coefficients under VMEC's half-grid conventions (parity-aware averages of R and Z onto the half grid, the wout's half-grid lambda and iota, centered differences of the covariant field across the node), at a stated set of full-grid nodes, bounded per component. Both symmetry classes are covered, and the pressure may be a power series, a two-power form, a spline piece, a rational function or a truncated Gaussian. What is not certified: anything about the solver's internals. The trust base is the Rocq kernel, the classical real axioms of its standard library, the primitive float and integer specifications, and a thin parsing driver, all listed in the Stellarocq README.
+
+Beside the certificates, Stellarocq proves identities the reconstruction satisfies rather than assumes. `divergence_free` states that the divergence of the reconstructed field is exactly zero, and `pressure_is_a_flux_function` that dp/ds reads neither angle; the latter rests on no axioms at all.
 
 ## Points and cells
 
@@ -31,15 +33,19 @@ stellarocq-check cert.txt
 
 Six nodes per case, 20 worker processes.
 
-| case | points | verdict |
-|---|---|---|
-| `wout_solovev` (axisymmetric, ns=55) | 48 | VALID, 0.1 s |
-| `wout_cma` (3D, nfp=2, 59 modes, ns=51) | 192 | VALID, 2.8 s on 20 workers |
-| solovev with one `rmnc` coefficient of a certified stencil perturbed by 0.1% | 48 | INVALID, 0.1 s |
+| case | points | worst bound, of the field scale | verdict |
+|---|---|---|---|
+| `wout_solovev` (axisymmetric, ns=55, power series) | 48 | 7.3e-5 | VALID, 0.1 s |
+| `wout_cma` (3D, nfp=2, 59 modes, ns=51) | 192 | 3.3e-2 | VALID, 2.8 s on 20 workers |
+| `wout_cth_like_fixed_bdy` (3D, nfp=5, 41 modes, ns=25, two-power pressure) | 192 | 7.9e-3 | VALID, 2.7 s |
+| `up_down_asym` (non-stellarator-symmetric, ns=17) | 48 | 6.0e-3 | VALID, 0.0 s |
+| solovev with one `rmnc` coefficient of a certified stencil perturbed by 0.1% | 48 | same claim | INVALID, 0.1 s |
+
+Every stellarator-symmetric case above also certifies through the non-stellarator-symmetric reconstruction with its antisymmetric coefficients set to zero, at the same bounds, which is the reduction `tests/test_lasym.py` requires of the solver.
 
 | case | cells | worst cell bound | of the field scale | verdict |
 |---|---|---|---|---|
-| `wout_solovev` (axisymmetric, ns=55) | 49152 | 1.3e-5 | 1.9e-4 | VALID, 1156 s |
+| `wout_solovev` (axisymmetric, ns=55) | 49152 | 1.3e-5 | 1.9e-4 | VALID, 434 s |
 | `wout_circular_tokamak` (axisymmetric, ns=17) | 49152 | 1.5e-2 | 2.5e-4 | VALID, 902 s |
 | `wout_cma` (3D, nfp=2, 59 modes, ns=51) | 24576 | 1.3e-2 | 4.3e-2 | VALID, 8368 s |
 | `wout_li383_low_res` (3D, nfp=3, 25 modes, ns=16) | 24576 | 8.7e-1 | 2.4e-1 | VALID, 2276 s |

--- a/docs/proof_carrying_equilibria.md
+++ b/docs/proof_carrying_equilibria.md
@@ -6,7 +6,13 @@ Rocq is a proof assistant: a program that checks mathematical proofs down to eve
 
 The value is independence. "This wout satisfies force balance" normally means "VMEC++ says so, and VMEC++ agrees with Fortran VMEC." The checker shares no code with either and does not trust the generator that wrote the certificate: it recomputes everything from the coefficients with proven-sound arithmetic. A wout that passes cannot misstate its residual, whatever bug either solver might contain.
 
-What is certified: the mu0-scaled residual `J x B - grad p` of the field defined by the wout Fourier coefficients under VMEC's half-grid conventions (parity-aware averages of R and Z onto the half grid, the wout's half-grid lambda and iota, centered differences of the covariant field across the node), evaluated at a stated set of full-grid nodes and angles, bounded per component. What is not: the continuum between the points, or anything about the solver's internals. The trust base is the Rocq kernel, the classical real axioms of its standard library, the primitive float and integer specifications, and a thin parsing driver, all listed in the Stellarocq README.
+What is certified: the mu0-scaled residual `J x B - grad p` of the field defined by the wout Fourier coefficients under VMEC's half-grid conventions (parity-aware averages of R and Z onto the half grid, the wout's half-grid lambda and iota, centered differences of the covariant field across the node), at a stated set of full-grid nodes, bounded per component. What is not: anything about the solver's internals. The trust base is the Rocq kernel, the classical real axioms of its standard library, the primitive float and integer specifications, and a thin parsing driver, all listed in the Stellarocq README.
+
+## Points and cells
+
+The angles of a certificate can be certified two ways. A point certificate bounds the residual at the angles it lists. A cell certificate bounds it over cells of angles that abut, so its verdict speaks for a continuum of angles and not for a sample of them: the theorem behind it (`check_ccert_correct`) walks from the centre of a cell to any point of it by a mean-value step in each angle, with the derivative enclosed over the whole cell.
+
+The bounds of a cell certificate are written by the checker, not by the generator. Interval arithmetic over a box loses the cancellation that makes an equilibrium residual small, and how much it loses is a property of the arithmetic that no float sample predicts, so `--tighten` reads back the enclosure the verified code computes for each cell and writes the smallest claim that code accepts. The result is an ordinary certificate, and an ordinary run establishes it.
 
 ## Usage
 
@@ -15,12 +21,31 @@ python examples/make_equilibrium_certificate.py wout_solovev.nc cert.txt   # --n
 stellarocq-check cert.txt        # the checker binary, built from Stellarocq; STELLAROCQ_JOBS=n workers
 ```
 
+```sh
+python examples/make_equilibrium_certificate.py wout_solovev.nc cells.txt --cells --nodes 6 --nu 8192
+stellarocq-check --tighten cells.txt cert.txt
+stellarocq-check cert.txt
+```
+
 ## Results
+
+Six nodes per case, 20 worker processes.
 
 | case | points | verdict |
 |---|---|---|
 | `wout_solovev` (axisymmetric, ns=55) | 48 | VALID, 0.1 s |
 | `wout_cma` (3D, nfp=2, 59 modes, ns=51) | 192 | VALID, 2.8 s on 20 workers |
 | solovev with one `rmnc` coefficient of a certified stencil perturbed by 0.1% | 48 | INVALID, 0.1 s |
+
+| case | cells | worst cell bound | of the field scale | verdict |
+|---|---|---|---|---|
+| `wout_solovev` (axisymmetric, ns=55) | 49152 | 1.3e-5 | 1.9e-4 | VALID, 1156 s |
+| `wout_circular_tokamak` (axisymmetric, ns=17) | 49152 | 1.5e-2 | 2.5e-4 | VALID, 902 s |
+| `wout_cma` (3D, nfp=2, 59 modes, ns=51) | 24576 | 1.3e-2 | 4.3e-2 | VALID, 8368 s |
+| `wout_li383_low_res` (3D, nfp=3, 25 modes, ns=16) | 24576 | 8.7e-1 | 2.4e-1 | VALID, 2276 s |
+
+The two axisymmetric cases carry 6 nodes of 8192 poloidal cells covering the whole angular torus; the two three-dimensional ones carry 3 nodes of 4096 poloidal cells at each of 2 toroidal angles.
+
+An axisymmetric equilibrium has every `n` zero, so its toroidal derivative encloses to zero and one cell spans the whole toroidal angle; the covering of the angular torus is one-dimensional. A three-dimensional one has to resolve the toroidal direction as finely as the poloidal, which squares the cell count, so its cells cover the poloidal angle at each of a few toroidal angles instead.
 
 Certification is offline and per-wout; nothing runs in CI.

--- a/docs/proof_carrying_equilibria.md
+++ b/docs/proof_carrying_equilibria.md
@@ -1,0 +1,26 @@
+# Proof-carrying equilibria
+
+Rocq is a proof assistant: a program that checks mathematical proofs down to every inference step. It has been developed at Inria since 1984 under its former name, Coq, and received the ACM Software System Award in 2013. It is the system in which the four-color theorem was verified and in which CompCert, the first formally verified C compiler, was built. When Rocq accepts a theorem, what remains to be trusted is its small proof-checking kernel and the stated assumptions, not the author of the proof and not the code that produced the numbers.
+
+[Stellarocq](https://github.com/CharlesCNorton/stellarocq) uses that machinery to give a VMEC++ equilibrium a certificate. A converged wout ships with a small file, and an independent checker, extracted from a Rocq proof, validates it. The theorem behind the checker says: if the verdict is VALID, then the ideal-MHD force residual of the field reconstructed from these exact coefficients, by a reconstruction rule stated in the certificate, is a genuine real number at every certified point, with magnitude below the stated bound. A division by zero, an invalid square root, or an unlucky rounding anywhere in that evaluation makes the verdict INVALID, because the arithmetic is verified interval arithmetic (CoqInterval, proven against the Flocq formalization of IEEE-754).
+
+The value is independence. "This wout satisfies force balance" normally means "VMEC++ says so, and VMEC++ agrees with Fortran VMEC." The checker shares no code with either and does not trust the generator that wrote the certificate: it recomputes everything from the coefficients with proven-sound arithmetic. A wout that passes cannot misstate its residual, whatever bug either solver might contain.
+
+What is certified: the mu0-scaled residual `J x B - grad p` of the smooth field defined by the wout Fourier coefficients under a fixed interpolation rule, evaluated at a stated grid of points, bounded per component. What is not: the continuum between the points, or anything about the solver's internals. The trust base is the Rocq kernel, the classical real axioms of its standard library, the primitive float and integer specifications, and a thin parsing driver, all listed in the Stellarocq README.
+
+## Usage
+
+```sh
+python examples/make_equilibrium_certificate.py wout_solovev.nc cert.txt
+stellarocq-check cert.txt        # the checker binary, built from Stellarocq
+```
+
+## Results
+
+| case | points | verdict |
+|---|---|---|
+| `wout_solovev` (axisymmetric, ns=55) | 48 | VALID, 146 s |
+| `wout_cma` (3D, nfp=2, 59 modes, ns=51) | 72 | VALID, 2025 s |
+| solovev with one `rmnc` coefficient perturbed by 0.1% | 48 | INVALID, 0.6 s |
+
+Certification is offline and per-wout; nothing runs in CI.

--- a/examples/make_equilibrium_certificate.py
+++ b/examples/make_equilibrium_certificate.py
@@ -4,19 +4,23 @@ The checker that validates the certificate is built from
 https://github.com/CharlesCNorton/stellarocq; see
 docs/proof_carrying_equilibria.md.
 
-The certificate states, for a set of evaluation points, that the mu0-scaled
-ideal-MHD force residual of the equilibrium reconstructed from the wout
-coefficients (by the rule fixed in theories/Physics.v) lies within the
-claimed per-component bounds.  Every numeric input is an IEEE double from
-the wout, emitted exactly as a dyadic rational m*2^e; the checker encloses
-the true real arithmetic with proven-sound interval arithmetic, so a VALID
-verdict is a theorem about these exact inputs.
+The certificate states, for a set of full-grid nodes and angles, that the
+mu0-scaled ideal-MHD force residual of the equilibrium reconstructed from the
+wout coefficients by VMEC's own half-grid rule (fixed in theories/Physics.v of
+Stellarocq) lies within the claimed per-component bounds: r_s at the node from
+the centered differences of its two half points, r_u and r_v at the outer half
+point.  Every numeric input is an IEEE double from the wout, emitted exactly as
+a dyadic rational m*2^e; the checker encloses the true real arithmetic with
+proven-sound interval arithmetic, so a VALID verdict is a theorem about these
+exact inputs.
 
 Environment layout per point (must match theories/Physics.v):
-  0 s | 1 u | 2 v | 3 phip | 4..7 sfull | 8..11 shalf | 12..15 iota
-  16..36 am | 37+0..4K-1 R | +4K Z | +8K L      (K = mnmax)
+  0 s_j | 1 u | 2 v | 3 phip | 4..6 s_{j-1} s_j s_{j+1} | 7..8 s_{j-1/2} s_{j+1/2}
+  9..10 iota(h-) iota(h+) | 11..31 am | 32+0..3K-1 R (rows j-1, j, j+1)
+  +3K Z | +6K lambda (rows h-, h+)      (K = mnmax)
+  32+8K..   scratch slots the checker fills with shared subexpressions
 
-Usage:  python make_equilibrium_certificate.py [wout_X.nc [cert_X.txt]] [--bands 6] [--nu 8] [--nv 4]
+Usage:  python make_equilibrium_certificate.py [wout_X.nc [cert_X.txt]] [--nodes 6] [--nu 8] [--nv 4]
 Without arguments it certifies the shipped wout_solovev.nc into cert_solovev.txt.
 """
 
@@ -61,10 +65,10 @@ class Wout:
         self.ns = int(v["ns"][:])
         self.xm = g("xm").astype(int)
         self.xn = g("xn").astype(int)
-        self.rmnc = g("rmnc")
+        self.rmnc = g("rmnc")  # (ns, mnmax), full grid
         self.zmns = g("zmns")
-        self.lmns = g("lmns")
-        self.iotas = g("iotas")
+        self.lmns = g("lmns")  # (ns, mnmax), half grid: row j is s_{j-1/2}
+        self.iotas = g("iotas")  # half grid, same indexing
         self.phips = g("phips")
         self.am = g("am")
         ptype = v["pmass_type"][:].tobytes().decode().replace("\x00", "").strip()
@@ -74,108 +78,67 @@ class Wout:
         d.close()
         self.h = 1.0 / (self.ns - 1)
         self.s_full = np.arange(self.ns) * self.h
-        self.s_half = (
-            np.arange(1, self.ns) - 0.5
-        ) * self.h  # nodes of lmns[1:], iotas[1:]
+        self.s_half = (np.arange(self.ns) - 0.5) * self.h  # row j of lmns, iotas
 
 
-def band_tables(w, i):
-    """Stencils for an evaluation point in full-grid band [s_i, s_{i+1}].
-
-    Full grid stencil: nodes i-1..i+2 of s_full (coefficients rmnc/zmns).
-    Half grid: the eval point s* = midpoint of the band lies exactly on
-    half node j = i (0-based into lmns[1:]); stencil j-1..j+2.
-    """
-    sf = w.s_full[i - 1 : i + 3]
-    sh = w.s_half[i - 1 : i + 3]
-    R = w.rmnc[i - 1 : i + 3, :]
-    Z = w.zmns[i - 1 : i + 3, :]
-    L = w.lmns[1:][i - 1 : i + 3, :]
-    IO = w.iotas[1:][i - 1 : i + 3]
-    return sf, sh, R, Z, L, IO
+# ----- float reference of the same rule, for choosing eps -----------------
 
 
-# ----- float reference evaluation (same rule), for choosing eps -------------
+def half_coefs(w, j_in, j_out, s_h, coefs):
+    """C(h) and c'(h) of every mode between full nodes j_in and j_out, by VMEC's parity-
+    aware rule."""
+    ya, yb = coefs[j_in], coefs[j_out]
+    s_a, s_b = w.s_full[j_in], w.s_full[j_out]
+    odd = (w.xm % 2) == 1
+    c = 0.5 * (ya + yb)
+    cs = (yb - ya) / (s_b - s_a)
+    qa, qb = ya / np.sqrt(s_a), yb / np.sqrt(s_b)
+    c_odd = np.sqrt(s_h) * 0.5 * (qa + qb)
+    cs_odd = np.sqrt(s_h) * (qb - qa) / (s_b - s_a) + c_odd / (2.0 * s_h)
+    return np.where(odd, c_odd, c), np.where(odd, cs_odd, cs)
 
 
-def hermite_rho(sn, y, s):
-    """Value, d/ds, d2/ds2 of the Hermite-in-rho profile at s."""
-    r = np.sqrt(sn)
-    rr = np.sqrt(s)
-    h = r[2] - r[1]
-    t = (rr - r[1]) / h
-    d1 = (y[2] - y[0]) / (r[2] - r[0])
-    d2 = (y[3] - y[1]) / (r[3] - r[1])
-    h00 = 2 * t**3 - 3 * t**2 + 1
-    h10 = t**3 - 2 * t**2 + t
-    h01 = -2 * t**3 + 3 * t**2
-    h11 = t**3 - t**2
-    val = h00 * y[1] + h10 * h * d1 + h01 * y[2] + h11 * h * d2
-    dh00 = (6 * t**2 - 6 * t) / h
-    dh10 = 3 * t**2 - 4 * t + 1
-    dh01 = (-6 * t**2 + 6 * t) / h
-    dh11 = 3 * t**2 - 2 * t
-    drho = dh00 * y[1] + dh10 * d1 + dh01 * y[2] + dh11 * d2
-    d2h00 = (12 * t - 6) / h**2
-    d2h10 = (6 * t - 4) / h
-    d2h01 = (-12 * t + 6) / h**2
-    d2h11 = (6 * t - 2) / h
-    d2rho = d2h00 * y[1] + d2h10 * d1 + d2h01 * y[2] + d2h11 * d2
-    ds = drho / (2 * rr)
-    dss = d2rho / (4 * s) - drho / (4 * s * rr)
-    return val, ds, dss
-
-
-def residual_ref(w, band, s, u, vv, phip):
-    """Float reference of the residual at one point, for choosing bounds."""
-    sf, sh, Rn, Zn, Ln, IOn = band
-    m = w.xm
-    n = w.xn
+def half_point(w, j_in, j_out, row_l, u, vv, phip):
+    """B^u, B^v, B_u, B_v, d_u B_s, d_v B_s and mu0 sqrtg J^s at the half point."""
+    m, n = w.xm, w.xn
+    s_h = w.s_half[row_l]
+    cR, cRs = half_coefs(w, j_in, j_out, s_h, w.rmnc)
+    cZ, cZs = half_coefs(w, j_in, j_out, s_h, w.zmns)
+    cL = w.lmns[row_l]
+    iota = float(w.iotas[row_l])
     ang = m * u - n * vv
     c = np.cos(ang)
-    sn_ = np.sin(ang)
-    rv, rd, rdd = hermite_rho(sf, Rn, s)
-    zv, zd, zdd = hermite_rho(sf, Zn, s)
-    lv, ld, _ = hermite_rho(sh, Ln, s)
-    iot, iotp, _ = hermite_rho(sh, IOn.reshape(4, 1), s)
-    iot = float(iot[0])
-    iotp = float(iotp[0])
+    sn = np.sin(ang)
 
     def S(cf, k):
         return float(np.dot(cf, k))
 
-    R = S(rv, c)
-    Z_s = S(zd, sn_)
-    lam_u = S(lv, m * c)
-    R_s = S(rd, c)
-    Z_ss = S(zdd, sn_)
-    lam_v = S(lv, -n * c)
-    R_ss = S(rdd, c)
-    Z_u = S(zv, m * c)
-    lam_su = S(ld, m * c)
-    R_u = S(rv, -m * sn_)
-    Z_v = S(zv, -n * c)
-    lam_sv = S(ld, -n * c)
-    R_v = S(rv, n * sn_)
-    Z_su = S(zd, m * c)
-    lam_uu = S(lv, -m * m * sn_)
-    R_su = S(rd, -m * sn_)
-    Z_sv = S(zd, -n * c)
-    lam_uv = S(lv, m * n * sn_)
-    R_sv = S(rd, n * sn_)
-    Z_uu = S(zv, -m * m * sn_)
-    lam_vv = S(lv, -n * n * sn_)
-    R_uu = S(rv, -m * m * c)
-    Z_uv = S(zv, m * n * sn_)
-    R_uv = S(rv, m * n * c)
-    Z_vv = S(zv, -n * n * sn_)
-    R_vv = S(rv, -n * n * c)
+    R = S(cR, c)
+    R_s = S(cRs, c)
+    R_u = S(cR, -m * sn)
+    R_v = S(cR, n * sn)
+    R_su = S(cRs, -m * sn)
+    R_sv = S(cRs, n * sn)
+    R_uu = S(cR, -m * m * c)
+    R_uv = S(cR, m * n * c)
+    R_vv = S(cR, -n * n * c)
+    Z_s = S(cZs, sn)
+    Z_u = S(cZ, m * c)
+    Z_v = S(cZ, -n * c)
+    Z_su = S(cZs, m * c)
+    Z_sv = S(cZs, -n * c)
+    Z_uu = S(cZ, -m * m * sn)
+    Z_uv = S(cZ, m * n * sn)
+    Z_vv = S(cZ, -n * n * sn)
+    L_u = S(cL, m * c)
+    L_v = S(cL, -n * c)
+    L_uu = S(cL, -m * m * sn)
+    L_uv = S(cL, m * n * sn)
+    L_vv = S(cL, -n * n * sn)
     tau = R_u * Z_s - R_s * Z_u
     sqrtg = R * tau
-    tau_s = R_su * Z_s + R_u * Z_ss - R_ss * Z_u - R_s * Z_su
     tau_u = R_uu * Z_s + R_u * Z_su - R_su * Z_u - R_s * Z_uu
     tau_v = R_uv * Z_s + R_u * Z_sv - R_sv * Z_u - R_s * Z_uv
-    g_s = R_s * tau + R * tau_s
     g_u = R_u * tau + R * tau_u
     g_v = R_v * tau + R * tau_v
     guu = R_u**2 + Z_u**2
@@ -183,9 +146,6 @@ def residual_ref(w, band, s, u, vv, phip):
     gvv = R_v**2 + Z_v**2 + R**2
     gsu = R_s * R_u + Z_s * Z_u
     gsv = R_s * R_v + Z_s * Z_v
-    guu_s = 2 * (R_u * R_su + Z_u * Z_su)
-    guv_s = R_su * R_v + R_u * R_sv + Z_su * Z_v + Z_u * Z_sv
-    gvv_s = 2 * (R_v * R_sv + Z_v * Z_sv + R * R_s)
     gsu_u = R_su * R_u + R_s * R_uu + Z_su * Z_u + Z_s * Z_uu
     gsu_v = R_sv * R_u + R_s * R_uv + Z_sv * Z_u + Z_s * Z_uv
     gsv_u = R_su * R_v + R_s * R_uv + Z_su * Z_v + Z_s * Z_uv
@@ -194,31 +154,51 @@ def residual_ref(w, band, s, u, vv, phip):
     guv_u = R_uu * R_v + R_u * R_uv + Z_uu * Z_v + Z_u * Z_uv
     guv_v = R_uv * R_v + R_u * R_vv + Z_uv * Z_v + Z_u * Z_vv
     gvv_u = 2 * (R_v * R_uv + Z_v * Z_uv + R * R_u)
-    bu = iot - lam_v
-    bv = 1.0 + lam_u
+    bu = iota - L_v
+    bv = 1.0 + L_u
     Bu = phip * bu / sqrtg
     Bv = phip * bv / sqrtg
-    bu_s = iotp - lam_sv
-    bv_s = lam_su
-    Bu_s = phip * (bu_s * sqrtg - bu * g_s) / sqrtg**2
-    Bv_s = phip * (bv_s * sqrtg - bv * g_s) / sqrtg**2
-    Bu_u = phip * (-lam_uv * sqrtg - bu * g_u) / sqrtg**2
-    Bv_u = phip * (lam_uu * sqrtg - bv * g_u) / sqrtg**2
-    Bu_v = phip * (-lam_vv * sqrtg - bu * g_v) / sqrtg**2
-    Bv_v = phip * (lam_uv * sqrtg - bv * g_v) / sqrtg**2
-    B_u_s = guu_s * Bu + guu * Bu_s + guv_s * Bv + guv * Bv_s
-    B_v_s = guv_s * Bu + guv * Bu_s + gvv_s * Bv + gvv * Bv_s
+    Bu_u = phip * (-L_uv * sqrtg - bu * g_u) / sqrtg**2
+    Bv_u = phip * (L_uu * sqrtg - bv * g_u) / sqrtg**2
+    Bu_v = phip * (-L_vv * sqrtg - bu * g_v) / sqrtg**2
+    Bv_v = phip * (L_uv * sqrtg - bv * g_v) / sqrtg**2
+    B_u = guu * Bu + guv * Bv
+    B_v = guv * Bu + gvv * Bv
     B_s_u = gsu_u * Bu + gsu * Bu_u + gsv_u * Bv + gsv * Bv_u
     B_s_v = gsu_v * Bu + gsu * Bu_v + gsv_v * Bv + gsv * Bv_v
     B_u_v = guu_v * Bu + guu * Bu_v + guv_v * Bv + guv * Bv_v
     B_v_u = guv_u * Bu + guv * Bu_u + gvv_u * Bv + gvv * Bv_u
-    pp = sum(k * a * s ** (k - 1) for k, a in enumerate(w.am) if k > 0)
-    rs = (B_s_v - B_v_s) * Bv - (B_u_s - B_s_u) * Bu - MU0 * pp
     mu0Js = B_v_u - B_u_v
-    ru = -mu0Js * Bv
-    rv_ = mu0Js * Bu
-    B2 = Bu * (guu * Bu + guv * Bv) + Bv * (guv * Bu + gvv * Bv)
-    return rs, ru, rv_, B2
+    B2 = Bu * B_u + Bv * B_v
+    return {
+        "Bu": Bu,
+        "Bv": Bv,
+        "B_u": B_u,
+        "B_v": B_v,
+        "B_s_u": B_s_u,
+        "B_s_v": B_s_v,
+        "mu0Js": mu0Js,
+        "B2": B2,
+    }
+
+
+def residual_ref(w, j, u, vv, phip):
+    """Float reference of the residual at node j, for choosing bounds."""
+    qm = half_point(w, j - 1, j, j, u, vv, phip)  # h- = row j of the half grid
+    qp = half_point(w, j, j + 1, j + 1, u, vv, phip)  # h+ = row j+1
+    h = w.s_half[j + 1] - w.s_half[j]
+    avg = lambda k: 0.5 * (qm[k] + qp[k])  # noqa: E731
+    dif = lambda k: (qp[k] - qm[k]) / h  # noqa: E731
+    s = w.s_full[j]
+    pp = sum(k * a * s ** (k - 1) for k, a in enumerate(w.am) if k > 0)
+    rs = (
+        (avg("B_s_v") - dif("B_v")) * avg("Bv")
+        - (dif("B_u") - avg("B_s_u")) * avg("Bu")
+        - MU0 * pp
+    )
+    ru = -qp["mu0Js"] * qp["Bv"]
+    rv_ = qp["mu0Js"] * qp["Bu"]
+    return rs, ru, rv_, max(qm["B2"], qp["B2"])
 
 
 def main():
@@ -230,10 +210,16 @@ def main():
     )
     ap.add_argument("wout", nargs="?", default=str(default_wout))
     ap.add_argument("out", nargs="?", default=None)
-    ap.add_argument("--bands", type=int, default=6)
+    ap.add_argument("--nodes", type=int, default=6)
     ap.add_argument("--nu", type=int, default=8)
     ap.add_argument("--nv", type=int, default=4)
     ap.add_argument("--slack", type=float, default=1.5)
+    ap.add_argument(
+        "--prec",
+        type=int,
+        default=53,
+        help="working precision of the interval arithmetic in bits",
+    )
     a = ap.parse_args()
     if a.out is None:
         a.out = f"cert_{pathlib.Path(a.wout).stem.removeprefix('wout_')}.txt"
@@ -247,9 +233,10 @@ def main():
     three_d = (w.xn != 0).any()
     nv = a.nv if three_d else 1
 
-    # evaluation bands: interior full-grid bands, evenly spread
-    lo, hi = 2, w.ns - 4
-    idx = np.unique(np.linspace(lo, hi, a.bands).astype(int))
+    # certified nodes: interior full-grid nodes with both neighbors off the
+    # axis, evenly spread
+    lo, hi = 2, w.ns - 2
+    idx = np.unique(np.linspace(lo, hi, a.nodes).astype(int))
     # angles: exact doubles
     us = [float(2 * np.pi * k / a.nu) for k in range(a.nu)]
     vs = [float(2 * np.pi * k / (nfp * nv)) for k in range(nv)]
@@ -258,27 +245,25 @@ def main():
     # choose eps from the float reference
     worst = np.zeros(3)
     scale = 0.0
-    per_band = []
-    for i in idx:
-        bt = band_tables(w, i)
-        s = float(w.s_half[i])  # midpoint of band [s_i, s_{i+1}]
+    per_node = []
+    for j in idx:
         mx = np.zeros(3)
         for u, v in angles:
-            rs, ru, rv_, B2 = residual_ref(w, bt, s, u, v, phip)
+            rs, ru, rv_, B2 = residual_ref(w, j, u, v, phip)
             mx = np.maximum(mx, np.abs([rs, ru, rv_]))
             scale = max(scale, abs(B2))
-        per_band.append((i, s, mx))
+        per_node.append((j, w.s_full[j], mx))
         worst = np.maximum(worst, mx)
     # Floor: interval evaluation carries genuine rounding width, so a claimed
     # bound must sit above it. 1e-10 of the field-energy scale is far above
-    # the enclosure width of ~1e5 double operations and far below any
-    # physical residual of interest.
+    # the enclosure width of the evaluation and far below any physical residual
+    # of interest.
     eps = np.maximum(worst * a.slack, 1e-10 * scale)
 
     lines = []
     P = lines.append
-    P("STELLAROCQ-CERT 1")
-    P("PREC 80")
+    P("STELLAROCQ-CERT 2")
+    P(f"PREC {a.prec}")
     P(f"MODES {K}")
     for m, n in zip(w.xm, w.xn, strict=True):
         P(f"{m} {n}")
@@ -292,22 +277,28 @@ def main():
     P(f"NANGLES {len(angles)}")
     for u, v in angles:
         P("{} {} {} {}".format(*dyadic(u), *dyadic(v)))
-    P(f"NBANDS {len(idx)}")
-    for i in idx:
-        sf, sh, Rn, Zn, Ln, IOn = band_tables(w, i)
-        P("BAND")
-        P("S {} {}".format(*dyadic(w.s_half[i])))
-        P("SFULL " + " ".join("{} {}".format(*dyadic(x)) for x in sf))
-        P("SHALF " + " ".join("{} {}".format(*dyadic(x)) for x in sh))
-        P("IOTA " + " ".join("{} {}".format(*dyadic(x)) for x in IOn))
-        for tag, M in (("RNODES", Rn), ("ZNODES", Zn), ("LNODES", Ln)):
+    P(f"NNODES {len(idx)}")
+    for j in idx:
+        P("NODE")
+        P("S {} {}".format(*dyadic(w.s_full[j])))
+        P(
+            "SNODES "
+            + " ".join("{} {}".format(*dyadic(x)) for x in w.s_full[j - 1 : j + 2])
+        )
+        P("SHALF " + " ".join("{} {}".format(*dyadic(x)) for x in w.s_half[j : j + 2]))
+        P("IOTA " + " ".join("{} {}".format(*dyadic(x)) for x in w.iotas[j : j + 2]))
+        for tag, M in (
+            ("RNODES", w.rmnc[j - 1 : j + 2]),
+            ("ZNODES", w.zmns[j - 1 : j + 2]),
+            ("LHALF", w.lmns[j : j + 2]),
+        ):
             P(tag)
-            for row in M:  # 4 stencil rows
+            for row in M:
                 P(" ".join("{} {}".format(*dyadic(x)) for x in row))
     pathlib.Path(a.out).write_text("\n".join(lines) + "\n")
 
     print(
-        f"wrote {a.out}: {len(idx)} bands x {len(angles)} angles = "
+        f"wrote {a.out}: {len(idx)} nodes x {len(angles)} angles = "
         f"{len(idx) * len(angles)} points, K={K}"
     )
     print(
@@ -318,8 +309,8 @@ def main():
         f"reference B^2 scale {scale:.3e}  ->  normalized r_s bound "
         f"{eps[0] / scale:.3e}"
     )
-    for i, s, mx in per_band:
-        print(f"  band {i:3d}  s={s:.4f}  |r|max = {mx[0]:.3e} {mx[1]:.3e} {mx[2]:.3e}")
+    for j, s, mx in per_node:
+        print(f"  node {j:3d}  s={s:.4f}  |r|max = {mx[0]:.3e} {mx[1]:.3e} {mx[2]:.3e}")
 
 
 if __name__ == "__main__":

--- a/examples/make_equilibrium_certificate.py
+++ b/examples/make_equilibrium_certificate.py
@@ -20,6 +20,15 @@ Environment layout per point (must match theories/Physics.v):
   +3K Z | +6K lambda (rows h-, h+)      (K = mnmax)
   32+8K..   scratch slots the checker fills with shared subexpressions
 
+With --cells the certificate instead claims its bounds over cells of angles, so
+that a VALID verdict covers the continuum between the sampled angles and not
+only the samples. The bounds of a cell certificate are written by the checker
+itself:
+
+  python make_equilibrium_certificate.py wout_X.nc cell_X.txt --cells --nu 8192
+  stellarocq-check --tighten cell_X.txt cert_X.txt
+  stellarocq-check cert_X.txt
+
 Usage:  python make_equilibrium_certificate.py [wout_X.nc [cert_X.txt]] [--nodes 6] [--nu 8] [--nv 4]
 Without arguments it certifies the shipped wout_solovev.nc into cert_solovev.txt.
 """
@@ -201,6 +210,103 @@ def residual_ref(w, j, u, vv, phip):
     return rs, ru, rv_, max(qm["B2"], qp["B2"])
 
 
+ANGLE_EXP = -50
+
+
+def dyadic_at(x, e=ANGLE_EXP):
+    """X on the fixed dyadic grid of step 2^e, as (mantissa, e).
+
+    The angles have to share a fine exponent: the checker varies the mantissa
+    of the angle slot, so one mantissa unit is 2^e radians, and taking whatever
+    exponent the double happens to carry makes the unit meaningless (u = 0 has
+    exponent 0, one unit of which is a radian).
+    """
+    return round(float(x) / 2.0**e), e
+
+
+def write_ccert(a, w, K, phip, idx, us, vs, nv, three_d):
+    """Write a cell certificate: every angle of every cell is covered.
+
+    A cell spans half a spacing either side of its centre angle, so the cells
+    of an axisymmetric case tile the whole angular torus and those of a
+    three-dimensional case tile u in [0, 2 pi) at each of nv toroidal angles.
+    The half-widths are carried in units of the mantissa of the centre angle,
+    which is what the checker varies, and the bounds are left to
+    "main --tighten".
+    """
+    wu = a.wscale * np.pi / len(us)
+    # An axisymmetric equilibrium has every n zero, so the v derivative of the
+    # residual encloses to zero and one cell covers the whole toroidal angle.
+    # A three-dimensional one needs the v extent resolved as finely as the u
+    # extent, which squares the cell count, so its cells are u segments at nv
+    # toroidal angles instead.
+    wv = a.wscale * np.pi if not three_d else 0.0
+    lines = []
+    P = lines.append
+    P("STELLAROCQ-CCERT 3")
+    P(f"PREC {a.prec}")
+    P(f"MODES {K}")
+    for m, n in zip(w.xm, w.xn, strict=True):
+        P(f"{m} {n}")
+    P("PHIP {} {}".format(*dyadic(phip)))
+    P("AM 21")
+    for j in range(21):
+        am_j = w.am[j] if j < len(w.am) else 0.0
+        P("{} {}".format(*dyadic(am_j)))
+
+    angles = [(u, v) for u in us for v in vs]
+    P(f"NANGLES {len(angles)}")
+    for u, v in angles:
+        mu, eu = dyadic_at(u)
+        mv, ev = dyadic_at(v)
+        # Half-width in mantissa units, rounded up. The rounding of a centre
+        # onto the grid moves it by at most half a unit, so rounding the
+        # half-width up by a whole one leaves the cells overlapping rather
+        # than gapped, and their union is the whole angle.
+        du = int(np.ceil(wu / 2.0**eu)) if wu > 0 else 0
+        dv = int(np.ceil(wv / 2.0**ev)) if wv > 0 else 0
+        P(f"{mu} {eu} {mv} {ev} {du} {dv}")
+
+    P(f"NNODES {len(idx)}")
+    for j in idx:
+        P("NODE")
+        P("S {} {}".format(*dyadic(w.s_full[j])))
+        P(
+            "SNODES "
+            + " ".join("{} {}".format(*dyadic(x)) for x in w.s_full[j - 1 : j + 2])
+        )
+        P("SHALF " + " ".join("{} {}".format(*dyadic(x)) for x in w.s_half[j : j + 2]))
+        P("IOTA " + " ".join("{} {}".format(*dyadic(x)) for x in w.iotas[j : j + 2]))
+        for tag, M in (
+            ("RNODES", w.rmnc[j - 1 : j + 2]),
+            ("ZNODES", w.zmns[j - 1 : j + 2]),
+            ("LHALF", w.lmns[j : j + 2]),
+        ):
+            P(tag)
+            for row in M:
+                P(" ".join("{} {}".format(*dyadic(x)) for x in row))
+        P(f"CELLS {len(angles)}")
+        # The bounds are placeholders that "main --tighten" replaces with the
+        # enclosures the checker computes, because the width of an interval
+        # enclosure of a cancelling expression is a property of the arithmetic
+        # and cannot be predicted from a float sample of the function.
+        for _ in angles:
+            for _ in range(3):
+                P("1 0 1 0 1 0 4 0")
+    pathlib.Path(a.out).write_text("\n".join(lines) + "\n")
+    print(
+        f"wrote {a.out}: {len(idx)} nodes x {len(angles)} cells = "
+        f"{len(idx) * len(angles)} cells, K={K}"
+    )
+    cover = (
+        "the cells tile the whole angular torus"
+        if not three_d
+        else f"the cells tile u in [0, 2 pi) at each of {nv} toroidal angles"
+    )
+    print(f"cell half-widths: u {wu:.4e} rad, v {wv:.4e} rad; {cover}")
+    print("run 'stellarocq-check --tighten' on it to set the bounds, then check it")
+
+
 def main():
     """Read the wout, choose the bounds, write the certificate."""
     ap = argparse.ArgumentParser()
@@ -210,7 +316,26 @@ def main():
     )
     ap.add_argument("wout", nargs="?", default=str(default_wout))
     ap.add_argument("out", nargs="?", default=None)
+    ap.add_argument(
+        "--cells",
+        action="store_true",
+        help="emit a cell certificate: the bound holds at every angle of each "
+        "cell, not only at its centre",
+    )
+    ap.add_argument(
+        "--wscale",
+        type=float,
+        default=1.0,
+        help="scale the cell half-widths. 1 makes the cells tile the angular "
+        "torus exactly; smaller leaves gaps and is for diagnosis only.",
+    )
     ap.add_argument("--nodes", type=int, default=6)
+    ap.add_argument(
+        "--node",
+        type=int,
+        default=None,
+        help="certify this single full-grid node instead of a spread of them",
+    )
     ap.add_argument("--nu", type=int, default=8)
     ap.add_argument("--nv", type=int, default=4)
     ap.add_argument("--slack", type=float, default=1.5)
@@ -236,11 +361,29 @@ def main():
     # certified nodes: interior full-grid nodes with both neighbors off the
     # axis, evenly spread
     lo, hi = 2, w.ns - 2
-    idx = np.unique(np.linspace(lo, hi, a.nodes).astype(int))
+    if a.node is not None:
+        if not lo <= a.node <= hi:
+            msg = f"--node must lie in [{lo}, {hi}]"
+            raise SystemExit(msg)
+        idx = np.array([a.node])
+    else:
+        idx = np.unique(np.linspace(lo, hi, a.nodes).astype(int))
     # angles: exact doubles
     us = [float(2 * np.pi * k / a.nu) for k in range(a.nu)]
     vs = [float(2 * np.pi * k / (nfp * nv)) for k in range(nv)]
     angles = [(u, v) for u in us for v in vs]
+
+    if a.cells:
+        # the field-energy scale the bounds are read against, from a coarse
+        # subset of the angles: the cell bounds themselves come from the
+        # checker, so the reference is needed for scale only
+        coarse = angles[:: max(1, len(angles) // 64)]
+        scale = max(
+            abs(residual_ref(w, j, u, v, phip)[3]) for j in idx for u, v in coarse
+        )
+        write_ccert(a, w, K, phip, idx, us, vs, nv, three_d)
+        print(f"reference B^2 scale {scale:.3e}")
+        return
 
     # choose eps from the float reference
     worst = np.zeros(3)

--- a/examples/make_equilibrium_certificate.py
+++ b/examples/make_equilibrium_certificate.py
@@ -16,7 +16,8 @@ Environment layout per point (must match theories/Physics.v):
   0 s | 1 u | 2 v | 3 phip | 4..7 sfull | 8..11 shalf | 12..15 iota
   16..36 am | 37+0..4K-1 R | +4K Z | +8K L      (K = mnmax)
 
-Usage:  python make_cert.py wout_X.nc cert_X.txt  [--bands 6] [--nu 8] [--nv 4]
+Usage:  python make_equilibrium_certificate.py [wout_X.nc [cert_X.txt]] [--bands 6] [--nu 8] [--nv 4]
+Without arguments it certifies the shipped wout_solovev.nc into cert_solovev.txt.
 """
 
 import argparse
@@ -223,13 +224,19 @@ def residual_ref(w, band, s, u, vv, phip):
 def main():
     """Read the wout, choose the bounds, write the certificate."""
     ap = argparse.ArgumentParser()
-    ap.add_argument("wout")
-    ap.add_argument("out")
+    repo = pathlib.Path(__file__).resolve().parent.parent
+    default_wout = (
+        repo / "src" / "vmecpp" / "cpp" / "vmecpp" / "test_data" / "wout_solovev.nc"
+    )
+    ap.add_argument("wout", nargs="?", default=str(default_wout))
+    ap.add_argument("out", nargs="?", default=None)
     ap.add_argument("--bands", type=int, default=6)
     ap.add_argument("--nu", type=int, default=8)
     ap.add_argument("--nv", type=int, default=4)
     ap.add_argument("--slack", type=float, default=1.5)
     a = ap.parse_args()
+    if a.out is None:
+        a.out = f"cert_{pathlib.Path(a.wout).stem.removeprefix('wout_')}.txt"
 
     w = Wout(a.wout)
     K = len(w.xm)

--- a/examples/make_equilibrium_certificate.py
+++ b/examples/make_equilibrium_certificate.py
@@ -1,0 +1,319 @@
+"""Emit a Stellarocq certificate from a VMEC wout file.
+
+The checker that validates the certificate is built from
+https://github.com/CharlesCNorton/stellarocq; see
+docs/proof_carrying_equilibria.md.
+
+The certificate states, for a set of evaluation points, that the mu0-scaled
+ideal-MHD force residual of the equilibrium reconstructed from the wout
+coefficients (by the rule fixed in theories/Physics.v) lies within the
+claimed per-component bounds.  Every numeric input is an IEEE double from
+the wout, emitted exactly as a dyadic rational m*2^e; the checker encloses
+the true real arithmetic with proven-sound interval arithmetic, so a VALID
+verdict is a theorem about these exact inputs.
+
+Environment layout per point (must match theories/Physics.v):
+  0 s | 1 u | 2 v | 3 phip | 4..7 sfull | 8..11 shalf | 12..15 iota
+  16..36 am | 37+0..4K-1 R | +4K Z | +8K L      (K = mnmax)
+
+Usage:  python make_cert.py wout_X.nc cert_X.txt  [--bands 6] [--nu 8] [--nv 4]
+"""
+
+import argparse
+import pathlib
+
+import netCDF4
+import numpy as np
+
+MU0 = 4e-7 * np.pi
+
+
+def dyadic(x):
+    """Exact (mantissa, exponent) with x = m * 2**e, for a finite double."""
+    num, den = float(x).as_integer_ratio()
+    e = 0
+    d = den
+    while d > 1:
+        d >>= 1
+        e -= 1
+    m = num
+    while m != 0 and m % 2 == 0:
+        m //= 2
+        e += 1
+    if m == 0:
+        e = 0
+    return m, e
+
+
+class Wout:
+    """The wout fields the certificate needs."""
+
+    def __init__(self, path):
+        """Load the fields and reject unsupported pressure types."""
+        d = netCDF4.Dataset(path)
+        d.set_auto_mask(False)
+        v = d.variables
+
+        def g(k):
+            return np.asarray(v[k][:], dtype=float)
+
+        self.ns = int(v["ns"][:])
+        self.xm = g("xm").astype(int)
+        self.xn = g("xn").astype(int)
+        self.rmnc = g("rmnc")
+        self.zmns = g("zmns")
+        self.lmns = g("lmns")
+        self.iotas = g("iotas")
+        self.phips = g("phips")
+        self.am = g("am")
+        ptype = v["pmass_type"][:].tobytes().decode().replace("\x00", "").strip()
+        if ptype != "power_series":
+            msg = f"v1 certifies power_series pressure only, got {ptype!r}"
+            raise SystemExit(msg)
+        d.close()
+        self.h = 1.0 / (self.ns - 1)
+        self.s_full = np.arange(self.ns) * self.h
+        self.s_half = (
+            np.arange(1, self.ns) - 0.5
+        ) * self.h  # nodes of lmns[1:], iotas[1:]
+
+
+def band_tables(w, i):
+    """Stencils for an evaluation point in full-grid band [s_i, s_{i+1}].
+
+    Full grid stencil: nodes i-1..i+2 of s_full (coefficients rmnc/zmns).
+    Half grid: the eval point s* = midpoint of the band lies exactly on
+    half node j = i (0-based into lmns[1:]); stencil j-1..j+2.
+    """
+    sf = w.s_full[i - 1 : i + 3]
+    sh = w.s_half[i - 1 : i + 3]
+    R = w.rmnc[i - 1 : i + 3, :]
+    Z = w.zmns[i - 1 : i + 3, :]
+    L = w.lmns[1:][i - 1 : i + 3, :]
+    IO = w.iotas[1:][i - 1 : i + 3]
+    return sf, sh, R, Z, L, IO
+
+
+# ----- float reference evaluation (same rule), for choosing eps -------------
+
+
+def hermite_rho(sn, y, s):
+    """Value, d/ds, d2/ds2 of the Hermite-in-rho profile at s."""
+    r = np.sqrt(sn)
+    rr = np.sqrt(s)
+    h = r[2] - r[1]
+    t = (rr - r[1]) / h
+    d1 = (y[2] - y[0]) / (r[2] - r[0])
+    d2 = (y[3] - y[1]) / (r[3] - r[1])
+    h00 = 2 * t**3 - 3 * t**2 + 1
+    h10 = t**3 - 2 * t**2 + t
+    h01 = -2 * t**3 + 3 * t**2
+    h11 = t**3 - t**2
+    val = h00 * y[1] + h10 * h * d1 + h01 * y[2] + h11 * h * d2
+    dh00 = (6 * t**2 - 6 * t) / h
+    dh10 = 3 * t**2 - 4 * t + 1
+    dh01 = (-6 * t**2 + 6 * t) / h
+    dh11 = 3 * t**2 - 2 * t
+    drho = dh00 * y[1] + dh10 * d1 + dh01 * y[2] + dh11 * d2
+    d2h00 = (12 * t - 6) / h**2
+    d2h10 = (6 * t - 4) / h
+    d2h01 = (-12 * t + 6) / h**2
+    d2h11 = (6 * t - 2) / h
+    d2rho = d2h00 * y[1] + d2h10 * d1 + d2h01 * y[2] + d2h11 * d2
+    ds = drho / (2 * rr)
+    dss = d2rho / (4 * s) - drho / (4 * s * rr)
+    return val, ds, dss
+
+
+def residual_ref(w, band, s, u, vv, phip):
+    """Float reference of the residual at one point, for choosing bounds."""
+    sf, sh, Rn, Zn, Ln, IOn = band
+    m = w.xm
+    n = w.xn
+    ang = m * u - n * vv
+    c = np.cos(ang)
+    sn_ = np.sin(ang)
+    rv, rd, rdd = hermite_rho(sf, Rn, s)
+    zv, zd, zdd = hermite_rho(sf, Zn, s)
+    lv, ld, _ = hermite_rho(sh, Ln, s)
+    iot, iotp, _ = hermite_rho(sh, IOn.reshape(4, 1), s)
+    iot = float(iot[0])
+    iotp = float(iotp[0])
+
+    def S(cf, k):
+        return float(np.dot(cf, k))
+
+    R = S(rv, c)
+    Z_s = S(zd, sn_)
+    lam_u = S(lv, m * c)
+    R_s = S(rd, c)
+    Z_ss = S(zdd, sn_)
+    lam_v = S(lv, -n * c)
+    R_ss = S(rdd, c)
+    Z_u = S(zv, m * c)
+    lam_su = S(ld, m * c)
+    R_u = S(rv, -m * sn_)
+    Z_v = S(zv, -n * c)
+    lam_sv = S(ld, -n * c)
+    R_v = S(rv, n * sn_)
+    Z_su = S(zd, m * c)
+    lam_uu = S(lv, -m * m * sn_)
+    R_su = S(rd, -m * sn_)
+    Z_sv = S(zd, -n * c)
+    lam_uv = S(lv, m * n * sn_)
+    R_sv = S(rd, n * sn_)
+    Z_uu = S(zv, -m * m * sn_)
+    lam_vv = S(lv, -n * n * sn_)
+    R_uu = S(rv, -m * m * c)
+    Z_uv = S(zv, m * n * sn_)
+    R_uv = S(rv, m * n * c)
+    Z_vv = S(zv, -n * n * sn_)
+    R_vv = S(rv, -n * n * c)
+    tau = R_u * Z_s - R_s * Z_u
+    sqrtg = R * tau
+    tau_s = R_su * Z_s + R_u * Z_ss - R_ss * Z_u - R_s * Z_su
+    tau_u = R_uu * Z_s + R_u * Z_su - R_su * Z_u - R_s * Z_uu
+    tau_v = R_uv * Z_s + R_u * Z_sv - R_sv * Z_u - R_s * Z_uv
+    g_s = R_s * tau + R * tau_s
+    g_u = R_u * tau + R * tau_u
+    g_v = R_v * tau + R * tau_v
+    guu = R_u**2 + Z_u**2
+    guv = R_u * R_v + Z_u * Z_v
+    gvv = R_v**2 + Z_v**2 + R**2
+    gsu = R_s * R_u + Z_s * Z_u
+    gsv = R_s * R_v + Z_s * Z_v
+    guu_s = 2 * (R_u * R_su + Z_u * Z_su)
+    guv_s = R_su * R_v + R_u * R_sv + Z_su * Z_v + Z_u * Z_sv
+    gvv_s = 2 * (R_v * R_sv + Z_v * Z_sv + R * R_s)
+    gsu_u = R_su * R_u + R_s * R_uu + Z_su * Z_u + Z_s * Z_uu
+    gsu_v = R_sv * R_u + R_s * R_uv + Z_sv * Z_u + Z_s * Z_uv
+    gsv_u = R_su * R_v + R_s * R_uv + Z_su * Z_v + Z_s * Z_uv
+    gsv_v = R_sv * R_v + R_s * R_vv + Z_sv * Z_v + Z_s * Z_vv
+    guu_v = 2 * (R_u * R_uv + Z_u * Z_uv)
+    guv_u = R_uu * R_v + R_u * R_uv + Z_uu * Z_v + Z_u * Z_uv
+    guv_v = R_uv * R_v + R_u * R_vv + Z_uv * Z_v + Z_u * Z_vv
+    gvv_u = 2 * (R_v * R_uv + Z_v * Z_uv + R * R_u)
+    bu = iot - lam_v
+    bv = 1.0 + lam_u
+    Bu = phip * bu / sqrtg
+    Bv = phip * bv / sqrtg
+    bu_s = iotp - lam_sv
+    bv_s = lam_su
+    Bu_s = phip * (bu_s * sqrtg - bu * g_s) / sqrtg**2
+    Bv_s = phip * (bv_s * sqrtg - bv * g_s) / sqrtg**2
+    Bu_u = phip * (-lam_uv * sqrtg - bu * g_u) / sqrtg**2
+    Bv_u = phip * (lam_uu * sqrtg - bv * g_u) / sqrtg**2
+    Bu_v = phip * (-lam_vv * sqrtg - bu * g_v) / sqrtg**2
+    Bv_v = phip * (lam_uv * sqrtg - bv * g_v) / sqrtg**2
+    B_u_s = guu_s * Bu + guu * Bu_s + guv_s * Bv + guv * Bv_s
+    B_v_s = guv_s * Bu + guv * Bu_s + gvv_s * Bv + gvv * Bv_s
+    B_s_u = gsu_u * Bu + gsu * Bu_u + gsv_u * Bv + gsv * Bv_u
+    B_s_v = gsu_v * Bu + gsu * Bu_v + gsv_v * Bv + gsv * Bv_v
+    B_u_v = guu_v * Bu + guu * Bu_v + guv_v * Bv + guv * Bv_v
+    B_v_u = guv_u * Bu + guv * Bu_u + gvv_u * Bv + gvv * Bv_u
+    pp = sum(k * a * s ** (k - 1) for k, a in enumerate(w.am) if k > 0)
+    rs = (B_s_v - B_v_s) * Bv - (B_u_s - B_s_u) * Bu - MU0 * pp
+    mu0Js = B_v_u - B_u_v
+    ru = -mu0Js * Bv
+    rv_ = mu0Js * Bu
+    B2 = Bu * (guu * Bu + guv * Bv) + Bv * (guv * Bu + gvv * Bv)
+    return rs, ru, rv_, B2
+
+
+def main():
+    """Read the wout, choose the bounds, write the certificate."""
+    ap = argparse.ArgumentParser()
+    ap.add_argument("wout")
+    ap.add_argument("out")
+    ap.add_argument("--bands", type=int, default=6)
+    ap.add_argument("--nu", type=int, default=8)
+    ap.add_argument("--nv", type=int, default=4)
+    ap.add_argument("--slack", type=float, default=1.5)
+    a = ap.parse_args()
+
+    w = Wout(a.wout)
+    K = len(w.xm)
+    phip = float(w.phips[1])
+    nfp = 1
+    if (w.xn != 0).any():
+        nfp = int(np.gcd.reduce(np.abs(w.xn[w.xn != 0])))
+    three_d = (w.xn != 0).any()
+    nv = a.nv if three_d else 1
+
+    # evaluation bands: interior full-grid bands, evenly spread
+    lo, hi = 2, w.ns - 4
+    idx = np.unique(np.linspace(lo, hi, a.bands).astype(int))
+    # angles: exact doubles
+    us = [float(2 * np.pi * k / a.nu) for k in range(a.nu)]
+    vs = [float(2 * np.pi * k / (nfp * nv)) for k in range(nv)]
+    angles = [(u, v) for u in us for v in vs]
+
+    # choose eps from the float reference
+    worst = np.zeros(3)
+    scale = 0.0
+    per_band = []
+    for i in idx:
+        bt = band_tables(w, i)
+        s = float(w.s_half[i])  # midpoint of band [s_i, s_{i+1}]
+        mx = np.zeros(3)
+        for u, v in angles:
+            rs, ru, rv_, B2 = residual_ref(w, bt, s, u, v, phip)
+            mx = np.maximum(mx, np.abs([rs, ru, rv_]))
+            scale = max(scale, abs(B2))
+        per_band.append((i, s, mx))
+        worst = np.maximum(worst, mx)
+    # Floor: interval evaluation carries genuine rounding width, so a claimed
+    # bound must sit above it. 1e-10 of the field-energy scale is far above
+    # the enclosure width of ~1e5 double operations and far below any
+    # physical residual of interest.
+    eps = np.maximum(worst * a.slack, 1e-10 * scale)
+
+    lines = []
+    P = lines.append
+    P("STELLAROCQ-CERT 1")
+    P("PREC 80")
+    P(f"MODES {K}")
+    for m, n in zip(w.xm, w.xn, strict=True):
+        P(f"{m} {n}")
+    P("PHIP {} {}".format(*dyadic(phip)))
+    P("AM 21")
+    for j in range(21):
+        am_j = w.am[j] if j < len(w.am) else 0.0
+        P("{} {}".format(*dyadic(am_j)))
+    for tag, e in zip(("EPS_S", "EPS_U", "EPS_V"), eps, strict=True):
+        P("{} {} {}".format(tag, *dyadic(e)))
+    P(f"NANGLES {len(angles)}")
+    for u, v in angles:
+        P("{} {} {} {}".format(*dyadic(u), *dyadic(v)))
+    P(f"NBANDS {len(idx)}")
+    for i in idx:
+        sf, sh, Rn, Zn, Ln, IOn = band_tables(w, i)
+        P("BAND")
+        P("S {} {}".format(*dyadic(w.s_half[i])))
+        P("SFULL " + " ".join("{} {}".format(*dyadic(x)) for x in sf))
+        P("SHALF " + " ".join("{} {}".format(*dyadic(x)) for x in sh))
+        P("IOTA " + " ".join("{} {}".format(*dyadic(x)) for x in IOn))
+        for tag, M in (("RNODES", Rn), ("ZNODES", Zn), ("LNODES", Ln)):
+            P(tag)
+            for row in M:  # 4 stencil rows
+                P(" ".join("{} {}".format(*dyadic(x)) for x in row))
+    pathlib.Path(a.out).write_text("\n".join(lines) + "\n")
+
+    print(
+        f"wrote {a.out}: {len(idx)} bands x {len(angles)} angles = "
+        f"{len(idx) * len(angles)} points, K={K}"
+    )
+    print(
+        f"claimed bounds (mu0-scaled, Pa*mu0):  "
+        f"r_s {eps[0]:.3e}  r_u {eps[1]:.3e}  r_v {eps[2]:.3e}"
+    )
+    print(
+        f"reference B^2 scale {scale:.3e}  ->  normalized r_s bound "
+        f"{eps[0] / scale:.3e}"
+    )
+    for i, s, mx in per_band:
+        print(f"  band {i:3d}  s={s:.4f}  |r|max = {mx[0]:.3e} {mx[1]:.3e} {mx[2]:.3e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Change** - `docs/proof_carrying_equilibria.md`, linked from the docs index, describes three uses of [Stellarocq](https://github.com/CharlesCNorton/stellarocq) with VMEC++: certificates of the force balance of a wout, theorems and enclosures about the reconstructed field, and an oracle for the solver. `examples/make_equilibrium_certificate.py` runs VMEC++ on an input file, saves the wout, and calls the generator, the checker and the wout guard of a Stellarocq checkout; `--checker` takes the statically linked checker from the Stellarocq releases, `--mpol`, `--ntor`, `--ns` and `--ftol` override the resolution and the force tolerance of the input, `--project` asks the checker for the harmonics of the residual at the modes of the run, and without `--stellarocq` the example saves the wout and stops, which is how the example job of CI runs it. A certificate lists, for a set of full-grid nodes and angles, per-component bounds on the mu0-scaled residual `J x B - grad p` of the field reconstructed from the wout Fourier coefficients by VMEC's half-grid rule; every numeric input is written exactly, as a dyadic rational. With `--cells` the bounds are claimed over cells that tile the poloidal angle instead of at sampled angles.

**Cause** - "this wout satisfies force balance" rests on VMEC++ and on its agreement with Fortran VMEC. The checker is extracted from the Rocq development in Stellarocq and shares no code with either solver or with the generator: it recomputes the residual from the coefficients in verified interval arithmetic (CoqInterval over the Flocq formalization of IEEE-754). A VALID verdict is therefore a theorem about those exact inputs, and a division by zero, an invalid square root or an unlucky rounding in the evaluation gives INVALID. What remains trusted is the Rocq kernel with the classical real axioms and the primitive float and integer specifications of its standard library, extraction and the OCaml compiler, and a parsing driver; `make audit` in Stellarocq prints the axioms behind every theorem. Certifying a stellarator-symmetric equilibrium through the non-stellarator-symmetric reconstruction found #788, fixed in #789.

**Evidence** - Stellarocq `29d89ed`, 20 worker processes. The example, with vmecpp 0.7.4, ran `examples/data/solovev.json` as a point and as a cell certificate, `examples/data/input.cth_like_fixed_bdy` and `test_data/up_down_asym.json`, each to a VALID verdict with every input slot of the certificate equal to the wout's, with the checker built in the checkout and with the released static one. Point certificates, six nodes per case; the bound is the largest of the three component bounds, over the reference `B^2` scale the generator prints:

| case | points | largest bound, of the field scale | verdict |
|---|---|---|---|
| `wout_solovev` (axisymmetric, ns=55, 6 modes, power series) | 48 | 7.3e-5 | VALID, under 0.1 s |
| `examples/data/w7x.json` as shipped (3D, nfp=5, 288 modes, ns=99) | 192 | 1.3e-2 | VALID, 3.7 s |
| `wout_cth_like_fixed_bdy` (3D, nfp=5, 41 modes, ns=25, two-power pressure, `PRES_SCALE` 432.29) | 192 | 1.0e-2 | VALID, 0.2 s |
| `up_down_asym.json` (non-stellarator-symmetric, ns=17) | 48 | 1.2e-2 | VALID, under 0.1 s |
| `wout_cma` (3D, nfp=2, 59 modes, ns=51) | 192 | 5.2e-2 | VALID, 0.3 s |
| solovev with one `rmnc` coefficient of a certified stencil perturbed by 0.1% | 48 | same claim | INVALID, under 0.1 s |

Every stellarator-symmetric case also certifies through the non-stellarator-symmetric reconstruction with its antisymmetric coefficients set to zero, at the same bounds (`gen/make_cert.py --force-lasym`).

For a three-dimensional equilibrium the bound follows the resolution and the force tolerance of the run. `input.li383_low_res`, which ships with 25 modes, 16 surfaces and a tolerance of 1e-6, run by the example with `--ns 31 --ftol 1e-14` and the Fourier resolution raised:

| `--mpol`, `--ntor` | modes | largest bound, of the field scale |
|---|---|---|
| 4, 3 | 25 | 3.0e-1 |
| 6, 4 | 50 | 4.1e-2 |
| 8, 6 | 98 | 1.0e-2 |
| 10, 8 | 162 | 6.8e-3 |
| 12, 10 | 242 | 5.6e-3 |

With the input's own tolerance the last row is 3.1e-2. Past about two hundred modes the bound stays near 6e-3 at this radial resolution.

A spectral solution balances forces mode by mode over the modes it retains, and what it leaves pointwise is the truncation. `--project` follows a point certificate with the largest mean harmonic of each component over the modes of the run and the angles of a node, a finite sum that `harm_encloses` of Stellarocq encloses. Over 48 by 48 angles per node, of the field scale:

| case | largest pointwise bound | `r_s` harmonic | `r_u` harmonic | `r_v` harmonic |
|---|---|---|---|---|
| `input.li383_low_res` at `--mpol 12 --ntor 10 --ns 31 --ftol 1e-14` | 6.7e-3 | 9.0e-4 | 9.7e-5 | 6.1e-5 |
| `examples/data/w7x.json` as shipped | 1.9e-2 | 2.1e-3 | 3.9e-5 | 7.1e-5 |

Cell certificates:

| case | cells | worst cell bound | of the field scale | tighten | verdict |
|---|---|---|---|---|---|
| `wout_solovev` (axisymmetric, ns=55) | 49152 | 1.3e-5 | 1.9e-4 | 30 s | VALID, 41 s |
| `wout_circular_tokamak_reference` (axisymmetric, ns=17) | 49152 | 1.5e-2 | 2.5e-4 | 33 s | VALID, 48 s |
| `wout_cma` (3D, nfp=2, 59 modes, ns=51) | 24576 | 1.3e-2 | 4.3e-2 | 50 s | VALID, 90 s |
| `wout_li383_low_res_reference` (3D, nfp=3, 25 modes, ns=16) | 24576 | 8.7e-1 | 2.4e-1 | 24 s | VALID, 39 s |
| `input.li383_low_res` at `--mpol 12 --ntor 10 --ns 31 --ftol 1e-14` (242 modes) | 24576 | 2.7e-2 | 7.4e-3 | 254 s | VALID, 628 s |

The two axisymmetric cases carry 6 nodes of 8192 poloidal cells covering the whole angular torus. An axisymmetric equilibrium has every `n` zero, so its toroidal derivative encloses to zero and one cell spans the whole toroidal angle. A three-dimensional one has to resolve the toroidal direction as finely as the poloidal, which squares the cell count, so the three-dimensional cases carry 3 nodes of 4096 poloidal cells at each of 2 toroidal angles. `check_ccert_correct`, the theorem behind a cell verdict, walks from the centre of a cell to any point of it by a mean-value step in each angle, with the derivative enclosed over the whole cell.

**Tests** - none; certification is offline and per wout. The example job of CI runs the script without arguments, which runs VMEC++ on `solovev.json` and saves the wout.

**Scope** - an example script and a documentation page. The example imports `vmecpp` and calls a Stellarocq checkout through `subprocess`; the solver, its dependencies and CI are untouched, and the proof development, the generator and the checker stay in Stellarocq.


