### PR TITLE
Report an unreadable makegrid parameters file as a status

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib.cc
+++ b/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib.cc
@@ -269,7 +269,9 @@ absl::StatusOr<MakegridParameters> ImportMakegridParametersFromFile(
     const std::filesystem::path& makegrid_parameters_file) {
   const auto maybe_makegrid_params_json =
       file_io::ReadFile(makegrid_parameters_file);
-  CHECK_OK(maybe_makegrid_params_json);
+  if (!maybe_makegrid_params_json.ok()) {
+    return maybe_makegrid_params_json.status();
+  }
   const auto& makegrid_params_json = *maybe_makegrid_params_json;
   return ImportMakegridParametersFromJson(makegrid_params_json);
 }  // ImportMakegridParametersFromFile

--- a/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib_test.cc
@@ -1255,4 +1255,13 @@ TEST(TestMakegridLib, CheckWriteMakegridNetCDFFileRejectsInconsistentCurrents) {
             absl::StatusCode::kInvalidArgument);
 }  // CheckWriteMakegridNetCDFFileRejectsInconsistentCurrents
 
+// A parameters file that cannot be read is reported through the return value.
+TEST(TestMakegridLib, CheckImportMakegridParametersReportsUnreadableFile) {
+  const absl::StatusOr<MakegridParameters> parameters =
+      ImportMakegridParametersFromFile(
+          "vmecpp/test_data/no_such_makegrid_parameters.json");
+  ASSERT_FALSE(parameters.ok());
+  EXPECT_EQ(parameters.status().code(), absl::StatusCode::kNotFound);
+}  // CheckImportMakegridParametersReportsUnreadableFile
+
 }  // namespace makegrid


### PR DESCRIPTION
`ImportMakegridParametersFromFile` returns `absl::StatusOr<MakegridParameters>` and calls `CHECK_OK` on the file read, so a parameters file that is not there ends the process:

```
F0000 00:00:1788531134.409748 1541289 makegrid_lib.cc:272] Check failed:
maybe_makegrid_params_json is OK (NOT_FOUND: File
vmecpp/test_data/no_such_makegrid_parameters.json not found.)
*** Check failure stack trace: ***
```

The read status is returned instead.

The file name comes from the user at both call sites: `makegrid/makegrid/makegrid.cc` takes it from `argv`, and `MakegridParameters.from_file` in `pybind_vmec.cc` takes it as the argument of a bound method whose body is `GetValueOrThrow(maybe_params)`. The `CHECK_OK` fires first, so the Python binding aborts the interpreter where it is written to raise.

`CheckImportMakegridParametersReportsUnreadableFile` asks for a file that does not exist and requires `kNotFound`. It aborts against the previous code and passes with this change.

`//vmecpp/common/makegrid_lib:makegrid_lib_test` passes 19 tests.
