### PR TITLE
Fix the poloidal layout of the lasym covariant-B derivatives in the output stage

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -2076,10 +2076,12 @@ vmecpp::SymmetryDecomposedCovariantB vmecpp::DecomposeCovariantBBySymmetry(
     // bs_a(v,u) = .5*( bs(v,u) + bs(-v,-u) )     ! * COS(mu - nv)
     for (int jF = 0; jF < vmec_internal_results.num_full; ++jF) {
       for (int kl = 0; kl < vmec_internal_results.nZnT_reduced; ++kl) {
-        const int source_index = jF * s.nZnT + kl;
-
         const int k = kl / s.nThetaReduced;
         const int l = kl % s.nThetaReduced;
+
+        // bsubs_full is stored in the full (nThetaEff) poloidal layout, so the
+        // within-surface offset has to use nThetaEven, as for bsubu below.
+        const int source_index = jF * s.nZnT + (k * s.nThetaEven + l);
 
         const int l_reversed = (s.nThetaEven - l) % s.nThetaEven;
         const int k_reversed = (s.nZeta - k) % s.nZeta;
@@ -2186,6 +2188,17 @@ vmecpp::CovariantBDerivatives vmecpp::LowPassFilterCovariantB(
   if (s.lasym) {
     bsubu_filtered_a.resize(m_vmec_internal_results.num_half * s.nZnT);
     bsubv_filtered_a.resize(m_vmec_internal_results.num_half * s.nZnT);
+  }
+
+  // d(B_v)/d(theta) and d(B_u)/d(zeta), accumulated per parity in the reduced
+  // (nThetaReduced) poloidal layout and extended to the full range below.
+  std::vector<double> bsubvu_s(m_vmec_internal_results.num_half * s.nZnT, 0.0);
+  std::vector<double> bsubuv_s(m_vmec_internal_results.num_half * s.nZnT, 0.0);
+  std::vector<double> bsubvu_a;
+  std::vector<double> bsubuv_a;
+  if (s.lasym) {
+    bsubvu_a.resize(m_vmec_internal_results.num_half * s.nZnT);
+    bsubuv_a.resize(m_vmec_internal_results.num_half * s.nZnT);
   }
 
   // FOURIER LOW-PASS FILTER bsubs
@@ -2365,13 +2378,11 @@ vmecpp::CovariantBDerivatives vmecpp::LowPassFilterCovariantB(
 
             const double tsinm1 = t.sinmum[idx_ml] * t.cosnv[idx_kn];
             const double tsinm2 = t.cosmum[idx_ml] * t.sinnv[idx_kn];
-            covariant_b_derivatives.bsubvu(target_index) +=
-                tsinm1 * bsubvmn1 + tsinm2 * bsubvmn2;
+            bsubvu_s[target_index] += tsinm1 * bsubvmn1 + tsinm2 * bsubvmn2;
 
             const double tsinn1 = t.cosmu[idx_ml] * t.sinnvn[idx_kn];
             const double tsinn2 = t.sinmu[idx_ml] * t.cosnvn[idx_kn];
-            covariant_b_derivatives.bsubuv(target_index) +=
-                tsinn1 * bsubumn1 + tsinn2 * bsubumn2;
+            bsubuv_s[target_index] += tsinn1 * bsubumn1 + tsinn2 * bsubumn2;
 
             if (s.lasym) {
               const double tsin1 = t.sinmu[idx_ml] * t.cosnv[idx_kn];
@@ -2383,13 +2394,11 @@ vmecpp::CovariantBDerivatives vmecpp::LowPassFilterCovariantB(
 
               const double tcosm1 = t.cosmum[idx_ml] * t.cosnv[idx_kn];
               const double tcosm2 = t.sinmum[idx_ml] * t.sinnv[idx_kn];
-              covariant_b_derivatives.bsubvu(target_index) +=
-                  tcosm1 * bsubvmn3 + tcosm2 * bsubvmn4;
+              bsubvu_a[target_index] += tcosm1 * bsubvmn3 + tcosm2 * bsubvmn4;
 
               const double tcosn1 = t.sinmu[idx_ml] * t.sinnvn[idx_kn];
               const double tcosn2 = t.cosmu[idx_ml] * t.cosnvn[idx_kn];
-              covariant_b_derivatives.bsubuv(target_index) +=
-                  tcosn1 * bsubumn3 + tcosn2 * bsubumn4;
+              bsubuv_a[target_index] += tcosn1 * bsubumn3 + tcosn2 * bsubumn4;
             }  // lasym
           }  // l
         }  // k
@@ -2439,6 +2448,50 @@ vmecpp::CovariantBDerivatives vmecpp::LowPassFilterCovariantB(
         const int idx_kl = jH * s.nZnT + kl;
         m_vmec_internal_results.bsubu(idx_kl) = bsubu_filtered_s[idx_kl];
         m_vmec_internal_results.bsubv(idx_kl) = bsubv_filtered_s[idx_kl];
+      }  // kl
+    }  // jH
+  }
+
+  // EXTEND bsubvu, bsubuv TO NTHETA3 MESH
+  // The stellarator-symmetric parts of d(B_v)/d(theta) and d(B_u)/d(zeta) are
+  // odd under (theta, zeta) -> (-theta, -zeta), the non-symmetric parts are
+  // even, so the reflected half carries -s + a.
+  if (s.lasym) {
+    const int nZnT_reduced = m_vmec_internal_results.nZnT_reduced;
+    for (int jH = 0; jH < m_vmec_internal_results.num_half; ++jH) {
+      for (int k = 0; k < s.nZeta; ++k) {
+        const int k_reversed = (s.nZeta - k) % s.nZeta;
+        for (int l = 0; l < s.nThetaReduced; ++l) {
+          const int source_index =
+              jH * nZnT_reduced + (k * s.nThetaReduced + l);
+          const int target_index = jH * s.nZnT + (k * s.nThetaEff + l);
+
+          covariant_b_derivatives.bsubvu(target_index) =
+              bsubvu_s[source_index] + bsubvu_a[source_index];
+          covariant_b_derivatives.bsubuv(target_index) =
+              bsubuv_s[source_index] + bsubuv_a[source_index];
+        }  // l
+        for (int l = s.nThetaReduced; l < s.nThetaEven; ++l) {
+          const int l_reversed = (s.nThetaEven - l) % s.nThetaEven;
+          const int source_index_reversed =
+              jH * nZnT_reduced + (k_reversed * s.nThetaReduced + l_reversed);
+          const int target_index = jH * s.nZnT + (k * s.nThetaEff + l);
+
+          covariant_b_derivatives.bsubvu(target_index) =
+              -bsubvu_s[source_index_reversed] +
+              bsubvu_a[source_index_reversed];
+          covariant_b_derivatives.bsubuv(target_index) =
+              -bsubuv_s[source_index_reversed] +
+              bsubuv_a[source_index_reversed];
+        }  // l
+      }  // k
+    }  // jH
+  } else {
+    for (int jH = 0; jH < m_vmec_internal_results.num_half; ++jH) {
+      for (int kl = 0; kl < s.nZnT; ++kl) {
+        const int idx_kl = jH * s.nZnT + kl;
+        covariant_b_derivatives.bsubvu(idx_kl) = bsubvu_s[idx_kl];
+        covariant_b_derivatives.bsubuv(idx_kl) = bsubuv_s[idx_kl];
       }  // kl
     }  // jH
   }
@@ -3927,8 +3980,10 @@ vmecpp::ComputeThreed1GeometricMagneticQuantities(
     const double r_outboard = vmec_internal_results.r_e(index_outboard) +
                               vmec_internal_results.r_o(index_outboard);
 
+    // theta = pi sits at l = nThetaReduced - 1 in both poloidal layouts; the
+    // within-surface stride is nThetaEff, as for the outboard point above.
     const int index_inboard =
-        ((fc.ns - 1) * s.nZeta + k) * s.nThetaReduced + (s.nThetaReduced - 1);
+        ((fc.ns - 1) * s.nZeta + k) * s.nThetaEff + (s.nThetaReduced - 1);
     const double r_inboard = vmec_internal_results.r_e(index_inboard) +
                              vmec_internal_results.r_o(index_inboard);
 

--- a/tests/test_lasym.py
+++ b/tests/test_lasym.py
@@ -89,6 +89,60 @@ def test_lasym_reduces_to_symmetric_3d():
     _assert_same_physics(sym, asym, vol_rtol=1e-9, beta_atol=1e-9, iota_atol=1e-8)
 
 
+def _numeric_fields(model, prefix=""):
+    """Every numeric field of an output model, recursing into nested models."""
+    fields = {}
+    for name in type(model).model_fields:
+        if name == "input":
+            continue
+        value = getattr(model, name)
+        if hasattr(type(value), "model_fields"):
+            fields.update(_numeric_fields(value, prefix + name + "."))
+        elif isinstance(value, (bool, str)):
+            continue
+        elif isinstance(value, (int, float, np.ndarray)):
+            fields[prefix + name] = np.asarray(value, dtype=float)
+    return fields
+
+
+def test_lasym_reduces_to_symmetric_3d_all_outputs():
+    """3D: every jxbout, Mercier, threed1 and wout quantity of the lasym run
+    reproduces the symmetric run on the shared poloidal range."""
+    base = vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cth_like_fixed_bdy.json")
+    sym = vmecpp.run(base, max_threads=1, verbose=False)
+    asym = vmecpp.run(_enable_lasym(base), max_threads=1, verbose=False)
+
+    nzeta = base.nzeta
+    # theta is the fastest index within a surface; the symmetric run stores the
+    # reduced poloidal range, the lasym run the full one
+    n_theta_reduced = sym.jxbout.itheta.shape[1] // nzeta
+    n_theta_full = asym.jxbout.itheta.shape[1] // nzeta
+    assert n_theta_full == 2 * (n_theta_reduced - 1)
+
+    sym_fields = _numeric_fields(sym)
+    asym_fields = _numeric_fields(asym)
+    for name, expected in sym_fields.items():
+        if expected.size == 0:
+            continue
+        actual = asym_fields[name]
+        reference = expected
+        if actual.shape != reference.shape:
+            assert actual.shape[:-1] == reference.shape[:-1], name
+            if reference.shape[-1] == n_theta_reduced:
+                actual = actual[..., :n_theta_reduced]
+            else:
+                assert reference.shape[-1] == nzeta * n_theta_reduced, name
+                actual = actual.reshape((*actual.shape[:-1], nzeta, n_theta_full))
+                actual = actual[..., :n_theta_reduced]
+                reference = reference.reshape(
+                    (*reference.shape[:-1], nzeta, n_theta_reduced)
+                )
+        scale = max(np.max(np.abs(reference)), 1e-300)
+        np.testing.assert_allclose(
+            actual, reference, rtol=1e-8, atol=1e-8 * scale, err_msg=name
+        )
+
+
 def test_z_shift_preserves_physics():
     """A rigid z-shift needs the asymmetric zbc[0,0] but leaves the physics
     unchanged."""


### PR DESCRIPTION
`DecomposeCovariantBBySymmetry` read `bsubs_full` at `jF * nZnT + kl` with `kl` in the reduced (`nThetaReduced`) poloidal layout, while `bsubs_full` is stored with the full (`nThetaEff`) stride; the `bsubu`/`bsubv` loop right below it already used `k * nThetaEven + l`. For `nZeta = 1` the two offsets coincide, so the up-down asymmetric tokamak cases never showed it. For `nZeta > 1` the sine and cosine parts of `B_s` were built from the wrong grid points, and everything downstream of `bsubsu`/`bsubsv` followed: `itheta`, `izeta`, `bdotk`, the jxbout currents and the Mercier terms.

The theta derivative of `B_v` and the zeta derivative of `B_u` were accumulated with the reduced stride straight into the full-layout `bsubvu`/`bsubuv` matrices and never extended to the second poloidal half. They now go through the same parity split and extension as `bsubsu`/`bsubsv`; the stellarator-symmetric parts are odd under the reflection, the non-symmetric parts even.

The waist used the reduced stride for the inboard point and the full stride for the outboard one.

Measured on `input.cth_like_fixed_bdy` (nfp = 5, ntor = 4, nzeta = 36), run once with `lasym = false` and once with `lasym = true`, comparing every dataset of the two `OutputQuantities` HDF5 files on the shared poloidal range, as max abs difference over the max abs of the symmetric run:

| quantity | before | after |
|---|---|---|
| `covariant_b_derivatives/bsubsu` | 1.2 | < 1e-9 |
| `covariant_b_derivatives/bsubsv` | 1.4 | < 1e-9 |
| `covariant_b_derivatives/bsubuv`, `bsubvu` | 1.5 | < 1e-9 |
| `jxbout/itheta` | 6.3 | < 1e-9 |
| `jxbout/bdotk` | 2.8 | < 1e-9 |
| `jxbout/jsups3` | 1.3 | < 1e-9 |
| `mercier/Dgeod`, `wout/DGeod` | 67 | < 1e-9 |
| `wout/DMerc` | 67 | < 1e-9 |
| `threed1_geometric_and_magnetic_quantities/waist` | 0.57 | < 1e-9 |

After the change the only datasets that still differ between the two runs are the per-point `surf_area` and `tau` intermediates, by the factor 0.5 that the integration weight of the reduced range carries. `input.cth_like_free_bdy` in both modes agrees to 2.4e-4 in `jsups3` and 1.2e-4 in the force residuals, which is the level set by the coil-group asymmetry of `mgrid_cth_like.nc`.

educational_VMEC gives identical output for the two modes of the fixed-boundary case, every wout quantity to 1e-10, so the corrected values are the ones the Fortran reference produces.

`tests/test_lasym.py` gains `test_lasym_reduces_to_symmetric_3d_all_outputs`, which runs `cth_like_fixed_bdy` in both symmetry modes and compares every numeric field of the wout, jxbout, Mercier and threed1 outputs on the shared poloidal range to 1e-8. On `main` it fails with 92% of the jxbout entries mismatched; with this change it passes.

`bazel test //vmecpp/vmec/output_quantities:output_quantities_test`, `tests/test_init.py` and `tests/cpp/vmecpp/vmec/pybind11/test_pybind_vmec.py` pass.
