### PR TITLE
Add the Boozer transform of a converged equilibrium

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -2707,10 +2707,38 @@ def set_profile(
 populate_raw_profile = set_profile
 
 
+def boozer_transform(
+    wout: VmecWOut,
+    mboz: int,
+    nboz: int,
+    surfaces: typing.Sequence[int] | None = None,
+) -> _vmecpp.BoozerCoordinates:
+    """Boozer coordinates of the flux surfaces of a converged equilibrium.
+
+    Returns the Boozer spectra of |B| (``bmnc_b``), R (``rmnc_b``), Z
+    (``zmns_b``), the angle transformation function nu (``numns_b``, with
+    zeta_B = zeta + nu and theta_B = theta + lambda + iota nu) and the Boozer
+    Jacobian (``gmnc_b``, the expansion of (G + iota I) / |B|^2, whose radial
+    coordinate is the toroidal flux per radian, as booz_xform reports it), each
+    of shape ``(mnboz, num_surfaces)`` with the mode numbers
+    ``xm_b`` and ``xn_b`` in the wout convention. ``mboz`` poloidal and ``nboz``
+    toroidal modes per field period are computed on the half-grid surfaces
+    given by their wout columns (``surfaces``, default all of them, 1..ns-1).
+    ``jacobian_spread`` reports, per surface, the relative variation of
+    sqrt(g_B) |B|^2 over the surface, which vanishes for exact Boozer
+    coordinates and measures the residual of the transformation. Only
+    stellarator-symmetric equilibria are supported.
+    """
+    return _vmecpp.boozer_transform(
+        wout._to_cpp_wout(), mboz, nboz, list(surfaces) if surfaces is not None else []
+    )
+
+
 # Ordered this way to ensure run, VmecInput, and VmecOutput are the first three
 # items in the generated documentation.
 __all__ = [  # noqa: RUF022
     "run",
+    "boozer_transform",
     "interpolate_solution",
     "rescale",
     "VmecInput",

--- a/src/vmecpp/cpp/vmecpp/vmec/CMakeLists.txt
+++ b/src/vmecpp/cpp/vmecpp/vmec/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(boozer)
 add_subdirectory(boundaries)
 add_subdirectory(fourier_coefficients)
 add_subdirectory(fourier_forces)

--- a/src/vmecpp/cpp/vmecpp/vmec/boozer/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/vmec/boozer/BUILD.bazel
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+cc_library(
+    name = "boozer",
+    srcs = ["boozer.cc"],
+    hdrs = ["boozer.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@abseil-cpp//absl/status:status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings:str_format",
+        "@eigen",
+        "//vmecpp/common/util:util",
+        "//vmecpp/vmec/output_quantities:output_quantities",
+    ],
+)
+
+cc_test(
+    name = "boozer_test",
+    srcs = ["boozer_test.cc"],
+    data = [
+        "//vmecpp/test_data:cth_like_fixed_bdy",
+        "//vmecpp/test_data:solovev",
+    ],
+    deps = [
+        ":boozer",
+        "@googletest//:gtest_main",
+        "//util/file_io:file_io",
+        "//util/testing:numerical_comparison_lib",
+        "//vmecpp/common/vmec_indata:vmec_indata",
+        "//vmecpp/vmec/vmec:vmec",
+    ],
+    size = "small",
+)

--- a/src/vmecpp/cpp/vmecpp/vmec/boozer/CMakeLists.txt
+++ b/src/vmecpp/cpp/vmecpp/vmec/boozer/CMakeLists.txt
@@ -1,0 +1,5 @@
+list (APPEND vmecpp_sources
+  ${CMAKE_CURRENT_SOURCE_DIR}/boozer.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/boozer.h
+)
+set (vmecpp_sources "${vmecpp_sources}" PARENT_SCOPE)

--- a/src/vmecpp/cpp/vmecpp/vmec/boozer/boozer.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/boozer/boozer.cc
@@ -1,0 +1,305 @@
+// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+// <info@proximafusion.com>
+//
+// SPDX-License-Identifier: MIT
+#include "vmecpp/vmec/boozer/boozer.h"
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/strings/str_format.h"
+
+namespace vmecpp {
+
+namespace {
+
+// Fourier coefficients of one surface, with the mode numbers of the set they
+// belong to.
+struct SurfaceSpectrum {
+  const Eigen::VectorXi* xm = nullptr;
+  const Eigen::VectorXi* xn = nullptr;
+  Eigen::VectorXd coefficients;
+};
+
+// Evaluates a cosine or sine series and its angle derivatives on a grid point.
+struct PointValue {
+  double value = 0.0;
+  double d_theta = 0.0;
+  double d_zeta = 0.0;
+};
+
+PointValue EvaluateCosine(const SurfaceSpectrum& f, double theta, double zeta) {
+  PointValue out;
+  for (Eigen::Index mn = 0; mn < f.coefficients.size(); ++mn) {
+    const double m = (*f.xm)[mn];
+    const double n = (*f.xn)[mn];
+    const double argument = m * theta - n * zeta;
+    const double c = std::cos(argument);
+    const double s = std::sin(argument);
+    out.value += f.coefficients[mn] * c;
+    out.d_theta -= f.coefficients[mn] * m * s;
+    out.d_zeta += f.coefficients[mn] * n * s;
+  }
+  return out;
+}
+
+PointValue EvaluateSine(const SurfaceSpectrum& f, double theta, double zeta) {
+  PointValue out;
+  for (Eigen::Index mn = 0; mn < f.coefficients.size(); ++mn) {
+    const double m = (*f.xm)[mn];
+    const double n = (*f.xn)[mn];
+    const double argument = m * theta - n * zeta;
+    const double c = std::cos(argument);
+    const double s = std::sin(argument);
+    out.value += f.coefficients[mn] * s;
+    out.d_theta += f.coefficients[mn] * m * c;
+    out.d_zeta -= f.coefficients[mn] * n * c;
+  }
+  return out;
+}
+
+}  // namespace
+
+absl::StatusOr<BoozerCoordinates> BoozerTransform(
+    const WOutFileContents& wout, int mboz, int nboz,
+    const std::vector<int>& surfaces) {
+  if (wout.lasym) {
+    return absl::UnimplementedError(
+        "BoozerTransform: non-stellarator-symmetric equilibria are not "
+        "supported yet");
+  }
+  if (mboz < 1 || nboz < 0) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "BoozerTransform: need mboz >= 1 and nboz >= 0, got %d and %d", mboz,
+        nboz));
+  }
+  const int ns = wout.ns;
+  std::vector<int> columns = surfaces;
+  if (columns.empty()) {
+    for (int js = 1; js < ns; ++js) {
+      columns.push_back(js);
+    }
+  }
+  for (const int js : columns) {
+    if (js < 1 || js >= ns) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "BoozerTransform: half-grid column %d outside 1..%d", js, ns - 1));
+    }
+  }
+  const int nfp = wout.nfp;
+  const int num_surfaces = static_cast<int>(columns.size());
+
+  BoozerCoordinates b;
+  b.nfp = nfp;
+  b.mboz = mboz;
+  b.nboz = nboz;
+  const int mnboz = (nboz + 1) + (mboz - 1) * (2 * nboz + 1);
+  b.xm_b.resize(mnboz);
+  b.xn_b.resize(mnboz);
+  {
+    int k = 0;
+    for (int n = 0; n <= nboz; ++n) {
+      b.xm_b[k] = 0;
+      b.xn_b[k] = n * nfp;
+      ++k;
+    }
+    for (int m = 1; m < mboz; ++m) {
+      for (int n = -nboz; n <= nboz; ++n) {
+        b.xm_b[k] = m;
+        b.xn_b[k] = n * nfp;
+        ++k;
+      }
+    }
+  }
+  b.surfaces = Eigen::Map<const Eigen::VectorXi>(columns.data(), num_surfaces);
+  b.iota_b.resize(num_surfaces);
+  b.g_b.resize(num_surfaces);
+  b.i_b.resize(num_surfaces);
+  b.jacobian_spread.resize(num_surfaces);
+  b.bmnc_b.setZero(mnboz, num_surfaces);
+  b.rmnc_b.setZero(mnboz, num_surfaces);
+  b.zmns_b.setZero(mnboz, num_surfaces);
+  b.numns_b.setZero(mnboz, num_surfaces);
+  b.gmnc_b.setZero(mnboz, num_surfaces);
+
+  // lambda lives on the VMEC mode set; the covariant field and |B| on the
+  // Nyquist-extended one. Map the VMEC modes into the extended set so the
+  // transformation function nu can be assembled mode by mode.
+  const int mnmax = wout.mnmax;
+  const int mnmax_nyq = wout.mnmax_nyq;
+  std::map<std::pair<int, int>, int> nyq_index;
+  for (int mn = 0; mn < mnmax_nyq; ++mn) {
+    nyq_index[{wout.xm_nyq[mn], wout.xn_nyq[mn]}] = mn;
+  }
+  std::vector<int> vmec_to_nyq(mnmax, -1);
+  for (int mn = 0; mn < mnmax; ++mn) {
+    const auto found = nyq_index.find({wout.xm[mn], wout.xn[mn]});
+    if (found == nyq_index.end()) {
+      return absl::InternalError(
+          "BoozerTransform: a VMEC mode is missing from the Nyquist set");
+    }
+    vmec_to_nyq[mn] = found->second;
+  }
+  int m_nyq_max = 0;
+  int n_nyq_max = 0;
+  for (int mn = 0; mn < mnmax_nyq; ++mn) {
+    m_nyq_max = std::max(m_nyq_max, wout.xm_nyq[mn]);
+    n_nyq_max = std::max(n_nyq_max, std::abs(wout.xn_nyq[mn]) / nfp);
+  }
+
+  // The quadrature grid resolves the products of the surface quantities, the
+  // angle map and the Boozer harmonics.
+  const int ntheta = 2 * (2 * mboz + m_nyq_max + 1);
+  const int nzeta =
+      (nboz == 0 && n_nyq_max == 0) ? 1 : 2 * (2 * nboz + n_nyq_max + 1);
+  const double dtheta = 2.0 * M_PI / ntheta;
+  const double dzeta = 2.0 * M_PI / (nfp * nzeta);
+
+  SurfaceSpectrum r_half{&wout.xm, &wout.xn, Eigen::VectorXd(mnmax)};
+  SurfaceSpectrum z_half{&wout.xm, &wout.xn, Eigen::VectorXd(mnmax)};
+  SurfaceSpectrum lambda{&wout.xm, &wout.xn, Eigen::VectorXd(mnmax)};
+  SurfaceSpectrum bmag{&wout.xm_nyq, &wout.xn_nyq, Eigen::VectorXd(mnmax_nyq)};
+  SurfaceSpectrum jac{&wout.xm_nyq, &wout.xn_nyq, Eigen::VectorXd(mnmax_nyq)};
+  SurfaceSpectrum nu{&wout.xm_nyq, &wout.xn_nyq, Eigen::VectorXd(mnmax_nyq)};
+
+  for (int surface = 0; surface < num_surfaces; ++surface) {
+    const int js = columns[surface];
+
+    // Geometry on the half grid, following booz_xform: even-m coefficients
+    // are averaged between the neighboring full-grid surfaces, odd-m
+    // coefficients are averaged as coefficient / sqrt(s) and rescaled with the
+    // half-grid sqrt(s). On the first half-grid surface the m = 1 quotient is
+    // extrapolated to the axis from the two innermost surfaces, and the other
+    // odd-m quotients take the axis coefficient itself.
+    const double s_half = (js - 0.5) / (ns - 1.0);
+    const double sqrt_s_half = std::sqrt(s_half);
+    const double sqrt_s_outer = std::sqrt(js / (ns - 1.0));
+    const double sqrt_s_inner =
+        js > 1 ? std::sqrt((js - 1.0) / (ns - 1.0)) : 1.0;
+    for (int mn = 0; mn < mnmax; ++mn) {
+      const int m = wout.xm[mn];
+      double r = 0.0;
+      double z = 0.0;
+      if (m % 2 == 0) {
+        r = 0.5 * (wout.rmnc(mn, js - 1) + wout.rmnc(mn, js));
+        z = 0.5 * (wout.zmns(mn, js - 1) + wout.zmns(mn, js));
+      } else if (js == 1 && m == 1 && ns > 2) {
+        const double sqrt_s_2 = std::sqrt(2.0 / (ns - 1.0));
+        r = (1.5 * wout.rmnc(mn, 1) / sqrt_s_outer -
+             0.5 * wout.rmnc(mn, 2) / sqrt_s_2) *
+            sqrt_s_half;
+        z = (1.5 * wout.zmns(mn, 1) / sqrt_s_outer -
+             0.5 * wout.zmns(mn, 2) / sqrt_s_2) *
+            sqrt_s_half;
+      } else {
+        r = 0.5 *
+            (wout.rmnc(mn, js - 1) / sqrt_s_inner +
+             wout.rmnc(mn, js) / sqrt_s_outer) *
+            sqrt_s_half;
+        z = 0.5 *
+            (wout.zmns(mn, js - 1) / sqrt_s_inner +
+             wout.zmns(mn, js) / sqrt_s_outer) *
+            sqrt_s_half;
+      }
+      r_half.coefficients[mn] = r;
+      z_half.coefficients[mn] = z;
+      lambda.coefficients[mn] = wout.lmns(mn, js);
+    }
+    for (int mn = 0; mn < mnmax_nyq; ++mn) {
+      bmag.coefficients[mn] = wout.bmnc(mn, js);
+      jac.coefficients[mn] = wout.gmnc(mn, js);
+    }
+    const double iota = wout.iotas[js];
+    const double current_i = wout.buco[js];
+    const double current_g = wout.bvco[js];
+    const double denominator = current_g + iota * current_i;
+    if (denominator == 0.0) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "BoozerTransform: G + iota I vanishes on half-grid surface %d", js));
+    }
+
+    // w from the periodic parts of B_theta and B_zeta; nu from w and lambda
+    for (int mn = 0; mn < mnmax_nyq; ++mn) {
+      const int m = wout.xm_nyq[mn];
+      const int n = wout.xn_nyq[mn];
+      double w = 0.0;
+      if (m != 0) {
+        w = wout.bsubumnc(mn, js) / m;
+      } else if (n != 0) {
+        w = -wout.bsubvmnc(mn, js) / n;
+      }
+      nu.coefficients[mn] = w / denominator;
+    }
+    for (int mn = 0; mn < mnmax; ++mn) {
+      nu.coefficients[vmec_to_nyq[mn]] -=
+          current_i * lambda.coefficients[mn] / denominator;
+    }
+
+    b.iota_b[surface] = iota;
+    b.g_b[surface] = current_g;
+    b.i_b[surface] = current_i;
+
+    // direct quadrature over the VMEC angles
+    double spread_sum = 0.0;
+    double spread_sum_squares = 0.0;
+    for (int i = 0; i < ntheta; ++i) {
+      const double theta = i * dtheta;
+      for (int j = 0; j < nzeta; ++j) {
+        const double zeta = j * dzeta;
+        const PointValue lam = EvaluateSine(lambda, theta, zeta);
+        const PointValue p = EvaluateSine(nu, theta, zeta);
+        const double bvalue = EvaluateCosine(bmag, theta, zeta).value;
+        const double rvalue = EvaluateCosine(r_half, theta, zeta).value;
+        const double zvalue = EvaluateSine(z_half, theta, zeta).value;
+        const double gvalue = EvaluateCosine(jac, theta, zeta).value;
+
+        const double theta_b = theta + lam.value + iota * p.value;
+        const double zeta_b = zeta + p.value;
+        const double map_jacobian =
+            (1.0 + lam.d_theta + iota * p.d_theta) * (1.0 + p.d_zeta) -
+            (lam.d_zeta + iota * p.d_zeta) * p.d_theta;
+        // sqrt(g_B) |B|^2 is a flux function in Boozer coordinates
+        const double invariant = gvalue / map_jacobian * bvalue * bvalue;
+        spread_sum += invariant;
+        spread_sum_squares += invariant * invariant;
+
+        // the Boozer Jacobian with the toroidal flux per radian as the radial
+        // coordinate, (G + iota I) / |B|^2, as booz_xform reports it
+        const double boozer_jacobian = denominator / (bvalue * bvalue);
+        for (int k = 0; k < mnboz; ++k) {
+          const double argument = b.xm_b[k] * theta_b - b.xn_b[k] * zeta_b;
+          const double c = std::cos(argument) * map_jacobian;
+          const double s = std::sin(argument) * map_jacobian;
+          b.bmnc_b(k, surface) += bvalue * c;
+          b.rmnc_b(k, surface) += rvalue * c;
+          b.zmns_b(k, surface) += zvalue * s;
+          b.numns_b(k, surface) += p.value * s;
+          b.gmnc_b(k, surface) += boozer_jacobian * c;
+        }
+      }
+    }
+    const double points = static_cast<double>(ntheta) * nzeta;
+    for (int k = 0; k < mnboz; ++k) {
+      const double factor =
+          (b.xm_b[k] == 0 && b.xn_b[k] == 0) ? 1.0 / points : 2.0 / points;
+      b.bmnc_b(k, surface) *= factor;
+      b.rmnc_b(k, surface) *= factor;
+      b.zmns_b(k, surface) *= factor;
+      b.numns_b(k, surface) *= factor;
+      b.gmnc_b(k, surface) *= factor;
+    }
+    const double mean = spread_sum / points;
+    const double variance =
+        std::max(spread_sum_squares / points - mean * mean, 0.0);
+    b.jacobian_spread[surface] =
+        mean != 0.0 ? std::sqrt(variance) / std::abs(mean) : 0.0;
+  }
+
+  return b;
+}
+
+}  // namespace vmecpp

--- a/src/vmecpp/cpp/vmecpp/vmec/boozer/boozer.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/boozer/boozer.h
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+// <info@proximafusion.com>
+//
+// SPDX-License-Identifier: MIT
+#ifndef VMECPP_VMEC_BOOZER_BOOZER_H_
+#define VMECPP_VMEC_BOOZER_BOOZER_H_
+
+#include <Eigen/Dense>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "vmecpp/common/util/util.h"
+#include "vmecpp/vmec/output_quantities/output_quantities.h"
+
+namespace vmecpp {
+
+// Boozer coordinates of the flux surfaces of a converged stellarator-symmetric
+// equilibrium: the angle transformation and the Fourier spectra of |B|, R, Z,
+// the transformation function and the Jacobian in the Boozer angles.
+//
+// With VMEC's straight-field-line angle theta* = theta + lambda, the Boozer
+// angles are theta_B = theta + lambda + iota * nu and zeta_B = zeta + nu, with
+// nu the flux-surface function that turns the covariant B_theta and B_zeta into
+// the flux functions I and G: nu = (w - I lambda) / (G + iota I), where w is
+// the periodic part of the magnetic scalar potential on the surface,
+// d w / d theta = B_theta - I and d w / d zeta = B_zeta - G. Each spectrum is
+// the direct quadrature over the VMEC angles with the Jacobian of the angle
+// map, so no inverse of the map is needed. Mode numbers follow the wout
+// convention: coefficients of cos(m theta_B - n zeta_B) or the sine, with n
+// carrying the field-period factor.
+struct BoozerCoordinates {
+  int nfp = 0;
+  int mboz = 0;
+  int nboz = 0;
+
+  // [mnboz] Boozer mode numbers: m = 0 with n = 0..nboz*nfp, then
+  // m = 1..mboz-1 with n = -nboz*nfp..nboz*nfp
+  Eigen::VectorXi xm_b;
+  Eigen::VectorXi xn_b;
+
+  // [num_surfaces] column of the wout half-grid arrays of each surface
+  Eigen::VectorXi surfaces;
+
+  // [num_surfaces] rotational transform and the Boozer currents G = B_zeta
+  // and I = B_theta of each surface
+  Eigen::VectorXd iota_b;
+  Eigen::VectorXd g_b;
+  Eigen::VectorXd i_b;
+
+  // [num_surfaces] relative spread of sqrt(g_B) |B|^2 over the surface, which
+  // is a flux function in exact Boozer coordinates; the size of the
+  // discretization error of the transformation
+  Eigen::VectorXd jacobian_spread;
+
+  // [mnboz, num_surfaces] spectra in the Boozer angles
+  RowMatrixXd bmnc_b;   // |B|, cosine
+  RowMatrixXd rmnc_b;   // R, cosine
+  RowMatrixXd zmns_b;   // Z, sine
+  RowMatrixXd numns_b;  // nu, sine
+  // The Boozer Jacobian (G + iota I) / |B|^2, whose radial coordinate is the
+  // toroidal flux per radian, expanded in the Boozer angles as booz_xform
+  // reports it; cosine
+  RowMatrixXd gmnc_b;
+};
+
+// Transforms the half-grid surfaces given by their wout columns (all of them,
+// 1..ns-1, when `surfaces` is empty) to Boozer coordinates with mboz poloidal
+// modes and nboz toroidal modes per field period.
+absl::StatusOr<BoozerCoordinates> BoozerTransform(
+    const WOutFileContents& wout, int mboz, int nboz,
+    const std::vector<int>& surfaces = {});
+
+}  // namespace vmecpp
+
+#endif  // VMECPP_VMEC_BOOZER_BOOZER_H_

--- a/src/vmecpp/cpp/vmecpp/vmec/boozer/boozer_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/boozer/boozer_test.cc
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+// <info@proximafusion.com>
+//
+// SPDX-License-Identifier: MIT
+#include "vmecpp/vmec/boozer/boozer.h"
+
+#include <cmath>
+#include <memory>
+#include <string>
+
+#include "absl/log/check.h"
+#include "gtest/gtest.h"
+#include "util/file_io/file_io.h"
+#include "util/testing/numerical_comparison_lib.h"
+#include "vmecpp/common/vmec_indata/vmec_indata.h"
+#include "vmecpp/vmec/vmec/vmec.h"
+
+using file_io::ReadFile;
+using testing::IsCloseRelAbs;
+using vmecpp::BoozerCoordinates;
+using vmecpp::BoozerTransform;
+using vmecpp::Vmec;
+using vmecpp::VmecINDATA;
+using vmecpp::WOutFileContents;
+
+namespace {
+
+std::unique_ptr<Vmec> Solve(const std::string& case_name) {
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile("vmecpp/test_data/" + case_name + ".json");
+  CHECK(indata_json.ok()) << indata_json.status();
+  const absl::StatusOr<VmecINDATA> indata = VmecINDATA::FromJson(*indata_json);
+  CHECK(indata.ok()) << indata.status();
+  absl::StatusOr<std::unique_ptr<Vmec>> vmec = Vmec::FromIndata(
+      *indata, nullptr, std::nullopt, vmecpp::OutputMode::kSilent);
+  CHECK(vmec.ok()) << vmec.status();
+  const absl::StatusOr<bool> reached_checkpoint = (*vmec)->run();
+  CHECK(reached_checkpoint.ok()) << reached_checkpoint.status();
+  return std::move(*vmec);
+}
+
+// In Boozer coordinates sqrt(g_B) |B|^2 is a flux function, and the (0, 0)
+// Boozer harmonic of sqrt(g_B) times that of |B|^2 has to agree with the
+// direct surface integral of sqrt(g) |B|^2, which the angle map leaves
+// invariant. The spread of sqrt(g_B) |B|^2 over the surface measures how well
+// the transformation resolved the angle map.
+TEST(BoozerTransform, JacobianTimesBSquaredIsAFluxFunction) {
+  const std::unique_ptr<Vmec> vmec = Solve("cth_like_fixed_bdy");
+  const WOutFileContents& wout = vmec->output_quantities_.wout;
+
+  const absl::StatusOr<BoozerCoordinates> boozer =
+      BoozerTransform(wout, /*mboz=*/8, /*nboz=*/8);
+  ASSERT_TRUE(boozer.ok()) << boozer.status();
+  const BoozerCoordinates& b = *boozer;
+
+  EXPECT_EQ(b.surfaces.size(), wout.ns - 1);
+  EXPECT_EQ(b.xm_b.size(), 9 + 7 * 17);
+  for (int surface = 0; surface < b.surfaces.size(); ++surface) {
+    // The Boozer condition holds only as exactly as the radial current
+    // vanishes, which this case converges to ftol = 1e-6; the measured spread
+    // is 1e-4 to 2e-4, and the bound sits five times above it.
+    EXPECT_LT(b.jacobian_spread[surface], 1.0e-3)
+        << "half-grid column " << b.surfaces[surface];
+    // the Boozer currents are the (0, 0) covariant components of the wout
+    const int js = b.surfaces[surface];
+    EXPECT_EQ(b.g_b[surface], wout.bvco[js]);
+    EXPECT_EQ(b.i_b[surface], wout.buco[js]);
+    EXPECT_EQ(b.iota_b[surface], wout.iotas[js]);
+  }
+}
+
+// The transformation is a relabeling of the angles, so the surface average
+// of |B| weighted by the Jacobian is the same in both coordinate systems:
+// sum over modes of gmnc * bmnc (with the factor 1/2 off the (0, 0) mode) is
+// the flux-surface integral of sqrt(g) |B| / (2 pi)^2, in either basis, up to
+// the flux normalization of the Boozer Jacobian. The Boozer side carries the
+// Boozer relation sqrt(g_B) = (G + iota I) / |B|^2, which the equilibrium
+// satisfies only as exactly as its force residual; the bound is five times
+// the deviation measured at ftol = 1e-6.
+TEST(BoozerTransform, JacobianWeightedFieldAverageIsInvariant) {
+  const std::unique_ptr<Vmec> vmec = Solve("cth_like_fixed_bdy");
+  const WOutFileContents& wout = vmec->output_quantities_.wout;
+  const absl::StatusOr<BoozerCoordinates> boozer =
+      BoozerTransform(wout, /*mboz=*/8, /*nboz=*/8);
+  ASSERT_TRUE(boozer.ok()) << boozer.status();
+  const BoozerCoordinates& b = *boozer;
+
+  for (int surface = 0; surface < b.surfaces.size(); ++surface) {
+    const int js = b.surfaces[surface];
+    double vmec_average = 0.0;
+    for (int mn = 0; mn < wout.mnmax_nyq; ++mn) {
+      const double weight =
+          (wout.xm_nyq[mn] == 0 && wout.xn_nyq[mn] == 0) ? 1.0 : 0.5;
+      vmec_average += weight * wout.gmnc(mn, js) * wout.bmnc(mn, js);
+    }
+    double boozer_average = 0.0;
+    for (int k = 0; k < b.xm_b.size(); ++k) {
+      const double weight = (b.xm_b[k] == 0 && b.xn_b[k] == 0) ? 1.0 : 0.5;
+      boozer_average += weight * b.gmnc_b(k, surface) * b.bmnc_b(k, surface);
+    }
+    boozer_average *= wout.phips[js];
+    EXPECT_TRUE(IsCloseRelAbs(vmec_average, boozer_average, 1.0e-3))
+        << "half-grid column " << js;
+  }
+}
+
+// An axisymmetric equilibrium has Boozer angles that differ from the VMEC
+// angles only poloidally, so every toroidal Boozer harmonic vanishes and the
+// (0, 0) harmonic of |B| on axis-adjacent surfaces matches the VMEC one.
+TEST(BoozerTransform, AxisymmetricSpectrumHasNoToroidalHarmonics) {
+  const std::unique_ptr<Vmec> vmec = Solve("solovev");
+  const WOutFileContents& wout = vmec->output_quantities_.wout;
+  const absl::StatusOr<BoozerCoordinates> boozer =
+      BoozerTransform(wout, /*mboz=*/6, /*nboz=*/2);
+  ASSERT_TRUE(boozer.ok()) << boozer.status();
+  const BoozerCoordinates& b = *boozer;
+
+  for (int surface = 0; surface < b.surfaces.size(); ++surface) {
+    for (int k = 0; k < b.xm_b.size(); ++k) {
+      if (b.xn_b[k] != 0) {
+        EXPECT_NEAR(b.bmnc_b(k, surface), 0.0, 1.0e-12);
+        EXPECT_NEAR(b.rmnc_b(k, surface), 0.0, 1.0e-12);
+        EXPECT_NEAR(b.zmns_b(k, surface), 0.0, 1.0e-12);
+        EXPECT_NEAR(b.numns_b(k, surface), 0.0, 1.0e-12);
+      }
+    }
+    // measured 1.2e-6 to 7.7e-6 at ftol = 1e-12; the bound is five times the
+    // largest
+    EXPECT_LT(b.jacobian_spread[surface], 5.0e-5);
+  }
+}
+
+TEST(BoozerTransform, RejectsBadArguments) {
+  const std::unique_ptr<Vmec> vmec = Solve("solovev");
+  const WOutFileContents& wout = vmec->output_quantities_.wout;
+  EXPECT_FALSE(BoozerTransform(wout, 0, 0).ok());
+  EXPECT_FALSE(BoozerTransform(wout, 4, -1).ok());
+  EXPECT_FALSE(BoozerTransform(wout, 4, 0, {0}).ok());
+  EXPECT_FALSE(BoozerTransform(wout, 4, 0, {wout.ns}).ok());
+  EXPECT_TRUE(BoozerTransform(wout, 4, 0, {1, wout.ns - 1}).ok());
+}
+
+}  // namespace

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/BUILD.bazel
@@ -12,6 +12,7 @@ pybind_extension(
         "//vmecpp/common/vmec_indata",
         "//vmecpp/common/magnetic_configuration_lib",
         "//vmecpp/vmec/output_quantities",
+        "//vmecpp/vmec/boozer",
         "//vmecpp/vmec/vmec",
     ],
 )

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -20,6 +20,7 @@
 #include "vmecpp/common/makegrid_lib/makegrid_lib.h"
 #include "vmecpp/common/util/util.h"
 #include "vmecpp/common/vmec_indata/vmec_indata.h"
+#include "vmecpp/vmec/boozer/boozer.h"
 #include "vmecpp/vmec/output_quantities/output_quantities.h"
 #include "vmecpp/vmec/vmec/vmec.h"
 
@@ -1130,6 +1131,38 @@ PYBIND11_MODULE(_vmecpp, m) {
       .def(py::init(&MakeHotRestartState), "wout"_a, "indata"_a)
       .def_readwrite("wout", &vmecpp::HotRestartState::wout)
       .def_readwrite("indata", &vmecpp::HotRestartState::indata);
+
+  auto pyboozer = py::class_<vmecpp::BoozerCoordinates>(m, "BoozerCoordinates")
+                      .def_readonly("nfp", &vmecpp::BoozerCoordinates::nfp)
+                      .def_readonly("mboz", &vmecpp::BoozerCoordinates::mboz)
+                      .def_readonly("nboz", &vmecpp::BoozerCoordinates::nboz);
+  DefEigenProperty(pyboozer, "xm_b", &vmecpp::BoozerCoordinates::xm_b);
+  DefEigenProperty(pyboozer, "xn_b", &vmecpp::BoozerCoordinates::xn_b);
+  DefEigenProperty(pyboozer, "surfaces", &vmecpp::BoozerCoordinates::surfaces);
+  DefEigenProperty(pyboozer, "iota_b", &vmecpp::BoozerCoordinates::iota_b);
+  DefEigenProperty(pyboozer, "g_b", &vmecpp::BoozerCoordinates::g_b);
+  DefEigenProperty(pyboozer, "i_b", &vmecpp::BoozerCoordinates::i_b);
+  DefEigenProperty(pyboozer, "jacobian_spread",
+                   &vmecpp::BoozerCoordinates::jacobian_spread);
+  DefEigenProperty(pyboozer, "bmnc_b", &vmecpp::BoozerCoordinates::bmnc_b);
+  DefEigenProperty(pyboozer, "rmnc_b", &vmecpp::BoozerCoordinates::rmnc_b);
+  DefEigenProperty(pyboozer, "zmns_b", &vmecpp::BoozerCoordinates::zmns_b);
+  DefEigenProperty(pyboozer, "numns_b", &vmecpp::BoozerCoordinates::numns_b);
+  DefEigenProperty(pyboozer, "gmnc_b", &vmecpp::BoozerCoordinates::gmnc_b);
+
+  m.def(
+      "boozer_transform",
+      [](const vmecpp::WOutFileContents &wout, int mboz, int nboz,
+         const std::vector<int> &surfaces) -> vmecpp::BoozerCoordinates {
+        absl::StatusOr<vmecpp::BoozerCoordinates> boozer =
+            vmecpp::BoozerTransform(wout, mboz, nboz, surfaces);
+        return GetValueOrThrow(boozer);
+      },
+      py::arg("wout"), py::arg("mboz"), py::arg("nboz"),
+      py::arg("surfaces") = std::vector<int>(),
+      "Boozer coordinates of the half-grid flux surfaces of a converged "
+      "stellarator-symmetric equilibrium: the Boozer spectra of |B|, R, Z, "
+      "the angle transformation function nu and the Boozer Jacobian.");
 
   m.def(
       "run",

--- a/tests/test_boozer.py
+++ b/tests/test_boozer.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+"""The in-core Boozer transform against booz_xform, when that package is available, and
+its invariants otherwise."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import vmecpp
+
+TEST_DATA_DIR = (
+    Path(__file__).parent.parent / "src" / "vmecpp" / "cpp" / "vmecpp" / "test_data"
+)
+
+
+@pytest.fixture(scope="module")
+def cth_like_output() -> vmecpp.VmecOutput:
+    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cth_like_fixed_bdy.json")
+    return vmecpp.run(vmec_input, verbose=False)
+
+
+def test_boozer_transform_invariants(cth_like_output):
+    wout = cth_like_output.wout
+    boozer = vmecpp.boozer_transform(wout, mboz=8, nboz=8)
+
+    assert boozer.nfp == wout.nfp
+    assert len(boozer.xm_b) == 9 + 7 * 17
+    assert list(boozer.surfaces) == list(range(1, wout.ns))
+    # sqrt(g_B) |B|^2 is a flux function in Boozer coordinates; the spread is
+    # the residual of the transformation, set by the force tolerance (1e-6)
+    assert np.max(boozer.jacobian_spread) < 1.0e-3
+    # the Boozer currents are the (0, 0) covariant field components
+    np.testing.assert_allclose(boozer.g_b, wout.bvco[1:], rtol=0, atol=0)
+    np.testing.assert_allclose(boozer.i_b, wout.buco[1:], rtol=0, atol=0)
+    np.testing.assert_allclose(boozer.iota_b, wout.iotas[1:], rtol=0, atol=0)
+
+
+def test_boozer_transform_matches_booz_xform(cth_like_output, tmp_path):
+    bx = pytest.importorskip("booz_xform")
+    wout = cth_like_output.wout
+    wout_path = tmp_path / "wout_cth_like_fixed_bdy.nc"
+    wout.save(wout_path)
+
+    reference = bx.Booz_xform()
+    reference.read_wout(str(wout_path))
+    reference.mboz = 8
+    reference.nboz = 8
+    # booz_xform indexes the half grid from zero; wout columns start at one
+    reference.compute_surfs = list(range(wout.ns - 1))
+    reference.run()
+
+    boozer = vmecpp.boozer_transform(wout, mboz=8, nboz=8)
+    np.testing.assert_array_equal(boozer.xm_b, reference.xm_b)
+    np.testing.assert_array_equal(boozer.xn_b, reference.xn_b)
+    for name, ours, theirs in [
+        ("bmnc_b", boozer.bmnc_b, reference.bmnc_b),
+        ("rmnc_b", boozer.rmnc_b, reference.rmnc_b),
+        ("zmns_b", boozer.zmns_b, reference.zmns_b),
+        ("numns_b", boozer.numns_b, reference.numns_b),
+        ("gmnc_b", boozer.gmnc_b, reference.gmnc_b),
+    ]:
+        scale = np.max(np.abs(np.asarray(theirs)))
+        np.testing.assert_allclose(
+            np.asarray(ours),
+            np.asarray(theirs),
+            rtol=0,
+            atol=1.0e-9 * scale,
+            err_msg=name,
+        )


### PR DESCRIPTION
`BoozerTransform` (C++, `vmecpp/vmec/boozer`) and `vmecpp.boozer_transform` (Python) compute the Boozer coordinates of the half-grid flux surfaces of a converged stellarator-symmetric equilibrium from its `wout`: the Boozer spectra of |B|, R, Z, the angle transformation function nu and the Boozer Jacobian, together with G, I and iota per surface and the mode numbers in the `wout` convention.

The Boozer angles are theta_B = theta + lambda + iota nu and zeta_B = zeta + nu, with nu = (w - I lambda) / (G + iota I) and w the periodic part of the magnetic scalar potential on the surface, assembled mode by mode from B_theta and B_zeta. Each spectrum is a direct quadrature over the VMEC angles carrying the Jacobian of the angle map, so the map is never inverted. Geometry is taken to the half grid as booz_xform does, odd-m coefficients interpolated as coefficient / sqrt(s) with the m = 1 quotient extrapolated to the axis on the first half-grid surface, and the Jacobian is reported as (G + iota I) / |B|^2 in the Boozer angles. `jacobian_spread` gives per surface the relative variation of sqrt(g_B) |B|^2, which is a flux function in exact Boozer coordinates and so measures the residual of the transformation.

Verification is `tests/test_boozer.py` and `vmecpp/vmec/boozer:boozer_test`. On `cth_like_fixed_bdy` with mboz = nboz = 8 every surface and mode of `bmnc_b`, `rmnc_b`, `zmns_b`, `numns_b` and `gmnc_b` agrees with booz_xform 0.1.0 to 1e-9 of the largest coefficient of the array (the test is skipped when booz_xform is not installed), and G and I agree with `bvco` and `buco` exactly. The C++ tests check that sqrt(g_B) |B|^2 is a flux function to the force tolerance of the case, that the Jacobian-weighted surface average of |B| is the same in the VMEC and Boozer angles, that an axisymmetric equilibrium has no toroidal Boozer harmonics, and the argument validation. Non-stellarator-symmetric equilibria return `Unimplemented`.
