### PR TITLE
Take bmin and bmax over every stored poloidal point

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -1964,10 +1964,10 @@ class Threed1GeometricAndMagneticQuantities(BaseModelWithNumpy):
     zmax_surf: float
     """Maximum height on the boundary."""
 
-    bmin: jt.Float[np.ndarray, "num_half nThetaReduced"]
+    bmin: jt.Float[np.ndarray, "num_half nThetaEff"]
     """Minimum `|B|` per half-grid surface and poloidal angle."""
 
-    bmax: jt.Float[np.ndarray, "num_half nThetaReduced"]
+    bmax: jt.Float[np.ndarray, "num_half nThetaEff"]
     """Maximum `|B|` per half-grid surface and poloidal angle."""
 
     waist: jt.Float[np.ndarray, "n_symmetry_planes"]

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -3886,26 +3886,26 @@ vmecpp::ComputeThreed1GeometricMagneticQuantities(
     result.zmax_surf = std::max(result.zmax_surf, std::abs(z));
   }  // kl
 
-  result.bmin = RowMatrixXd::Ones(fc.ns - 1, s.nThetaReduced) * DBL_MAX;
-  result.bmax = RowMatrixXd::Zero(fc.ns - 1, s.nThetaReduced);
+  // One column per stored poloidal point: the reduced range for a
+  // stellarator-symmetric run, the full range for lasym.
+  result.bmin = RowMatrixXd::Ones(fc.ns - 1, s.nThetaEff) * DBL_MAX;
+  result.bmax = RowMatrixXd::Zero(fc.ns - 1, s.nThetaEff);
 
   for (int jH = 0; jH < fc.ns - 1; ++jH) {
     for (int k = 0; k < s.nZeta; ++k) {
-      for (int l = 0; l < s.nThetaReduced; ++l) {
-        // total_pressure is stored with the full nThetaEff within-surface
-        // stride; bmax/bmin only need the reduced poloidal range.
+      for (int l = 0; l < s.nThetaEff; ++l) {
         const int kl = k * s.nThetaEff + l;
         const int index_half = jH * s.nZnT + kl;
 
         const double mod_b =
             std::sqrt(2.0 * (vmec_internal_results.total_pressure(index_half) -
                              vmec_internal_results.presH[jH]));
-        result.bmax(jH * s.nThetaReduced + l) =
-            std::max(result.bmax(jH * s.nThetaReduced + l), mod_b);
-        result.bmin(jH * s.nThetaReduced + l) =
-            std::min(result.bmin(jH * s.nThetaReduced + l), mod_b);
-      }  // k
-    }  // l
+        result.bmax(jH * s.nThetaEff + l) =
+            std::max(result.bmax(jH * s.nThetaEff + l), mod_b);
+        result.bmin(jH * s.nThetaEff + l) =
+            std::min(result.bmin(jH * s.nThetaEff + l), mod_b);
+      }  // l
+    }  // k
   }  // jH
 
   // Compute Waist thickness and height in \f$\varphi = 0, \pi\f$ symmetry

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
@@ -1016,18 +1016,18 @@ TEST_P(Threed1GeometricMagneticQuantitiesTest,
       IsCloseRelAbs(threed1_geomag["zmax_surf"], result.zmax_surf, tolerance));
 
   EXPECT_TRUE(IsCloseRelAbs(threed1_geomag["bmin_1_ns"],
-                            result.bmin((fc.ns - 2) * s.nThetaReduced + 0),
+                            result.bmin((fc.ns - 2) * s.nThetaEff + 0),
                             tolerance));
   EXPECT_TRUE(IsCloseRelAbs(threed1_geomag["bmax_1_ns"],
-                            result.bmax((fc.ns - 2) * s.nThetaReduced + 0),
+                            result.bmax((fc.ns - 2) * s.nThetaEff + 0),
                             tolerance));
   EXPECT_TRUE(IsCloseRelAbs(
       threed1_geomag["bmin_ntheta2_ns"],
-      result.bmin((fc.ns - 2) * s.nThetaReduced + (s.nThetaReduced - 1)),
+      result.bmin((fc.ns - 2) * s.nThetaEff + (s.nThetaReduced - 1)),
       tolerance));
   EXPECT_TRUE(IsCloseRelAbs(
       threed1_geomag["bmax_ntheta2_ns"],
-      result.bmax((fc.ns - 2) * s.nThetaReduced + (s.nThetaReduced - 1)),
+      result.bmax((fc.ns - 2) * s.nThetaEff + (s.nThetaReduced - 1)),
       tolerance));
 
   EXPECT_TRUE(


### PR DESCRIPTION
Fixes #776.

`bmin` and `bmax` were sized `(ns - 1, nThetaReduced)` and filled from the first `nThetaReduced` poloidal points of every surface. A lasym run stores `nThetaEff = nThetaEven` points whose second half is not the mirror of the first, so the extrema along the points in `[pi, 2 pi)` were never examined. The arrays now have one column per stored poloidal point, `nThetaEff`, which is unchanged for a stellarator-symmetric run.

Checked on `cth_like_fixed_bdy` run in both symmetry modes: the lasym columns that coincide with the symmetric run's columns agree bit for bit, and the added columns hold the extrema over the reflected half. On `cth_like_fixed_bdy_asym` the boundary `bmax` rises from 0.73987 over the first half to 0.78388 over the full surface, the value the wout `bmnc`, `bmns` give on the full grid.

The large-suite indexing of `bmin`, `bmax` uses the new row stride; the reference cases are symmetric, so their values are unchanged.
