### PR TITLE
Write and read variable-length string datasets through character pointers

### DIFF
--- a/src/vmecpp/cpp/util/hdf5_io/BUILD.bazel
+++ b/src/vmecpp/cpp/util/hdf5_io/BUILD.bazel
@@ -11,3 +11,13 @@ cc_library(
         "//third_party/hdf5",
     ],
 )
+
+cc_test(
+    name = "hdf5_io_test",
+    srcs = ["hdf5_io_test.cc"],
+    deps = [
+        ":hdf5_io",
+        "@googletest//:gtest_main",
+    ],
+    size = "small",
+)

--- a/src/vmecpp/cpp/util/hdf5_io/hdf5_io.cc
+++ b/src/vmecpp/cpp/util/hdf5_io/hdf5_io.cc
@@ -32,7 +32,14 @@ void hdf5_io::WriteH5Dataset(const std::vector<std::string>& vs,
   H5::DataSpace dataspace(/*rank=*/1, /*dims=*/&size);
   H5::StrType str_type(H5::PredType::C_S1, H5T_VARIABLE);
   H5::DataSet dataset = file.createDataSet(name, str_type, dataspace);
-  dataset.write(vs.data(), str_type);
+  // A variable-length string dataset is written from an array of pointers to
+  // the characters, not from the std::string objects themselves.
+  std::vector<const char*> pointers;
+  pointers.reserve(vs.size());
+  for (const std::string& s : vs) {
+    pointers.push_back(s.c_str());
+  }
+  dataset.write(pointers.data(), str_type);
 }
 
 void hdf5_io::WriteH5Dataset(const std::string& str, const std::string& name,
@@ -64,9 +71,21 @@ void hdf5_io::ReadH5Dataset(std::vector<std::string>& vs,
   hsize_t size;
   space.getSimpleExtentDims(&size);
 
-  vs.resize(size);
   H5::StrType str_type(H5::PredType::C_S1, H5T_VARIABLE);
-  ds.read(vs.data(), str_type);
+  // HDF5 allocates one buffer per element and hands back the pointers, which
+  // have to be copied into the strings and then released.
+  std::vector<char*> pointers(size, nullptr);
+  ds.read(pointers.data(), str_type);
+
+  vs.resize(size);
+  for (hsize_t i = 0; i < size; ++i) {
+    vs[i] = pointers[i] == nullptr ? std::string() : std::string(pointers[i]);
+  }
+  if (size > 0) {
+    H5::DataSpace space_for_reclaim = ds.getSpace();
+    H5::DataSet::vlenReclaim(str_type, space_for_reclaim,
+                             H5::DSetMemXferPropList::DEFAULT, pointers.data());
+  }
 }
 
 void hdf5_io::ReadH5Dataset(std::string& str, const std::string& dataset,

--- a/src/vmecpp/cpp/util/hdf5_io/hdf5_io_test.cc
+++ b/src/vmecpp/cpp/util/hdf5_io/hdf5_io_test.cc
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+// <info@proximafusion.com>
+//
+// SPDX-License-Identifier: MIT
+#include "util/hdf5_io/hdf5_io.h"
+
+#include <string>
+#include <vector>
+
+#include "H5Cpp.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+TEST(Hdf5Io, StringVectorRoundTrip) {
+  const std::vector<std::string> written = {
+      "circuit_0", "circuit_1",
+      // longer than the small-string buffer, so the characters live on the heap
+      "a coil group name well past the small string optimization threshold"};
+
+  const std::string fname = "test_hdf5_io_string_vector.h5";
+  {
+    H5::H5File file(fname, H5F_ACC_TRUNC);
+    hdf5_io::WriteH5Dataset(written, "names", file);
+  }
+
+  std::vector<std::string> read;
+  {
+    H5::H5File file(fname, H5F_ACC_RDONLY);
+    hdf5_io::ReadH5Dataset(read, "names", file);
+  }
+
+  EXPECT_EQ(read, written);
+}
+
+TEST(Hdf5Io, EmptyStringVectorRoundTrip) {
+  const std::vector<std::string> written;
+
+  const std::string fname = "test_hdf5_io_empty_string_vector.h5";
+  {
+    H5::H5File file(fname, H5F_ACC_TRUNC);
+    hdf5_io::WriteH5Dataset(written, "names", file);
+  }
+
+  std::vector<std::string> read = {"leftover"};
+  {
+    H5::H5File file(fname, H5F_ACC_RDONLY);
+    hdf5_io::ReadH5Dataset(read, "names", file);
+  }
+
+  EXPECT_TRUE(read.empty());
+}
+
+}  // namespace


### PR DESCRIPTION
Fixes #780.

`WriteH5Dataset(const std::vector<std::string>&, ...)` passed `vs.data()` to a dataset of variable-length strings. That is a `const std::string*` where HDF5 expects an array of `char*`, so it read the leading bytes of each `std::string` as a pointer and took its length there. An empty vector dereferences nothing, which is why the only crash seen so far was on a free-boundary run: a fixed-boundary run has no mgrid, so no coil group names, so `curlabel` is empty. It now writes through an array of `c_str()` pointers.

`ReadH5Dataset` had the same defect on the way back, and dropped the buffers HDF5 allocates for each element. It now reads into `char*`, copies the characters into the strings, and reclaims.

The test covers the round trip for a non-empty vector, including a string past the small-string buffer so the characters live on the heap, and for an empty one. It segfaults against the previous write on `main` and passes with this change, in 0.2 s and without a VMEC run. `bazel test //util/... //vmecpp/vmec/output_quantities/...` is green.
