### PR TITLE
Carry the sign of the Jacobian in chi

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -3520,8 +3520,11 @@ vmecpp::ComputeIntermediateThreed1FirstTableQuantities(
         (vmec_internal_results.phipH[jHi] * vmec_internal_results.iotaH[jHi]) *
             fc.deltaS;
 
+    // phi, phipf and chipf carry the sign of the Jacobian, so chi does too;
+    // iota = d(chi)/d(phi) then holds between the wout profiles.
     threed1_first_table_intermediate.chi[jF] =
-        2.0 * M_PI * threed1_first_table_intermediate.chi1[jF];
+        2.0 * M_PI * vmec_internal_results.sign_of_jacobian *
+        threed1_first_table_intermediate.chi1[jF];
   }  // jF
 
   // calc_fbal

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities_test.cc
@@ -277,8 +277,10 @@ TEST_P(WOutFileContentsTest, CheckWOutFileContents) {
         IsCloseRelAbs(reference_pressure_full[jF], wout.presf[jF], tolerance));
     EXPECT_TRUE(
         IsCloseRelAbs(reference_toroidal_flux[jF], wout.phi[jF], tolerance));
+    // The Fortran reference writes chi without the sign of the Jacobian; see
+    // ComputeThreed1FirstTableIntermediate.
     EXPECT_TRUE(
-        IsCloseRelAbs(reference_poloidal_flux[jF], wout.chi[jF], tolerance));
+        IsCloseRelAbs(-reference_poloidal_flux[jF], wout.chi[jF], tolerance));
     EXPECT_TRUE(IsCloseRelAbs(reference_phipf[jF], wout.phipf[jF], tolerance));
     if (jF > 0 && jF < fc.ns - 1) {
       // The axis and the boundary entries of chipf follow PARVMEC rather than

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
@@ -830,7 +830,9 @@ TEST_P(Threed1FirstTableTest, CheckThreed1FirstTable) {
     EXPECT_TRUE(IsCloseRelAbs(threed1_firstTable["chi1"][jF],
                               threed1_first_table_intermediate.chi1[jF],
                               tolerance));
-    EXPECT_TRUE(IsCloseRelAbs(threed1_firstTable["chi"][jF],
+    // The Fortran reference writes chi without the sign of the Jacobian; see
+    // ComputeThreed1FirstTableIntermediate.
+    EXPECT_TRUE(IsCloseRelAbs(-threed1_firstTable["chi"][jF].get<double>(),
                               threed1_first_table_intermediate.chi[jF],
                               tolerance));
 

--- a/tests/cpp/vmecpp/vmec/pybind11/test_pybind_vmec.py
+++ b/tests/cpp/vmecpp/vmec/pybind11/test_pybind_vmec.py
@@ -326,7 +326,8 @@ def test_output_quantities():
     assert is_close_ra(output_quantities.wout.presf, wout["presf"][()], 1.0e-8)
     assert is_close_ra(output_quantities.wout.phi, wout["phi"][()], 1.0e-8)
     assert is_close_ra(output_quantities.wout.phipf, wout["phipf"][()], 1.0e-8)
-    assert is_close_ra(output_quantities.wout.chi, wout["chi"][()], 1.0e-8)
+    # The Fortran reference writes chi without the sign of the Jacobian.
+    assert is_close_ra(output_quantities.wout.chi, -wout["chi"][()], 1.0e-8)
     # The axis and the boundary entries of chipf follow PARVMEC rather than the
     # 8.52 lineage the references come from; see computeBContra.
     assert is_close_ra(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -267,6 +267,9 @@ def test_vmecwout_io(cma_output: vmecpp.VmecOutput):
         rtol = 1e-3 if varname in ("currumnc", "currvmnc") else 1e-6
         actual = np.asarray(test_value[:])
         desired = np.asarray(expected_value[:])
+        if varname == "chi":
+            # The Fortran reference writes chi without the sign of the Jacobian.
+            desired = -desired
         if varname == "chipf":
             # The axis and the boundary entries of chipf follow PARVMEC
             # rather than the 8.52 lineage the references come from; see
@@ -356,6 +359,9 @@ def test_against_reference_wout(indata_file, reference_wout_file, path_type):
         # nan is a valid value for some fields (e.g. extcur) and can't be compared otherwise.
         actual = np.asarray(test_value[:])
         desired = np.asarray(expected_value[:])
+        if varname == "chi":
+            # The Fortran reference writes chi without the sign of the Jacobian.
+            desired = -desired
         if varname == "chipf":
             # The axis and the boundary entries of chipf follow PARVMEC
             # rather than the 8.52 lineage the references come from; see


### PR DESCRIPTION
**Change** - `chi` carries the sign of the Jacobian: `ComputeIntermediateThreed1FirstTableQuantities` forms it as `2 pi * sign_of_jacobian * chi1`, and `wout.chi` follows.

**Cause** - `chi` was accumulated as `2 pi * chi1` with `chi1 = sum(phipH * iotaH) * deltaS`, while `phi`, `phipf` and `chipf` all carry `sign_of_jacobian`. With the usual negative Jacobian the wout therefore held `chi` = minus the integral of iota over phi. Fortran VMEC has the same omission (`eqfor.f`, `chi = twopi*chi1`) and PARVMEC 10.0 reproduces it, so the reference wout files hold the negated profile.

**Evidence** - on `cth_like_fixed_bdy`, `phi(ns)` is -0.035, the integral of `chipf` over s is -0.040, and `chi(ns)` was +0.040. `iota = dchi/dphi` read back from the file had the sign opposite to `iotaf`, and the threed1 `psi`, which does carry the sign, disagreed with `chi`.

**Tests** - the five comparisons against the reference files negate the reference for `chi`, with a note at each: `CheckWOutFileContents` in `output_quantities_test`, `CheckThreed1FirstTable` in the large `output_quantities_test`, `test_output_quantities` in `test_pybind_vmec.py`, and `test_vmecwout_io` and `test_against_reference_wout` in `tests/test_init.py`.

**Scope** - nothing else reads `chi1`, and the force balance never reads `chi`, so the converged equilibrium is unchanged.
