### PR TITLE
Fix the reason strings for wout status codes 0 and 5

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -860,11 +860,11 @@ class VmecWOut(BaseModelWithNumpy):
     @property
     def reason(self) -> str:
         return {
-            0: "no fatal error but convergence was not reached",
+            0: "normal termination: converged, or returned without convergence because return_outputs_even_if_not_converged was set",
             1: "initially bad Jacobian",
             3: "NCURR_NE_1_BLOAT_NE_1",
             4: "Jacobian reset 75 times, the geometry isn't well defined",
-            5: "input parsing error",
+            5: "unrecoverable error: a physical inconsistency in the MHD model, such as a degenerate flux-surface geometry or a free-boundary current mismatch, with no retry strategy",
             8: "NS array must not be all zeroes",
             9: "miscellaneous error, can happen in mgrid_mod",
             10: "vacuum VMEC and ITOR mismatch",


### PR DESCRIPTION
`VmecWOut.reason` described two status codes wrongly.

Code 0: `output_quantities.cc` maps `SUCCESSFUL_TERMINATION` (11) to 0 when writing the wout, as educational_VMEC does, so a converged run reports 0. The string said "no fatal error but convergence was not reached". It now says normal termination, and names the one case in which 0 is not a converged run (`return_outputs_even_if_not_converged`).

Code 5: `VmecStatus::UNRECOVERABLE_ERROR`. The string said "input parsing error", the meaning of 5 in the Fortran code. It now follows the enum's comment.

Seen on a run of 312 QUASR free-boundary cases where every converged wout carried `reason == "no fatal error but convergence was not reached"`.
