### PR TITLE
Extrapolate chipF onto the axis like iotaF

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -1790,6 +1790,12 @@ void IdealMhdModel::computeBContra() {
   }
 
   // update full-grid chi'
+  if (r_.nsMinF1 == 0) {
+    // The axis value is extrapolated the same way as iotaF below. Fortran VMEC
+    // (add_fluxes.f90) leaves chipf(1) unset, so the reference carries a zero
+    // there; PARVMEC added this rule in 2016.
+    m_p_.chipF[0] = 1.5 * m_p_.chipH[0] - 0.5 * m_p_.chipH[1];
+  }
   for (int jFi = r_.nsMinFi; jFi < r_.nsMaxFi; ++jFi) {
     m_p_.chipF[jFi - r_.nsMinF1] =
         0.5 * (m_p_.chipH[jFi - r_.nsMinH] + m_p_.chipH[jFi - 1 - r_.nsMinH]);

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -1791,9 +1791,7 @@ void IdealMhdModel::computeBContra() {
 
   // update full-grid chi'
   if (r_.nsMinF1 == 0) {
-    // The axis value is extrapolated the same way as iotaF below. Fortran VMEC
-    // (add_fluxes.f90) leaves chipf(1) unset, so the reference carries a zero
-    // there; PARVMEC added this rule in 2016.
+    // The axis value is extrapolated the same way as iotaF below.
     m_p_.chipF[0] = 1.5 * m_p_.chipH[0] - 0.5 * m_p_.chipH[1];
   }
   for (int jFi = r_.nsMinFi; jFi < r_.nsMaxFi; ++jFi) {

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities_test.cc
@@ -262,7 +262,12 @@ TEST_P(WOutFileContentsTest, CheckWOutFileContents) {
     EXPECT_TRUE(
         IsCloseRelAbs(reference_poloidal_flux[jF], wout.chi[jF], tolerance));
     EXPECT_TRUE(IsCloseRelAbs(reference_phipf[jF], wout.phipf[jF], tolerance));
-    EXPECT_TRUE(IsCloseRelAbs(reference_chipf[jF], wout.chipf[jF], tolerance));
+    if (jF > 0) {
+      // The axis chipf is extrapolated like iotaf and deviates from the
+      // Fortran reference, which leaves it at zero; see computeBContra.
+      EXPECT_TRUE(
+          IsCloseRelAbs(reference_chipf[jF], wout.chipf[jF], tolerance));
+    }
     EXPECT_TRUE(IsCloseRelAbs(reference_jcuru[jF], wout.jcuru[jF], tolerance));
     EXPECT_TRUE(IsCloseRelAbs(reference_jcurv[jF], wout.jcurv[jF], tolerance));
     EXPECT_TRUE(

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities_test.cc
@@ -263,8 +263,8 @@ TEST_P(WOutFileContentsTest, CheckWOutFileContents) {
         IsCloseRelAbs(reference_poloidal_flux[jF], wout.chi[jF], tolerance));
     EXPECT_TRUE(IsCloseRelAbs(reference_phipf[jF], wout.phipf[jF], tolerance));
     if (jF > 0) {
-      // The axis chipf is extrapolated like iotaf and deviates from the
-      // Fortran reference, which leaves it at zero; see computeBContra.
+      // The Fortran reference leaves the axis chipf at zero; see
+      // computeBContra.
       EXPECT_TRUE(
           IsCloseRelAbs(reference_chipf[jF], wout.chipf[jF], tolerance));
     }

--- a/tests/cpp/vmecpp/vmec/pybind11/test_pybind_vmec.py
+++ b/tests/cpp/vmecpp/vmec/pybind11/test_pybind_vmec.py
@@ -321,9 +321,7 @@ def test_output_quantities():
     assert is_close_ra(output_quantities.wout.chi, wout["chi"][()], 1.0e-8)
     # The axis chipf is extrapolated like iotaf and deviates from the Fortran
     # reference, which leaves it at zero; see computeBContra.
-    assert is_close_ra(
-        output_quantities.wout.chipf[1:], wout["chipf"][()][1:], 1.0e-8
-    )
+    assert is_close_ra(output_quantities.wout.chipf[1:], wout["chipf"][()][1:], 1.0e-8)
     assert is_close_ra(output_quantities.wout.jcuru, wout["jcuru"][()], 1.0e-6)
     assert is_close_ra(output_quantities.wout.jcurv, wout["jcurv"][()], 1.0e-6)
 

--- a/tests/cpp/vmecpp/vmec/pybind11/test_pybind_vmec.py
+++ b/tests/cpp/vmecpp/vmec/pybind11/test_pybind_vmec.py
@@ -319,8 +319,7 @@ def test_output_quantities():
     assert is_close_ra(output_quantities.wout.phi, wout["phi"][()], 1.0e-8)
     assert is_close_ra(output_quantities.wout.phipf, wout["phipf"][()], 1.0e-8)
     assert is_close_ra(output_quantities.wout.chi, wout["chi"][()], 1.0e-8)
-    # The axis chipf is extrapolated like iotaf and deviates from the Fortran
-    # reference, which leaves it at zero; see computeBContra.
+    # The Fortran reference leaves the axis chipf at zero; see computeBContra.
     assert is_close_ra(output_quantities.wout.chipf[1:], wout["chipf"][()][1:], 1.0e-8)
     assert is_close_ra(output_quantities.wout.jcuru, wout["jcuru"][()], 1.0e-6)
     assert is_close_ra(output_quantities.wout.jcurv, wout["jcurv"][()], 1.0e-6)

--- a/tests/cpp/vmecpp/vmec/pybind11/test_pybind_vmec.py
+++ b/tests/cpp/vmecpp/vmec/pybind11/test_pybind_vmec.py
@@ -319,7 +319,11 @@ def test_output_quantities():
     assert is_close_ra(output_quantities.wout.phi, wout["phi"][()], 1.0e-8)
     assert is_close_ra(output_quantities.wout.phipf, wout["phipf"][()], 1.0e-8)
     assert is_close_ra(output_quantities.wout.chi, wout["chi"][()], 1.0e-8)
-    assert is_close_ra(output_quantities.wout.chipf, wout["chipf"][()], 1.0e-8)
+    # The axis chipf is extrapolated like iotaf and deviates from the Fortran
+    # reference, which leaves it at zero; see computeBContra.
+    assert is_close_ra(
+        output_quantities.wout.chipf[1:], wout["chipf"][()][1:], 1.0e-8
+    )
     assert is_close_ra(output_quantities.wout.jcuru, wout["jcuru"][()], 1.0e-6)
     assert is_close_ra(output_quantities.wout.jcurv, wout["jcurv"][()], 1.0e-6)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -268,8 +268,7 @@ def test_vmecwout_io(cma_output: vmecpp.VmecOutput):
         actual = np.asarray(test_value[:])
         desired = np.asarray(expected_value[:])
         if varname == "chipf":
-            # The axis chipf is extrapolated like iotaf and deviates from the
-            # Fortran reference, which leaves it at zero; see computeBContra.
+            # The Fortran reference leaves the axis chipf at zero; see computeBContra.
             actual = actual[..., 1:]
             desired = desired[..., 1:]
         np.testing.assert_allclose(
@@ -356,8 +355,7 @@ def test_against_reference_wout(indata_file, reference_wout_file, path_type):
         actual = np.asarray(test_value[:])
         desired = np.asarray(expected_value[:])
         if varname == "chipf":
-            # The axis chipf is extrapolated like iotaf and deviates from the
-            # Fortran reference, which leaves it at zero; see computeBContra.
+            # The Fortran reference leaves the axis chipf at zero; see computeBContra.
             actual = actual[..., 1:]
             desired = desired[..., 1:]
         np.testing.assert_allclose(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -265,9 +265,16 @@ def test_vmecwout_io(cma_output: vmecpp.VmecOutput):
         # covariant B field Fourier coefficients, which amplifies floating-point
         # non-determinism (e.g., from OpenMP reduction order).
         rtol = 1e-3 if varname in ("currumnc", "currvmnc") else 1e-6
+        actual = np.asarray(test_value[:])
+        desired = np.asarray(expected_value[:])
+        if varname == "chipf":
+            # The axis chipf is extrapolated like iotaf and deviates from the
+            # Fortran reference, which leaves it at zero; see computeBContra.
+            actual = actual[..., 1:]
+            desired = desired[..., 1:]
         np.testing.assert_allclose(
-            np.asarray(test_value[:]),
-            np.asarray(expected_value[:]),
+            actual,
+            desired,
             err_msg=error_msg,
             rtol=rtol,
             atol=1e-7,
@@ -346,9 +353,16 @@ def test_against_reference_wout(indata_file, reference_wout_file, path_type):
 
         # np.asarray is needed to convert the masked array to a regular array.
         # nan is a valid value for some fields (e.g. extcur) and can't be compared otherwise.
+        actual = np.asarray(test_value[:])
+        desired = np.asarray(expected_value[:])
+        if varname == "chipf":
+            # The axis chipf is extrapolated like iotaf and deviates from the
+            # Fortran reference, which leaves it at zero; see computeBContra.
+            actual = actual[..., 1:]
+            desired = desired[..., 1:]
         np.testing.assert_allclose(
-            np.asarray(test_value[:]),
-            np.asarray(expected_value[:]),
+            actual,
+            desired,
             err_msg=error_msg,
             rtol=rtol,
             atol=atol,


### PR DESCRIPTION
`computeBContra` filled `chipF` on the interior full-grid points and, when the boundary is in range, at the edge, but never at the axis, so `wout.chipf[0]` stayed at its zero initialisation while `iotaf[0]` and `phipf[0]` are extrapolated there. `chipf/phipf` equals `iotaf` on every other surface and is 0 at the axis; `q = phipf/chipf` is infinite there, and any radial interpolation through `chipf` dips to zero at `s = 0`.

The axis now gets the rule `iotaF` uses, `1.5 * chipH[0] - 0.5 * chipH[1]`. This is the rule PARVMEC added to `add_fluxes.f90` in 2016 (`chipf(1) = c1p5*chips(2) - p5*chips(3)`, "SPH ADDED THIS 4-8-16"); the 8.52 lineage behind the reference files never received it, so the references carry a zero there and the comparisons skip the axis entry of `chipf`, with a note at each. The `ideal_mhd_model` test compares `chipF` from `nsMinFi` on and is unaffected. #736 handles the boundary entry of the same profile; the two changes are independent.

`bazel test //vmecpp/vmec/output_quantities:output_quantities_test`, `tests/test_init.py` and `tests/cpp/vmecpp/vmec/pybind11/test_pybind_vmec.py` pass.
