### PR TITLE
Scan the complete cross-section for the geometry table of a lasym run

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -4028,11 +4028,13 @@ vmecpp::ComputeThreed1GeometricMagneticQuantities(
       // double zxmax = 0.0;
       // double zxmin = 0.0;
 
-      // Only theta in [0, pi] is stored under stellarator symmetry. The
-      // second pass takes the reflected plane 2 pi - zeta with Z -> -Z, which
-      // supplies the missing half of the cross-section, so that the extrema
-      // searched for below are those of the complete closed contour.
-      for (int icount = 0; icount < 2; ++icount) {
+      // Under stellarator symmetry only theta in [0, pi] is stored, and the
+      // second pass takes the reflected plane 2 pi - zeta with Z -> -Z to
+      // supply the other half of the cross-section. A lasym run stores the
+      // complete contour, which is scanned in a single pass.
+      const int num_passes = s.lasym ? 1 : 2;
+      const int num_theta = s.lasym ? s.nThetaEff : s.nThetaReduced;
+      for (int icount = 0; icount < num_passes; ++icount) {
         int k1 = k;
         int t1 = 1;
         if (icount == 1) {
@@ -4041,7 +4043,7 @@ vmecpp::ComputeThreed1GeometricMagneticQuantities(
           t1 = -1;
         }
 
-        for (int l = 0; l < s.nThetaReduced; ++l) {
+        for (int l = 0; l < num_theta; ++l) {
           const int l_off = (jF * s.nZeta + k1) * s.nThetaEff + l;
 
           const double yr1u = vmec_internal_results.r_e(l_off) +


### PR DESCRIPTION
Fixes #777.

The cross-section table (`ygeo`, `yinden`, `yellip`, `ytrian`, `yshift`) scanned `theta` in `[0, pi]` at the plane `zeta` and then the reflected plane `2 pi - zeta` with `Z -> -Z`, which reconstructs the other half of the contour only under stellarator symmetry. A lasym run stores the complete contour, so it is now scanned in a single pass over all `nThetaEff` points at the plane itself; the symmetric run keeps its two passes.

Checked on `cth_like_fixed_bdy` in both symmetry modes: all five columns agree between the two runs to 1e-14. On `cth_like_fixed_bdy_asym` the boundary ellipticity moves from 2.03788 to 2.06080 in the `zeta = 0` plane and from 0.71460 to 0.73748 in the `zeta = pi/nfp` plane; educational_VMEC with the same change (jonathanschilling/educational_VMEC#20) prints the same two values.
