### PR TITLE
Carry the Jacobian sign in the Mercier volume derivative

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -3187,9 +3187,12 @@ vmecpp::MercierFileContents vmecpp::ComputeMercierStability(
     // S
     mercier.s[jF] = mercier_intermediate.s[jF];
 
+    // mercier.f90 forms this as sqs = 0.5*(vp_real(i) + vp_real(i+1))*sign_jac
+    // and divides SHEAR, ITOR' and PRES' by it, so the Jacobian sign belongs
+    // here rather than only on WELL.
     const double vp_full = (mercier_intermediate.vp_real[jHo] +
                             mercier_intermediate.vp_real[jHi]) /
-                           2.0;
+                           2.0 * vmec_internal_results.sign_of_jacobian;
     if (vp_full == 0.0) {
       // skip this surface
       continue;

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/output_quantities/output_quantities_test.cc
@@ -671,7 +671,7 @@ TEST_P(MercierStabilityTest, CheckMercierStability) {
 
     const double vp_full = (static_cast<double>(mercier["vp_real"][jHo]) +
                             static_cast<double>(mercier["vp_real"][jHi])) /
-                           2.0;
+                           2.0 * sign_of_jacobian;
 
     // The running sum advances even on surfaces the assembly skips, and is
     // scaled by deltaS only at the end, as the assembly does.


### PR DESCRIPTION
**Change** - `ComputeMercierStability` multiplies the volume derivative of the first Mercier table by `sign_of_jacobian`, as it already does for WELL at the same site.

**Cause** - the volume derivative was the plain half-grid average of `vp_real`. `mercier.f90:191` forms it as

```fortran
sqs = p5*(vp_real(i) + vp_real(i+1))*sign_jac
```

and then writes `shear(i)/sqs` as SHEAR, `sqs` itself as VP, `ip(i)/sqs` as ITOR' and `presp(i)/sqs` as PRES'. The Jacobian sign is therefore carried by all four columns, and with the usual negative Jacobian, which is every bundled case, they came out negated.

**Evidence** - ratio to the `mercier.<case>` file educational_VMEC writes, before the change, to the five significant figures the file carries, on every case:

| column | ratio before |
| --- | --- |
| SHEAR | -0.999987 |
| VP | -1.000005 |
| ITOR' | -0.999999 |
| PRES' | -0.999996 |
| WELL | 0.999978 |
| IOTA | 0.999974 |

S, PHI, PRES and ITOR agree as well. Comparing every column of both Mercier tables against that file across the bundled cases, nine go from four differing columns to all fifteen agreeing: `solovev`, `solovev_no_axis`, `solovev_analytical`, `cth_like_fixed_bdy`, `cth_like_fixed_bdy_iota`, `cth_like_fixed_bdy_nzeta_37`, `cth_like_fixed_bdy_spline_pressure`, `cth_like_free_bdy` and `li383_low_res`. What still differs elsewhere does not come from this quantity: `cma` carries no current, so its ITOR and ITOR' are round-off around 1e-10; the asymmetric cases differ by the `tmult` normalisation; and `up_down_asymmetric_tokamak` sits in a different poloidal gauge.

**Tests** - `CheckMercierStability` reproduced the same unsigned average and asserted the first table against it, so the test and the implementation agreed with each other and both differed from the reference. The test now applies `sign_of_jacobian` where it already reads it for the WELL comparison.

**Scope** - the second table is unaffected, since `Dshear`, `Dcurr`, `Dwell` and `Dgeod` are built from the intermediates and not from this quantity. Nothing outside the output stage reads these fields.
