### PR TITLE
Take the extremum of |Z| for zmax_surf

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -3883,7 +3883,10 @@ vmecpp::ComputeThreed1GeometricMagneticQuantities(
         vmec_internal_results.z_e(lcfs_kl) + vmec_internal_results.z_o(lcfs_kl);
     result.rmax_surf = std::max(result.rmax_surf, r);
     result.rmin_surf = std::min(result.rmin_surf, r);
-    result.zmax_surf = std::max(result.zmax_surf, z);
+    // Only the reduced poloidal range is stored for a stellarator-symmetric
+    // run, so the extremum of Z over the whole boundary is that of |Z| over
+    // the stored half; Fortran VMEC (eqfor.f90) takes MAXVAL(ABS(z1)) as well.
+    result.zmax_surf = std::max(result.zmax_surf, std::abs(z));
   }  // kl
 
   result.bmin = RowMatrixXd::Ones(fc.ns - 1, s.nThetaReduced) * DBL_MAX;

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -3883,9 +3883,6 @@ vmecpp::ComputeThreed1GeometricMagneticQuantities(
         vmec_internal_results.z_e(lcfs_kl) + vmec_internal_results.z_o(lcfs_kl);
     result.rmax_surf = std::max(result.rmax_surf, r);
     result.rmin_surf = std::min(result.rmin_surf, r);
-    // Only the reduced poloidal range is stored for a stellarator-symmetric
-    // run, so the extremum of Z over the whole boundary is that of |Z| over
-    // the stored half; Fortran VMEC (eqfor.f90) takes MAXVAL(ABS(z1)) as well.
     result.zmax_surf = std::max(result.zmax_surf, std::abs(z));
   }  // kl
 


### PR DESCRIPTION
`zmax_surf` was the maximum of `Z` over the stored boundary points. For a stellarator-symmetric run only the poloidal range `[0, pi]` is stored, so the result depends on where the poloidal origin sits. The `cth_like_fixed_bdy` boundary with theta reversed (`RBC(n,m) -> RBC(-n,m)`, `ZBS(n,m) -> -ZBS(-n,m)`, which VMEC maps back onto itself with a half-turn of the poloidal origin) gave `zmax_surf = 0.0807` instead of `0.2163`, while every other wout quantity matched the original run up to the `(-1)^m` sign pattern. Fortran VMEC takes `MAXVAL(ABS(z1))` (eqfor.f90:389) and returns `0.2163` for both orientations; this does the same.

`bazel test //vmecpp/vmec/output_quantities:output_quantities_test`, `tests/test_init.py` and `tests/cpp/vmecpp/vmec/pybind11/test_pybind_vmec.py` pass.
