### PR TITLE
Return netCDF failures from WriteMakegridNetCDFFile instead of aborting

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib.cc
+++ b/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib.cc
@@ -735,6 +735,19 @@ absl::StatusOr<MakegridCachedVectorPotential> ComputeVectorPotentialCache(
   return response_table_a;
 }  // ComputeVectorPotentialCache
 
+// Report a netCDF failure through the return value of the enclosing function,
+// carrying the library's own message, and close the file being written.
+#define VMECPP_RETURN_IF_NETCDF_ERROR(nc_call)                               \
+  do {                                                                       \
+    const int nc_status = (nc_call);                                         \
+    if (nc_status != NC_NOERR) {                                             \
+      nc_close(ncid);                                                        \
+      return absl::InternalError(absl::StrFormat("could not write '%s': %s", \
+                                                 makegrid_filename,          \
+                                                 nc_strerror(nc_status)));   \
+    }                                                                        \
+  } while (0)
+
 absl::Status WriteMakegridNetCDFFile(
     const std::string& makegrid_filename,
     const MakegridParameters& makegrid_parameters,
@@ -761,97 +774,100 @@ absl::Status WriteMakegridNetCDFFile(
   }
 
   int ncid = 0;
-  CHECK_EQ(nc_create(makegrid_filename.c_str(), NC_CLOBBER, &ncid), NC_NOERR);
+  const int create_status =
+      nc_create(makegrid_filename.c_str(), NC_CLOBBER, &ncid);
+  if (create_status != NC_NOERR) {
+    return absl::InternalError(absl::StrFormat("could not create '%s': %s",
+                                               makegrid_filename,
+                                               nc_strerror(create_status)));
+  }
 
   // create dimensions
   int id_dimension_stringsize = 0;
-  CHECK_EQ(
-      nc_def_dim(ncid, "stringsize", kStringSize, &id_dimension_stringsize),
-      NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(
+      nc_def_dim(ncid, "stringsize", kStringSize, &id_dimension_stringsize));
 
   int id_dimension_external_coil_groups = 0;
-  CHECK_EQ(nc_def_dim(ncid, "external_coil_groups", n_serial_circuits,
-                      &id_dimension_external_coil_groups),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(nc_def_dim(ncid, "external_coil_groups",
+                                           n_serial_circuits,
+                                           &id_dimension_external_coil_groups));
 
   int id_dimension_dim_00001 = 0;
-  CHECK_EQ(nc_def_dim(ncid, "dim_00001", 1, &id_dimension_dim_00001), NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(
+      nc_def_dim(ncid, "dim_00001", 1, &id_dimension_dim_00001));
 
   int id_dimension_external_coils = 0;
-  CHECK_EQ(nc_def_dim(ncid, "external_coils", n_serial_circuits,
-                      &id_dimension_external_coils),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(nc_def_dim(
+      ncid, "external_coils", n_serial_circuits, &id_dimension_external_coils));
 
   int id_dimension_rad = 0;
-  CHECK_EQ(nc_def_dim(ncid, "rad", makegrid_parameters.number_of_r_grid_points,
-                      &id_dimension_rad),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(
+      nc_def_dim(ncid, "rad", makegrid_parameters.number_of_r_grid_points,
+                 &id_dimension_rad));
 
   int id_dimension_zee = 0;
-  CHECK_EQ(nc_def_dim(ncid, "zee", makegrid_parameters.number_of_z_grid_points,
-                      &id_dimension_zee),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(
+      nc_def_dim(ncid, "zee", makegrid_parameters.number_of_z_grid_points,
+                 &id_dimension_zee));
 
   int id_dimension_phi = 0;
-  CHECK_EQ(
+  VMECPP_RETURN_IF_NETCDF_ERROR(
       nc_def_dim(ncid, "phi", makegrid_parameters.number_of_phi_grid_points,
-                 &id_dimension_phi),
-      NC_NOERR);
+                 &id_dimension_phi));
 
   // create variables
   int id_variable_ir = 0;
-  CHECK_EQ(nc_def_var(ncid, "ir", NC_INT, 0, nullptr, &id_variable_ir),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(
+      nc_def_var(ncid, "ir", NC_INT, 0, nullptr, &id_variable_ir));
 
   int id_variable_jz = 0;
-  CHECK_EQ(nc_def_var(ncid, "jz", NC_INT, 0, nullptr, &id_variable_jz),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(
+      nc_def_var(ncid, "jz", NC_INT, 0, nullptr, &id_variable_jz));
 
   int id_variable_kp = 0;
-  CHECK_EQ(nc_def_var(ncid, "kp", NC_INT, 0, nullptr, &id_variable_kp),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(
+      nc_def_var(ncid, "kp", NC_INT, 0, nullptr, &id_variable_kp));
 
   int id_variable_nfp = 0;
-  CHECK_EQ(nc_def_var(ncid, "nfp", NC_INT, 0, nullptr, &id_variable_nfp),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(
+      nc_def_var(ncid, "nfp", NC_INT, 0, nullptr, &id_variable_nfp));
 
   int id_variable_nextcur = 0;
-  CHECK_EQ(
-      nc_def_var(ncid, "nextcur", NC_INT, 0, nullptr, &id_variable_nextcur),
-      NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(
+      nc_def_var(ncid, "nextcur", NC_INT, 0, nullptr, &id_variable_nextcur));
 
   int id_variable_rmin = 0;
-  CHECK_EQ(nc_def_var(ncid, "rmin", NC_DOUBLE, 0, nullptr, &id_variable_rmin),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(
+      nc_def_var(ncid, "rmin", NC_DOUBLE, 0, nullptr, &id_variable_rmin));
 
   int id_variable_rmax = 0;
-  CHECK_EQ(nc_def_var(ncid, "rmax", NC_DOUBLE, 0, nullptr, &id_variable_rmax),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(
+      nc_def_var(ncid, "rmax", NC_DOUBLE, 0, nullptr, &id_variable_rmax));
 
   int id_variable_zmin = 0;
-  CHECK_EQ(nc_def_var(ncid, "zmin", NC_DOUBLE, 0, nullptr, &id_variable_zmin),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(
+      nc_def_var(ncid, "zmin", NC_DOUBLE, 0, nullptr, &id_variable_zmin));
 
   int id_variable_zmax = 0;
-  CHECK_EQ(nc_def_var(ncid, "zmax", NC_DOUBLE, 0, nullptr, &id_variable_zmax),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(
+      nc_def_var(ncid, "zmax", NC_DOUBLE, 0, nullptr, &id_variable_zmax));
 
   int id_variable_coil_group = 0;
   std::array<int, 2> coil_group_dimensions = {id_dimension_external_coil_groups,
                                               id_dimension_stringsize};
-  CHECK_EQ(nc_def_var(ncid, "coil_group", NC_CHAR, 2,
-                      coil_group_dimensions.data(), &id_variable_coil_group),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(nc_def_var(ncid, "coil_group", NC_CHAR, 2,
+                                           coil_group_dimensions.data(),
+                                           &id_variable_coil_group));
 
   int id_variable_mgrid_mode = 0;
-  CHECK_EQ(nc_def_var(ncid, "mgrid_mode", NC_CHAR, 1, &id_dimension_dim_00001,
-                      &id_variable_mgrid_mode),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(nc_def_var(ncid, "mgrid_mode", NC_CHAR, 1,
+                                           &id_dimension_dim_00001,
+                                           &id_variable_mgrid_mode));
 
   int id_variable_raw_coil_cur = 0;
-  CHECK_EQ(nc_def_var(ncid, "raw_coil_cur", NC_DOUBLE, 1,
-                      &id_dimension_external_coils, &id_variable_raw_coil_cur),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(nc_def_var(ncid, "raw_coil_cur", NC_DOUBLE, 1,
+                                           &id_dimension_external_coils,
+                                           &id_variable_raw_coil_cur));
 
   std::vector<int> ids_variable_br(n_serial_circuits, 0);
   std::vector<int> ids_variable_bp(n_serial_circuits, 0);
@@ -866,86 +882,79 @@ absl::Status WriteMakegridNetCDFFile(
 
     std::string br_name = absl::StrFormat("br_%03d", circuit_index + 1);
     int id_variable_br = 0;
-    CHECK_EQ(nc_def_var(ncid, br_name.c_str(), NC_DOUBLE, 3,
-                        grid_dimension.data(), &id_variable_br),
-             NC_NOERR);
+    VMECPP_RETURN_IF_NETCDF_ERROR(nc_def_var(ncid, br_name.c_str(), NC_DOUBLE,
+                                             3, grid_dimension.data(),
+                                             &id_variable_br));
     ids_variable_br[circuit_index] = id_variable_br;
 
     std::string bp_name = absl::StrFormat("bp_%03d", circuit_index + 1);
     int id_variable_bp = 0;
-    CHECK_EQ(nc_def_var(ncid, bp_name.c_str(), NC_DOUBLE, 3,
-                        grid_dimension.data(), &id_variable_bp),
-             NC_NOERR);
+    VMECPP_RETURN_IF_NETCDF_ERROR(nc_def_var(ncid, bp_name.c_str(), NC_DOUBLE,
+                                             3, grid_dimension.data(),
+                                             &id_variable_bp));
     ids_variable_bp[circuit_index] = id_variable_bp;
 
     std::string bz_name = absl::StrFormat("bz_%03d", circuit_index + 1);
     int id_variable_bz = 0;
-    CHECK_EQ(nc_def_var(ncid, bz_name.c_str(), NC_DOUBLE, 3,
-                        grid_dimension.data(), &id_variable_bz),
-             NC_NOERR);
+    VMECPP_RETURN_IF_NETCDF_ERROR(nc_def_var(ncid, bz_name.c_str(), NC_DOUBLE,
+                                             3, grid_dimension.data(),
+                                             &id_variable_bz));
     ids_variable_bz[circuit_index] = id_variable_bz;
 
     if (response_table_a.has_value()) {
       std::string ar_name = absl::StrFormat("ar_%03d", circuit_index + 1);
       int id_variable_ar = 0;
-      CHECK_EQ(nc_def_var(ncid, ar_name.c_str(), NC_DOUBLE, 3,
-                          grid_dimension.data(), &id_variable_ar),
-               NC_NOERR);
+      VMECPP_RETURN_IF_NETCDF_ERROR(nc_def_var(ncid, ar_name.c_str(), NC_DOUBLE,
+                                               3, grid_dimension.data(),
+                                               &id_variable_ar));
       ids_variable_ar[circuit_index] = id_variable_ar;
 
       std::string ap_name = absl::StrFormat("ap_%03d", circuit_index + 1);
       int id_variable_ap = 0;
-      CHECK_EQ(nc_def_var(ncid, ap_name.c_str(), NC_DOUBLE, 3,
-                          grid_dimension.data(), &id_variable_ap),
-               NC_NOERR);
+      VMECPP_RETURN_IF_NETCDF_ERROR(nc_def_var(ncid, ap_name.c_str(), NC_DOUBLE,
+                                               3, grid_dimension.data(),
+                                               &id_variable_ap));
       ids_variable_ap[circuit_index] = id_variable_ap;
 
       std::string az_name = absl::StrFormat("az_%03d", circuit_index + 1);
       int id_variable_az = 0;
-      CHECK_EQ(nc_def_var(ncid, az_name.c_str(), NC_DOUBLE, 3,
-                          grid_dimension.data(), &id_variable_az),
-               NC_NOERR);
+      VMECPP_RETURN_IF_NETCDF_ERROR(nc_def_var(ncid, az_name.c_str(), NC_DOUBLE,
+                                               3, grid_dimension.data(),
+                                               &id_variable_az));
       ids_variable_az[circuit_index] = id_variable_az;
     }
   }  // number_of_serial_circuits
 
   // explicitly end "define mode" and switch over to "data writing mode"
-  CHECK_EQ(nc_enddef(ncid), NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(nc_enddef(ncid));
 
   // write actual data
-  CHECK_EQ(nc_put_var(ncid, id_variable_ir,
-                      &(makegrid_parameters.number_of_r_grid_points)),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(nc_put_var(
+      ncid, id_variable_ir, &(makegrid_parameters.number_of_r_grid_points)));
 
-  CHECK_EQ(nc_put_var(ncid, id_variable_jz,
-                      &(makegrid_parameters.number_of_z_grid_points)),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(nc_put_var(
+      ncid, id_variable_jz, &(makegrid_parameters.number_of_z_grid_points)));
 
-  CHECK_EQ(nc_put_var(ncid, id_variable_kp,
-                      &(makegrid_parameters.number_of_phi_grid_points)),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(nc_put_var(
+      ncid, id_variable_kp, &(makegrid_parameters.number_of_phi_grid_points)));
 
-  CHECK_EQ(nc_put_var(ncid, id_variable_nfp,
-                      &(makegrid_parameters.number_of_field_periods)),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(nc_put_var(
+      ncid, id_variable_nfp, &(makegrid_parameters.number_of_field_periods)));
 
-  CHECK_EQ(nc_put_var(ncid, id_variable_nextcur, &n_serial_circuits), NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(
+      nc_put_var(ncid, id_variable_nextcur, &n_serial_circuits));
 
-  CHECK_EQ(
-      nc_put_var(ncid, id_variable_rmin, &(makegrid_parameters.r_grid_minimum)),
-      NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(nc_put_var(
+      ncid, id_variable_rmin, &(makegrid_parameters.r_grid_minimum)));
 
-  CHECK_EQ(
-      nc_put_var(ncid, id_variable_rmax, &(makegrid_parameters.r_grid_maximum)),
-      NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(nc_put_var(
+      ncid, id_variable_rmax, &(makegrid_parameters.r_grid_maximum)));
 
-  CHECK_EQ(
-      nc_put_var(ncid, id_variable_zmin, &(makegrid_parameters.z_grid_minimum)),
-      NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(nc_put_var(
+      ncid, id_variable_zmin, &(makegrid_parameters.z_grid_minimum)));
 
-  CHECK_EQ(
-      nc_put_var(ncid, id_variable_zmax, &(makegrid_parameters.z_grid_maximum)),
-      NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(nc_put_var(
+      ncid, id_variable_zmax, &(makegrid_parameters.z_grid_maximum)));
 
   // This is a flat storage of all coil group names.
   // The NetCDF writing routines will interpret this as a two-dimensional array
@@ -965,47 +974,55 @@ absl::Status WriteMakegridNetCDFFile(
     absl::StrAppend(&coil_group_names,
                     absl::StrFormat("%-30s", coil_group_name));
   }  // number_of_serial_circuits
-  CHECK_EQ(nc_put_var(ncid, id_variable_coil_group, coil_group_names.c_str()),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(
+      nc_put_var(ncid, id_variable_coil_group, coil_group_names.c_str()));
 
   if (makegrid_parameters.normalize_by_currents) {
-    CHECK_EQ(nc_put_var(ncid, id_variable_mgrid_mode, &kNormalizeByCurrents),
-             NC_NOERR);
+    VMECPP_RETURN_IF_NETCDF_ERROR(
+        nc_put_var(ncid, id_variable_mgrid_mode, &kNormalizeByCurrents));
   } else {
-    CHECK_EQ(nc_put_var(ncid, id_variable_mgrid_mode, &kRawCurrents), NC_NOERR);
+    VMECPP_RETURN_IF_NETCDF_ERROR(
+        nc_put_var(ncid, id_variable_mgrid_mode, &kRawCurrents));
   }
 
-  CHECK_EQ(nc_put_var(ncid, id_variable_raw_coil_cur, circuit_currents.data()),
-           NC_NOERR);
+  VMECPP_RETURN_IF_NETCDF_ERROR(
+      nc_put_var(ncid, id_variable_raw_coil_cur, circuit_currents.data()));
 
   for (int circuit_index = 0; circuit_index < n_serial_circuits;
        ++circuit_index) {
-    CHECK_EQ(nc_put_var(ncid, ids_variable_br[circuit_index],
-                        response_table_b.b_r.row(circuit_index).data()),
-             NC_NOERR);
-    CHECK_EQ(nc_put_var(ncid, ids_variable_bp[circuit_index],
-                        response_table_b.b_p.row(circuit_index).data()),
-             NC_NOERR);
-    CHECK_EQ(nc_put_var(ncid, ids_variable_bz[circuit_index],
-                        response_table_b.b_z.row(circuit_index).data()),
-             NC_NOERR);
+    VMECPP_RETURN_IF_NETCDF_ERROR(
+        nc_put_var(ncid, ids_variable_br[circuit_index],
+                   response_table_b.b_r.row(circuit_index).data()));
+    VMECPP_RETURN_IF_NETCDF_ERROR(
+        nc_put_var(ncid, ids_variable_bp[circuit_index],
+                   response_table_b.b_p.row(circuit_index).data()));
+    VMECPP_RETURN_IF_NETCDF_ERROR(
+        nc_put_var(ncid, ids_variable_bz[circuit_index],
+                   response_table_b.b_z.row(circuit_index).data()));
 
     if (response_table_a.has_value()) {
-      CHECK_EQ(nc_put_var(ncid, ids_variable_ar[circuit_index],
-                          response_table_a->a_r.row(circuit_index).data()),
-               NC_NOERR);
-      CHECK_EQ(nc_put_var(ncid, ids_variable_ap[circuit_index],
-                          response_table_a->a_p.row(circuit_index).data()),
-               NC_NOERR);
-      CHECK_EQ(nc_put_var(ncid, ids_variable_az[circuit_index],
-                          response_table_a->a_z.row(circuit_index).data()),
-               NC_NOERR);
+      VMECPP_RETURN_IF_NETCDF_ERROR(
+          nc_put_var(ncid, ids_variable_ar[circuit_index],
+                     response_table_a->a_r.row(circuit_index).data()));
+      VMECPP_RETURN_IF_NETCDF_ERROR(
+          nc_put_var(ncid, ids_variable_ap[circuit_index],
+                     response_table_a->a_p.row(circuit_index).data()));
+      VMECPP_RETURN_IF_NETCDF_ERROR(
+          nc_put_var(ncid, ids_variable_az[circuit_index],
+                     response_table_a->a_z.row(circuit_index).data()));
     }
   }  // number_of_serial_circuits
 
-  CHECK_EQ(nc_close(ncid), NC_NOERR);
+  const int close_status = nc_close(ncid);
+  if (close_status != NC_NOERR) {
+    return absl::InternalError(absl::StrFormat("could not close '%s': %s",
+                                               makegrid_filename,
+                                               nc_strerror(close_status)));
+  }
 
   return absl::OkStatus();
 }  // NOLINT(readability/fn_size)
+
+#undef VMECPP_RETURN_IF_NETCDF_ERROR
 
 }  // namespace makegrid

--- a/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/makegrid_lib/makegrid_lib_test.cc
@@ -14,6 +14,7 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "util/file_io/file_io.h"
 #include "util/netcdf_io/netcdf_io.h"
@@ -1263,5 +1264,27 @@ TEST(TestMakegridLib, CheckImportMakegridParametersReportsUnreadableFile) {
   ASSERT_FALSE(parameters.ok());
   EXPECT_EQ(parameters.status().code(), absl::StatusCode::kNotFound);
 }  // CheckImportMakegridParametersReportsUnreadableFile
+
+// A file that cannot be created is reported through the return value, in the
+// same way as an inconsistent argument.
+TEST(TestMakegridLib, CheckWriteMakegridNetCDFFileReportsUnwritablePath) {
+  const MakegridParameters makegrid_parameters = SmallMakegridParameters();
+  const absl::StatusOr<MagneticFieldResponseTable> response_table =
+      ComputeMagneticFieldResponseTable(makegrid_parameters,
+                                        SingleCircularFilament(5.0));
+  ASSERT_OK(response_table);
+
+  Eigen::VectorXd one_current(1);
+  one_current[0] = 5.0;
+
+  const std::string filename =
+      ::testing::TempDir() + "/no_such_directory/mgrid_write_unwritable.nc";
+  const absl::Status status =
+      WriteMakegridNetCDFFile(filename, makegrid_parameters, one_current,
+                              *response_table, std::nullopt);
+  ASSERT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), absl::StatusCode::kInternal);
+  EXPECT_THAT(std::string(status.message()), ::testing::HasSubstr(filename));
+}  // CheckWriteMakegridNetCDFFileReportsUnwritablePath
 
 }  // namespace makegrid


### PR DESCRIPTION
`WriteMakegridNetCDFFile` returns `absl::Status` and reports its two argument checks that way since #722, while every netCDF call in the same function is a `CHECK_EQ` against `NC_NOERR`. An output path whose directory does not exist ends the process at the first of them:

```
F0000 00:00:1788529526.383789 1532117 makegrid_lib.cc:762] Check failed:
nc_create(makegrid_filename.c_str(), NC_CLOBBER, &ncid) == NC_NOERR (2 vs. 0)
*** Check failure stack trace: ***
```

The same holds for the definition and write calls below it, which is where a full disk lands.

The 47 checks become status returns carrying `nc_strerror` and the file name. `nc_create` and `nc_close` are written out, one having no open file to close yet and the other being the close itself; the rest go through a `VMECPP_RETURN_IF_NETCDF_ERROR` macro that closes the file and is undefined again after the function.

`CheckWriteMakegridNetCDFFileReportsUnwritablePath` writes into a directory that does not exist and requires `kInternal` and the file name in the message. It aborts against the previous code and passes with this change.

`//vmecpp/common/makegrid_lib:makegrid_lib_test` passes 19 tests, including the write round trip and the argument rejections that #722 added.

Independent of #793, which changes a different function in this file.
