### PR TITLE
Test the Jacobian orientation with a quantity the lasym rotation preserves

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/BUILD.bazel
@@ -55,6 +55,7 @@ cc_test(
         "//vmecpp/test_data:cma",
         "//vmecpp/test_data:cth_like_fixed_bdy",
         "//vmecpp/test_data:solovev",
+        "//vmecpp/test_data:up_down_asym",
     ],
     deps = [
         ":boundaries",

--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/boundaries.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/boundaries.cc
@@ -228,22 +228,31 @@ bool Boundaries::checkSignOfJacobian() {
 
   double rTest = 0.0;
   double zTest = 0.0;
+  double rTestAsym = 0.0;
+  double zTestAsym = 0.0;
   for (int n = 0; n < s_.ntor + 1; ++n) {
     int m = 1;
     int idx_mn = m * (s_.ntor + 1) + n;
     rTest += rbcc[idx_mn];
     zTest += zbsc[idx_mn];
+    if (s_.lasym) {
+      rTestAsym += rbsc[idx_mn];
+      zTestAsym += zbcc[idx_mn];
+    }
   }
 
-  // TODO(jons): potentially more robust version of this
-  // - eval boundary in a given poloidal plane at equal theta intervals, enough
-  // to satisfy Nyquist requirement
-  // - compute signed polygon area
-  // --> handedness of polygon is given by sign of polygon area
+  // An asymmetric boundary has been rotated in the poloidal angle by
+  // parseToInternalArrays, to put it into the representation with
+  // RBS(m=1) = ZBC(m=1). The product rTest*zTest is not invariant under that
+  // rotation, which can leave it at zero for a boundary that does need
+  // flipping. This determinant is the signed area of the m=1 ellipse, so it is
+  // invariant under the rotation and changes sign with the poloidal direction.
+  // It reduces to rTest*zTest for a stellarator-symmetric boundary.
+  const double handedness = rTest * zTest - rTestAsym * zTestAsym;
 
-  // for signOfJacobian == -1, need to flip when rTest*zTest < 0
+  // for signOfJacobian == -1, need to flip when the handedness is negative
   // ---> this is true when the total sign is positive
-  return (rTest * zTest * sign_of_jacobian_ > 0.0);
+  return (handedness * sign_of_jacobian_ > 0.0);
 }
 
 void Boundaries::flipTheta() {

--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/boundaries_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/boundaries_test.cc
@@ -66,4 +66,48 @@ TEST(TestBoundaries, BundledInputsAreNotSpectrallyDense) {
   }
 }
 
+namespace {
+// theta -> pi - theta on an ntor = 0 boundary. The surface is unchanged as a
+// point set and only the poloidal direction reverses, so the orientation check
+// has to notice and flip it back.
+VmecINDATA RelabelledByPiMinusTheta(const VmecINDATA& indata) {
+  VmecINDATA out = indata;
+  const int n0 = out.ntor;  // column of n = 0
+  for (int m = 0; m < out.rbc.rows(); ++m) {
+    const double s = (m % 2 == 0) ? 1.0 : -1.0;
+    out.rbc(m, n0) *= s;
+    out.zbs(m, n0) *= -s;
+    if (out.rbs.has_value()) {
+      (*out.rbs)(m, n0) *= -s;
+    }
+    if (out.zbc.has_value()) {
+      (*out.zbc)(m, n0) *= s;
+    }
+  }
+  return out;
+}
+
+// Whether the orientation check asks for the poloidal angle to be flipped.
+bool AsksForThetaFlip(const VmecINDATA& indata) {
+  const Sizes sizes(indata);
+  const FourierBasisFastPoloidal fourier_basis(&sizes);
+  Boundaries boundaries(&sizes, &fourier_basis,
+                        vmec_algorithm_constants::kSignOfJacobian);
+  return boundaries.setupFromIndata(indata, /*verbose=*/false);
+}
+}  // namespace
+
+TEST(TestBoundaries, RelabelledAsymmetricBoundaryIsFlippedBack) {
+  const VmecINDATA indata =
+      VmecINDATA::FromFile("vmecpp/test_data/up_down_asym_current.json");
+  ASSERT_TRUE(indata.lasym);
+  ASSERT_EQ(indata.ntor, 0);
+
+  // The boundary as given is already traversed the right way round.
+  EXPECT_FALSE(AsksForThetaFlip(indata));
+
+  // Reversing the poloidal direction of the same surface has to be caught.
+  EXPECT_TRUE(AsksForThetaFlip(RelabelledByPiMinusTheta(indata)));
+}
+
 }  // namespace vmecpp


### PR DESCRIPTION
Fixes #788.

The orientation check runs on a boundary that `parseToInternalArrays` has already rotated in the poloidal angle when `lasym` is set, and `rTest * zTest` is not invariant under that rotation. The m=1 determinant is, and it reduces to `rTest * zTest` for a stellarator-symmetric boundary, where `rbsc` and `zbcc` are zero, so that path keeps the criterion it had. This is the leading term of the signed polygon area the TODO next to the check proposes.

The test relabels `up_down_asym_current` by `theta -> pi - theta`, which leaves the surface alone and reverses the poloidal direction, and asks whether `setupFromIndata` reports a flip. Against the previous criterion the relabelled boundary reports `false`, because the rotation leaves `zTest` at `3.7e-17` and the product at zero; with the determinant it reports `true`, and the boundary as given still reports `false`.

`bazel test //vmecpp/vmec/... //vmecpp/common/...` is green.
