### PR TITLE
Add opt-in Anderson acceleration of the descent iteration

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -425,6 +425,15 @@ class VmecInput(BaseModelWithNumpy):
     """Time-step / restart control scheme for the equilibrium iteration (``"vmec_8_52"``
     or ``"parvmec"``)."""
 
+    anderson_acceleration: bool = False
+    """Accelerate the equilibrium iteration by Anderson extrapolation of the Garabedian
+    time step from a short history of iterates.
+
+    The extrapolation acts in the nonlinear early phase of each multigrid stage and
+    hands the tail back to the plain descent. The accelerated and the plain iteration
+    converge to the same equilibrium within the force tolerance.
+    """
+
     nstep: int = 10
     """Printout interval at which convergence progress is logged."""
 

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -228,6 +228,7 @@ VmecINDATA::VmecINDATA() {
   tcon0 = 1.0;
   lforbal = false;
   iteration_style = IterationStyle::VMEC_8_52;
+  anderson_acceleration = false;
   return_outputs_even_if_not_converged = false;
 
   // zero-initialized magnetic axis
@@ -352,6 +353,7 @@ absl::Status VmecINDATA::WriteTo(H5::H5File& file) const {
   WriteH5Dataset(delt, "/indata/delt", file);
   WriteH5Dataset(tcon0, "/indata/tcon0", file);
   WriteH5Dataset(lforbal, "/indata/lforbal", file);
+  WriteH5Dataset(anderson_acceleration, "/indata/anderson_acceleration", file);
   WriteH5Dataset(return_outputs_even_if_not_converged,
                  "/indata/return_outputs_even_if_not_converged", file);
 
@@ -454,6 +456,15 @@ absl::Status VmecINDATA::LoadInto(VmecINDATA& m_indata, H5::H5File& from_file) {
   ReadH5Dataset(m_indata.delt, "/indata/delt", from_file);
   ReadH5Dataset(m_indata.tcon0, "/indata/tcon0", from_file);
   ReadH5Dataset(m_indata.lforbal, "/indata/lforbal", from_file);
+
+  // Added after the initial schema; files written before it load the
+  // default.
+  if (H5Lexists(from_file.getId(), "/indata/anderson_acceleration", 0) == 1) {
+    ReadH5Dataset(m_indata.anderson_acceleration,
+                  "/indata/anderson_acceleration", from_file);
+  } else {
+    m_indata.anderson_acceleration = false;
+  }
 
   // Legacy way of checking for dataset existence
   if (H5Lexists(from_file.getId(),
@@ -944,6 +955,14 @@ absl::StatusOr<VmecINDATA> VmecINDATA::FromJson(
     }
   }
 
+  auto maybe_anderson_acceleration = JsonReadBool(j, "anderson_acceleration");
+  if (!maybe_anderson_acceleration.ok()) {
+    return maybe_anderson_acceleration.status();
+  }
+  if (maybe_anderson_acceleration->has_value()) {
+    vmec_indata.anderson_acceleration = maybe_anderson_acceleration->value();
+  }
+
   auto maybe_return_outputs_even_if_not_converged =
       JsonReadBool(j, "return_outputs_even_if_not_converged");
   if (!maybe_return_outputs_even_if_not_converged.ok()) {
@@ -1254,6 +1273,7 @@ absl::StatusOr<std::string> VmecINDATA::ToJson() const {
   output["tcon0"] = tcon0;
   output["lforbal"] = lforbal;
   output["iteration_style"] = ToString(iteration_style);
+  output["anderson_acceleration"] = anderson_acceleration;
   output["return_outputs_even_if_not_converged"] =
       return_outputs_even_if_not_converged;
 

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
@@ -219,6 +219,11 @@ class VmecINDATA {
   // based on)
   IterationStyle iteration_style;
 
+  // Anderson acceleration of the descent iteration: a short history of
+  // iterates extrapolates the fixed-point map of the Garabedian time step
+  // (see Vmec::SetAndersonAcceleration). Off by default.
+  bool anderson_acceleration;
+
   // If true, return a wout even if VMEC++ did not converge.
   // Intended for debugging convergence issues only: the
   // returned quantities are computed from whatever internal state the solver

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
@@ -164,6 +164,7 @@ TEST(TestVmecINDATA, CheckDefaults) {
   EXPECT_EQ(indata.delt, 1.0);
   EXPECT_EQ(indata.tcon0, 1.0);
   EXPECT_EQ(indata.lforbal, false);
+  EXPECT_EQ(indata.anderson_acceleration, false);
 
   // initial guess for magnetic axis
   EXPECT_EQ(indata.raxis_c.size(), indata.ntor + 1);
@@ -427,6 +428,8 @@ void CheckHdf5RoundTrip(const std::string& filename) {
   EXPECT_EQ(indata.delt, indata_from_file.delt);
   EXPECT_EQ(indata.tcon0, indata_from_file.tcon0);
   EXPECT_EQ(indata.lforbal, indata_from_file.lforbal);
+  EXPECT_EQ(indata.anderson_acceleration,
+            indata_from_file.anderson_acceleration);
   EXPECT_EQ(indata.raxis_c, indata_from_file.raxis_c);
   EXPECT_EQ(indata.zaxis_s, indata_from_file.zaxis_s);
   EXPECT_EQ(indata.raxis_s, indata_from_file.raxis_s);
@@ -597,6 +600,7 @@ TEST(TestVmecINDATA, CopyMethod) {
   EXPECT_EQ(copy.tcon0, indata.tcon0);
   EXPECT_EQ(copy.lforbal, indata.lforbal);
   EXPECT_EQ(copy.iteration_style, indata.iteration_style);
+  EXPECT_EQ(copy.anderson_acceleration, indata.anderson_acceleration);
   EXPECT_EQ(copy.return_outputs_even_if_not_converged,
             indata.return_outputs_even_if_not_converged);
   EXPECT_EQ(copy.raxis_c, indata.raxis_c);

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -621,6 +621,8 @@ PYBIND11_MODULE(_vmecpp, m) {
       .def_readwrite("tcon0", &VmecINDATA::tcon0)
       .def_readwrite("lforbal", &VmecINDATA::lforbal)
       .def_readwrite("iteration_style", &VmecINDATA::iteration_style)
+      .def_readwrite("anderson_acceleration",
+                     &VmecINDATA::anderson_acceleration)
       .def_readwrite("return_outputs_even_if_not_converged",
                      &VmecINDATA::return_outputs_even_if_not_converged)
 

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/BUILD.bazel
@@ -3,8 +3,14 @@
 # SPDX-License-Identifier: MIT
 cc_library(
     name = "vmec",
-    srcs = ["vmec.cc"],
-    hdrs = ["vmec.h"],
+    srcs = [
+        "anderson_acceleration.cc",
+        "vmec.cc",
+    ],
+    hdrs = [
+        "anderson_acceleration.h",
+        "vmec.h",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "@abseil-cpp//absl/log",

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/CMakeLists.txt
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/CMakeLists.txt
@@ -1,5 +1,7 @@
 list (APPEND vmecpp_sources
+  ${CMAKE_CURRENT_SOURCE_DIR}/anderson_acceleration.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/vmec.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/anderson_acceleration.h
   ${CMAKE_CURRENT_SOURCE_DIR}/vmec.h
 )
 set (vmecpp_sources "${vmecpp_sources}" PARENT_SCOPE)

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/anderson_acceleration.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/anderson_acceleration.cc
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+// <info@proximafusion.com>
+//
+// SPDX-License-Identifier: MIT
+#include "vmecpp/vmec/vmec/anderson_acceleration.h"
+
+#include <array>
+#include <span>
+
+namespace {
+
+// The evolved state arrays of a FourierGeometry, in a fixed order. The spans
+// cover the full stored radial range of the owning thread, satellite points
+// included.
+std::array<std::span<double>, 12> StateSpans(const vmecpp::FourierGeometry& x,
+                                             const vmecpp::Sizes& s,
+                                             int& m_num_spans) {
+  std::array<std::span<double>, 12> spans;
+  int count = 0;
+  spans[count++] = x.rmncc;
+  spans[count++] = x.zmnsc;
+  spans[count++] = x.lmnsc;
+  if (s.lthreed) {
+    spans[count++] = x.rmnss;
+    spans[count++] = x.zmncs;
+    spans[count++] = x.lmncs;
+  }
+  if (s.lasym) {
+    spans[count++] = x.rmnsc;
+    spans[count++] = x.zmncc;
+    spans[count++] = x.lmncc;
+    if (s.lthreed) {
+      spans[count++] = x.rmncs;
+      spans[count++] = x.zmnss;
+      spans[count++] = x.lmnss;
+    }
+  }
+  m_num_spans = count;
+  return spans;
+}
+
+}  // namespace
+
+vmecpp::AndersonAcceleration::AndersonAcceleration(const Sizes* s, int window)
+    : s_(s), window_(window) {}
+
+void vmecpp::AndersonAcceleration::Reset() {
+  map_outputs_.clear();
+  residuals_.clear();
+}
+
+void vmecpp::AndersonAcceleration::Pack(const FourierGeometry& x,
+                                        Eigen::VectorXd& m_out) const {
+  int num_spans = 0;
+  const auto spans = StateSpans(x, *s_, num_spans);
+  Eigen::Index total = 0;
+  for (int i = 0; i < num_spans; ++i) {
+    total += static_cast<Eigen::Index>(spans[i].size());
+  }
+  m_out.resize(total);
+  Eigen::Index offset = 0;
+  for (int i = 0; i < num_spans; ++i) {
+    for (const double value : spans[i]) {
+      m_out[offset++] = value;
+    }
+  }
+}
+
+void vmecpp::AndersonAcceleration::CapturePreStep(const FourierGeometry& x) {
+  Pack(x, pre_step_);
+}
+
+void vmecpp::AndersonAcceleration::PushPostStep(const FourierGeometry& x) {
+  Eigen::VectorXd post;
+  Pack(x, post);
+  residuals_.push_back(post - pre_step_);
+  map_outputs_.push_back(std::move(post));
+  while (static_cast<int>(map_outputs_.size()) > window_ + 1) {
+    map_outputs_.pop_front();
+    residuals_.pop_front();
+  }
+}
+
+int vmecpp::AndersonAcceleration::NumDifferences() const {
+  return static_cast<int>(map_outputs_.size()) - 1;
+}
+
+void vmecpp::AndersonAcceleration::LocalNormalEquations(double* m_gram,
+                                                        double* m_rhs) const {
+  const int k = NumDifferences();
+  const Eigen::VectorXd& current = residuals_.back();
+  for (int i = 0; i < k; ++i) {
+    const Eigen::VectorXd delta_i = residuals_[i + 1] - residuals_[i];
+    for (int j = i; j < k; ++j) {
+      const double dot = delta_i.dot(residuals_[j + 1] - residuals_[j]);
+      m_gram[i * k + j] = dot;
+      m_gram[j * k + i] = dot;
+    }
+    m_rhs[i] = delta_i.dot(current);
+  }
+}
+
+void vmecpp::AndersonAcceleration::ApplyCombination(
+    const double* gamma, FourierGeometry& m_x) const {
+  const int k = NumDifferences();
+  Eigen::VectorXd accelerated = map_outputs_.back();
+  for (int i = 0; i < k; ++i) {
+    accelerated -= gamma[i] * (map_outputs_[i + 1] - map_outputs_[i]);
+  }
+
+  int num_spans = 0;
+  const auto spans = StateSpans(m_x, *s_, num_spans);
+  Eigen::Index offset = 0;
+  for (int i = 0; i < num_spans; ++i) {
+    for (double& value : spans[i]) {
+      value = accelerated[offset++];
+    }
+  }
+}

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/anderson_acceleration.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/anderson_acceleration.h
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+// <info@proximafusion.com>
+//
+// SPDX-License-Identifier: MIT
+#ifndef VMECPP_VMEC_VMEC_ANDERSON_ACCELERATION_H_
+#define VMECPP_VMEC_VMEC_ANDERSON_ACCELERATION_H_
+
+#include <Eigen/Dense>
+#include <deque>
+
+#include "vmecpp/common/sizes/sizes.h"
+#include "vmecpp/vmec/fourier_geometry/fourier_geometry.h"
+
+namespace vmecpp {
+
+// Per-thread state for Anderson acceleration of the descent iteration.
+//
+// One Garabedian time step maps the Fourier state x_k to g_k. Anderson
+// acceleration treats that map as a fixed-point iteration: it keeps a short
+// history of map outputs g and residuals r = g - x, finds the least-squares
+// combination of the recent residual differences that best cancels the
+// current residual, and applies the same combination to the map outputs.
+//
+// Each thread holds the history of its own slice of the state, taken over the
+// full stored radial range including the satellite points, so a linear
+// combination of exchange-consistent iterates is again exchange-consistent at
+// the partition seams. The normal equations of the least-squares problem are
+// the only cross-thread quantities; Vmec reduces them over the team and hands
+// the resulting coefficients back to every thread.
+class AndersonAcceleration {
+ public:
+  AndersonAcceleration(const Sizes* s, int window);
+
+  // Drop the history, e.g. after a restart or a multigrid step.
+  void Reset();
+
+  // Record the state before the time step.
+  void CapturePreStep(const FourierGeometry& x);
+
+  // Record the state after the time step and its residual against the
+  // captured pre-step state, dropping the oldest pair beyond the window.
+  void PushPostStep(const FourierGeometry& x);
+
+  // Number of residual differences available for the least-squares problem.
+  int NumDifferences() const;
+
+  // This thread's contribution to the normal equations over the residual
+  // differences: `m_gram` receives the k*k Gram matrix in row-major order and
+  // `m_rhs` the k inner products with the current residual, k =
+  // NumDifferences().
+  void LocalNormalEquations(double* m_gram, double* m_rhs) const;
+
+  // Overwrite this thread's slice of the state with the accelerated
+  // combination g_last - sum_i gamma[i] * (g_{i+1} - g_i).
+  void ApplyCombination(const double* gamma, FourierGeometry& m_x) const;
+
+ private:
+  void Pack(const FourierGeometry& x, Eigen::VectorXd& m_out) const;
+
+  const Sizes* s_;
+  int window_;
+
+  Eigen::VectorXd pre_step_;
+  std::deque<Eigen::VectorXd> map_outputs_;
+  std::deque<Eigen::VectorXd> residuals_;
+};
+
+}  // namespace vmecpp
+
+#endif  // VMECPP_VMEC_VMEC_ANDERSON_ACCELERATION_H_

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstddef>
 #include <cstdio>
 #include <iostream>
 #include <memory>
@@ -36,6 +37,40 @@
 #include "vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.h"
 
 namespace {
+
+// Sums each thread's `width` contributions by a fixed binary tree over the
+// team. Thread t parks its values in row t of `m_slots`; at strides 1, 2, 4,
+// ... thread t with t % (2*stride) == 0 adds row t+stride into row t. The
+// pairing depends only on thread ids, never on arrival order, so the
+// floating-point result is reproducible at a fixed thread count. Row 0 holds
+// the team total after the call, which ends on a barrier.
+//
+// `m_slots` must provide num_threads rows of `row_stride` doubles of shared
+// storage (row_stride >= width), and every thread of the team must call this
+// together with the same arguments apart from `local`.
+void SumInFixedTree(double* m_slots, int row_stride, int width, int thread_id,
+                    int num_threads, const double* local) {
+  double* row = m_slots + static_cast<std::ptrdiff_t>(thread_id) * row_stride;
+  for (int i = 0; i < width; ++i) {
+    row[i] = local[i];
+  }
+#ifdef _OPENMP
+#pragma omp barrier
+#endif  // _OPENMP
+  for (int stride = 1; stride < num_threads; stride *= 2) {
+    if (thread_id % (2 * stride) == 0 && thread_id + stride < num_threads) {
+      const double* other =
+          m_slots +
+          static_cast<std::ptrdiff_t>(thread_id + stride) * row_stride;
+      for (int i = 0; i < width; ++i) {
+        row[i] += other[i];
+      }
+    }
+#ifdef _OPENMP
+#pragma omp barrier
+#endif  // _OPENMP
+  }
+}
 
 void UpdateStatusForThread(absl::Status& m_status_of_all_threads, int thread_id,
                            const absl::Status& thread_status) {
@@ -197,6 +232,10 @@ Vmec::Vmec(const VmecINDATA& indata, std::optional<int> max_threads,
       last_full_update_nestor_(0) {
   // remainder of readin()
   fc_.haveToFlipTheta = b_.setupFromIndata(indata_, verbose_);
+
+  if (indata_.anderson_acceleration) {
+    SetAndersonAcceleration(kAndersonWindow, kAndersonStartIteration);
+  }
 
   if (fc_.lfreeb) {
     // tangential Fourier resolution
@@ -642,6 +681,20 @@ bool Vmec::InitializeRadial(
     decomposed_f_.resize(num_threads_);
     physical_f_.resize(num_threads_);
     decomposed_v_.resize(num_threads_);
+    if (anderson_window_ > 0) {
+      anderson_.resize(num_threads_);
+      for (int thread_id = 0; thread_id < num_threads_; ++thread_id) {
+        anderson_[thread_id] =
+            std::make_unique<AndersonAcceleration>(&s_, anderson_window_);
+      }
+      anderson_reduction_slots_.setZero(
+          static_cast<Eigen::Index>(num_threads_) * anderson_window_ *
+          (anderson_window_ + 1));
+      anderson_last_iter1_ = -1;
+      anderson_last_iter2_ = -1;
+      anderson_stage_ns_ = -1;
+      anderson_stage_fsq0_ = 0.0;
+    }
 
     // single-threaded creation of objects used in parallel threads
     for (int thread_id = 0; thread_id < num_threads_; ++thread_id) {
@@ -1338,6 +1391,104 @@ void Vmec::RestartIteration(double& m_delt0r, int thread_id) {
 #endif  // _OPENMP
 }
 
+void Vmec::SetAndersonAcceleration(int window, int start_iteration,
+                                   int frequency, bool zero_velocity_on_jump) {
+  anderson_window_ = std::max(window, 0);
+  anderson_start_ = std::max(start_iteration, 1);
+  anderson_frequency_ = std::max(frequency, 1);
+  anderson_zero_velocity_ = zero_velocity_on_jump;
+}
+
+void Vmec::AndersonPreStep(int thread_id) {
+#ifdef _OPENMP
+#pragma omp single
+#endif  // _OPENMP
+  {
+    // The history only extrapolates a settled, uninterrupted iteration:
+    // anything that moved iter1_ (a restart, a new multigrid step) or skipped
+    // an iteration invalidates it.
+    anderson_reset_ = (iter1_ != anderson_last_iter1_) ||
+                      (iter2_ != anderson_last_iter2_ + 1);
+    anderson_last_iter1_ = iter1_;
+    anderson_last_iter2_ = iter2_;
+    if (fc_.ns != anderson_stage_ns_) {
+      anderson_stage_ns_ = fc_.ns;
+      anderson_stage_fsq0_ = fc_.fsqr + fc_.fsqz + fc_.fsql;
+    }
+  }  // implicit barrier
+
+  AndersonAcceleration& acceleration = *anderson_[thread_id];
+  if (anderson_reset_) {
+    acceleration.Reset();
+  }
+  acceleration.CapturePreStep(*decomposed_x_[thread_id]);
+}
+
+void Vmec::AndersonPostStep(int thread_id) {
+  AndersonAcceleration& acceleration = *anderson_[thread_id];
+  acceleration.PushPostStep(*decomposed_x_[thread_id]);
+
+  const int k = acceleration.NumDifferences();
+  // The extrapolation pays off in the nonlinear early phase of a stage, where
+  // the descent is still finding the basin. Once the invariant residual is
+  // small the fixed-point map is linear and the momentum iteration already
+  // converges at its optimal rate, and extrapolating there holds the residual
+  // in a limit cycle instead (measured on the QUASR fixed-boundary cases at
+  // ftol 1e-9), so the tail is handed back to the descent. The ftolv term
+  // keeps a loosely converged run from engaging right at its target.
+  const double fsq_invariant = fc_.fsqr + fc_.fsqz + fc_.fsql;
+  const double disengage_floor =
+      std::max({kAndersonFloor, kAndersonRelativeFloor * anderson_stage_fsq0_,
+                1.0e3 * fc_.ftolv});
+  if (k < 1 || (iter2_ - iter1_) < anderson_start_ ||
+      iter2_ % anderson_frequency_ != 0 || fsq_invariant <= disengage_floor) {
+    return;
+  }
+
+  // Reduce the normal equations of the least-squares problem over the team.
+  // Every thread contributes the inner products of its own slice; the fixed
+  // tree keeps the sums reproducible.
+  const int width = k * k + k;
+  std::vector<double> local(width);
+  acceleration.LocalNormalEquations(local.data(), local.data() + k * k);
+  const int row_stride = anderson_window_ * (anderson_window_ + 1);
+  SumInFixedTree(anderson_reduction_slots_.data(), row_stride, width, thread_id,
+                 num_threads_, local.data());
+
+#ifdef _OPENMP
+#pragma omp single
+#endif  // _OPENMP
+  {
+    Eigen::Map<
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>
+        gram(anderson_reduction_slots_.data(), k, k);
+    Eigen::Map<Eigen::VectorXd> rhs(anderson_reduction_slots_.data() + k * k,
+                                    k);
+    // Tikhonov-regularize against a rank-deficient history.
+    const double regularization = 1.0e-12 * gram.trace() / k;
+    Eigen::MatrixXd lhs = gram;
+    lhs.diagonal().array() += regularization;
+    anderson_gamma_ = lhs.ldlt().solve(rhs);
+    // An unreliable extrapolation is skipped rather than damped: the plain
+    // step already taken stands.
+    anderson_apply_ = anderson_gamma_.allFinite() &&
+                      anderson_gamma_.lpNorm<Eigen::Infinity>() < 1.0e2;
+  }  // implicit barrier
+
+  if (!anderson_apply_) {
+    return;
+  }
+
+  acceleration.ApplyCombination(anderson_gamma_.data(),
+                                *decomposed_x_[thread_id]);
+  if (anderson_zero_velocity_) {
+    decomposed_v_[thread_id]->setZero();
+  }
+#ifdef _OPENMP
+#pragma omp barrier
+#endif  // _OPENMP
+}
+
 absl::StatusOr<bool> Vmec::Evolve(VmecCheckpoint checkpoint,
                                   int iterations_before_checkpointing,
                                   double time_step, int thread_id,
@@ -1454,7 +1605,14 @@ absl::StatusOr<bool> Vmec::Evolve(VmecCheckpoint checkpoint,
   // THIS IS THE TIME-STEP ALGORITHM. IT IS ESSENTIALLY A CONJUGATE
   // GRADIENT METHOD, WITHOUT THE LINE SEARCHES (FLETCHER-REEVES),
   // BASED ON A METHOD GIVEN BY P. GARABEDIAN
+  const bool accelerate = anderson_window_ > 0;
+  if (accelerate) {
+    AndersonPreStep(thread_id);
+  }
   PerformTimeStep(fac, b1, time_step, thread_id);
+  if (accelerate) {
+    AndersonPostStep(thread_id);
+  }
 
   return false;
 }

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
@@ -29,6 +29,7 @@
 #include "vmecpp/vmec/output_quantities/output_quantities.h"
 #include "vmecpp/vmec/radial_partitioning/radial_partitioning.h"
 #include "vmecpp/vmec/radial_profiles/radial_profiles.h"
+#include "vmecpp/vmec/vmec/anderson_acceleration.h"
 #include "vmecpp/vmec/vmec_constants/vmec_constants.h"
 
 namespace vmecpp {
@@ -145,6 +146,27 @@ class Vmec {
   absl::StatusOr<bool> Evolve(VmecCheckpoint checkpoint, int maximum_iterations,
                               double time_step, int thread_id,
                               bool& m_liter_flag);
+  // Anderson acceleration of the descent iteration, which the input flag
+  // `anderson_acceleration` switches on with the defaults below. `window`
+  // previous iterates enter each extrapolation (0 disables);
+  // `start_iteration` delays engagement until the transients of a fresh
+  // (multigrid) step have passed; the correction is applied every `frequency`
+  // iterations; `zero_velocity_on_jump` restarts the Garabedian momentum after
+  // each accelerated jump. The extrapolation acts in the nonlinear early
+  // phase of each multigrid stage only: it disengages once the invariant
+  // residual fsqr + fsqz + fsql falls below kAndersonFloor, below
+  // kAndersonRelativeFloor times the residual at stage entry, or below
+  // 1e3 ftol, whichever is largest, and the momentum descent finishes the
+  // tail on its own.
+  static constexpr int kAndersonWindow = 2;
+  static constexpr int kAndersonStartIteration = 25;
+  static constexpr double kAndersonFloor = 1.0e-4;
+  static constexpr double kAndersonRelativeFloor = 1.0e-3;
+  void SetAndersonAcceleration(int window,
+                               int start_iteration = kAndersonStartIteration,
+                               int frequency = 1,
+                               bool zero_velocity_on_jump = true);
+
   void Printout(double delt0r, int thread_id, int iter2);
   absl::StatusOr<bool> UpdateForwardModel(VmecCheckpoint checkpoint,
                                           int maximum_iterations,
@@ -278,6 +300,26 @@ class Vmec {
   // value of iter2_ at which the state vector was restored the last time.
   // represents how many steps we are into the current optimization "branch".
   int iter1_;
+
+  // Anderson acceleration (see SetAndersonAcceleration); disabled at 0.
+  int anderson_window_ = 0;
+  int anderson_start_ = kAndersonStartIteration;
+  int anderson_frequency_ = 1;
+  bool anderson_zero_velocity_ = true;
+  std::vector<std::unique_ptr<AndersonAcceleration>> anderson_;
+  // Shared scratch for the cross-thread reduction of the normal equations and
+  // for broadcasting the solved combination coefficients.
+  Eigen::VectorXd anderson_reduction_slots_;
+  Eigen::VectorXd anderson_gamma_;
+  bool anderson_apply_ = false;
+  bool anderson_reset_ = false;
+  int anderson_last_iter1_ = -1;
+  int anderson_last_iter2_ = -1;
+  // invariant residual at the entry of the current multigrid stage
+  int anderson_stage_ns_ = -1;
+  double anderson_stage_fsq0_ = 0.0;
+  void AndersonPreStep(int thread_id);
+  void AndersonPostStep(int thread_id);
 
   // history size for averaging of 1/tau
   static constexpr int kNDamp = 10;

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
@@ -361,6 +361,60 @@ void CheckPrescribedIotaProfile(const vmecpp::WOutFileContents& w,
   }
 }
 
+// Anderson acceleration is opt-in and must reach the same equilibrium as the
+// plain Garabedian iteration, in fewer iterations. Two independent
+// convergence paths agree at the size of the force-tolerance ball, so each
+// bound below is at least five times the deviation measured between the
+// accelerated and the plain converged state; the curl-derived diagnostics
+// (jcuru, jdotb, the Mercier terms) amplify that ball beyond usefulness and
+// are covered by their own reference tests instead.
+TEST(TestVmec, AndersonAcceleratedCthMatchesPlainIteration) {
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile("vmecpp/test_data/cth_like_fixed_bdy.json");
+  ASSERT_TRUE(indata_json.ok());
+  const absl::StatusOr<VmecINDATA> indata = VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(indata.ok());
+
+  auto maybe_plain = Vmec::FromIndata(*indata);
+  ASSERT_TRUE(maybe_plain.ok());
+  Vmec& plain = **maybe_plain;
+  ASSERT_FALSE(plain.run().value());
+
+  auto maybe_accelerated = Vmec::FromIndata(*indata);
+  ASSERT_TRUE(maybe_accelerated.ok());
+  Vmec& accelerated = **maybe_accelerated;
+  accelerated.SetAndersonAcceleration(/*window=*/4, /*start_iteration=*/25);
+  ASSERT_FALSE(accelerated.run().value());
+
+  const vmecpp::WOutFileContents& p = plain.output_quantities_.wout;
+  const vmecpp::WOutFileContents& a = accelerated.output_quantities_.wout;
+
+  EXPECT_LT(a.niter, p.niter);
+
+  using testing::IsCloseRelAbs;
+  EXPECT_TRUE(IsCloseRelAbs(p.wb, a.wb, 5.0e-7));
+  EXPECT_TRUE(IsCloseRelAbs(p.volume, a.volume, 1.0e-10));
+  EXPECT_TRUE(IsCloseRelAbs(p.aspect, a.aspect, 1.0e-10));
+  EXPECT_TRUE(IsCloseRelAbs(p.ctor, a.ctor, 1.0e-13));
+  EXPECT_TRUE(IsCloseRelAbs(p.rbtor, a.rbtor, 2.0e-4));
+  EXPECT_TRUE(IsCloseRelAbs(p.b0, a.b0, 5.0e-3));
+
+  ASSERT_EQ(a.ns, p.ns);
+  for (int jF = 0; jF < p.ns; ++jF) {
+    EXPECT_TRUE(IsCloseRelAbs(p.phi[jF], a.phi[jF], 1.0e-10));
+    EXPECT_TRUE(IsCloseRelAbs(p.iotaf[jF], a.iotaf[jF], 2.0e-2));
+  }
+
+  ASSERT_EQ(a.mnmax, p.mnmax);
+  for (int jF = 0; jF < p.ns; ++jF) {
+    for (int mn = 0; mn < p.mnmax; ++mn) {
+      EXPECT_TRUE(IsCloseRelAbs(p.rmnc(mn, jF), a.rmnc(mn, jF), 5.0e-3));
+      EXPECT_TRUE(IsCloseRelAbs(p.zmns(mn, jF), a.zmns(mn, jF), 2.0e-3));
+      EXPECT_TRUE(IsCloseRelAbs(p.lmns(mn, jF), a.lmns(mn, jF), 1.0e-1));
+    }
+  }
+}
+
 }  // namespace
 
 // A run without toroidal modes gives the same equilibrium on a toroidal grid

--- a/tests/test_iteration.py
+++ b/tests/test_iteration.py
@@ -303,6 +303,29 @@ def test_run_honors_iteration_style_flag():
     assert par.wb == pytest.approx(ref.wb, rel=1.0e-5)  # magnetic energy
 
 
+def test_run_honors_anderson_acceleration_flag():
+    """vmecpp.run() honors the anderson_acceleration input flag through the native
+    solver.
+
+    The accelerated iteration reaches the same equilibrium in fewer iterations. The two
+    paths end at different points of the force-tolerance ball of the case (ftol 1e-6),
+    so the magnetic energy is held to that ball, and the global geometry and the
+    toroidal current, which the boundary and the current profile pin, tightly.
+    """
+    base = vmecpp.VmecInput.from_file(TEST_DATA / "cth_like_fixed_bdy.json")
+    assert not base.anderson_acceleration
+    accelerated_input = base.model_copy(update={"anderson_acceleration": True})
+    assert accelerated_input._to_cpp_vmecindata().anderson_acceleration
+
+    plain = vmecpp.run(base, max_threads=1, verbose=False).wout
+    accelerated = vmecpp.run(accelerated_input, max_threads=1, verbose=False).wout
+    assert accelerated.niter < plain.niter
+    assert accelerated.volume_p == pytest.approx(plain.volume_p, rel=1.0e-10)
+    assert accelerated.aspect == pytest.approx(plain.aspect, rel=1.0e-10)
+    assert accelerated.ctor == pytest.approx(plain.ctor, rel=1.0e-13)
+    assert accelerated.wb == pytest.approx(plain.wb, rel=1.0e-4)
+
+
 @pytest.mark.parametrize("case", ["cth_like_fixed_bdy", "solovev"])
 def test_parvmec_matches_parvmec_reference(case):
     """The PARVMEC iteration style reproduces the ORNL-Fusion/PARVMEC wout.


### PR DESCRIPTION
**Change** - `VmecInput.anderson_acceleration`, off by default, switches on Anderson acceleration of the descent iteration (JSON and HDF5 round trip through `VmecINDATA`); `Vmec::SetAndersonAcceleration(window, start_iteration, frequency, zero_velocity_on_jump)` keeps the tuning parameters for C++ callers. One Garabedian time step maps the Fourier state x to g(x). `AndersonAcceleration` keeps a short per-thread history of map outputs and residuals r = g - x; the team solves the least-squares problem for the combination of recent residual differences that best cancels the current residual, each thread applies that combination to its map outputs, and the momentum restarts. A thread stores the history of its own slice over its full stored radial range, satellite points included, so the combination stays consistent at the partition seams. The k x k normal equations are the only cross-thread data: `SumInFixedTree` reduces them over a binary tree fixed by thread id, they are Tikhonov-regularized by 1e-12 of their mean diagonal, and a combination that is not finite or exceeds 100 in magnitude is skipped. The defaults are a window of 2, engagement 25 iterations after a stage starts or restarts, and disengagement once fsqr + fsqz + fsql falls below max(1e-4, 1e-3 x the residual at stage entry, 1e3 ftol). Free-boundary runs are included.

**Cause** - the extrapolation pays in the nonlinear phase at the start of each multigrid stage, where the descent is still finding the basin. In the tail the fixed-point map is linear and the momentum iteration already converges at its optimal rate; extrapolating there held the residual in a limit cycle on the QUASR fixed-boundary cases at ftol 1e-9, so the tail is handed back to the descent. An earlier study ran Anderson from fsq = 1e-6 down, where it loses.

**Evidence** - iterations to convergence on the QUASR configurations of `tests/test_free_boundary_quasr.py` (ns [8, 16, 31], mpol = ntor = 6, ftol 1e-9, 8 threads), summed over the multigrid stages. Fixed boundary:

| case | plain | accelerated |
|---|---|---|
| 954 | 414 | 394 |
| 9914 | 739 | 546 |
| 19493 | 2186 | 1816 |
| 19609 | 1719 | 1472 |
| 19940 | 1311 | 1122 |
| 29346 | 1079 | 959 |
| 50136 | 3866 | 3894 |
| 65579 | 3342 | 3279 |
| 112718 | 1789 | 1671 |
| 165868 | 1288 | 1152 |
| 167381 | 1277 | 1197 |
| 336902 | 1314 | 1280 |
| total | 20324 | 18782 |

Free boundary:

| case | plain | accelerated |
|---|---|---|
| 954 | 1512 | 1414 |
| 9914 | 1339 | 1021 |
| 19609 | JACOBIAN_75_TIMES_BAD | 1433 |
| 19940 | 1546 | 1285 |
| 29346 | 1391 | 1302 |
| 65579 | 3212 | 2672 |

The other six free-boundary cases do not converge either way. Accelerated and plain runs converge to the same equilibrium: over the twelve fixed-boundary cases they differ by less, in `wb`, axis, iota profile and every Fourier array, than the plain run at ftol 1e-9 differs from the plain run at ftol 1e-11. Repeated 8-thread accelerated runs agree in all 438 output datasets.

**Tests** - `AndersonAcceleratedCthMatchesPlainIteration` in `vmec_test` solves `cth_like_fixed_bdy` both ways, requires fewer iterations with the flag, and holds each equilibrium-defining quantity to at least five times its measured deviation between the two paths. `test_run_honors_anderson_acceleration_flag` in `tests/test_iteration.py` drives the input flag through `vmecpp.run`.

**Scope** - with the flag unset the window is 0, no history is allocated and the time step is the one that was there.
