### PR TITLE
Fold the sin-source vacuum kernel about theta -> -theta for lasym

### DIFF
--- a/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/laplace_solver/laplace_solver.cc
@@ -422,19 +422,40 @@ void LaplaceSolver::PerformPoloidalFourierTransforms() {
         astemp_l[l] = astemp[base_idx + l];
       }
 
-      Eigen::VectorXd result_ss = sinmui_scaled.transpose() * actemp_l -
-                                  cosmui_scaled.transpose() * astemp_l;
-
-      for (int m = 0; m < mf + 1; ++m) {
-        const int idx_amat = (all_n * (mf + 1) + m) * mnpd + mn;
-        amat_sin_sin[idx_amat] = result_ss[m];
-      }
-
-      if (s_.lasym) {
-        Eigen::VectorXd result_sc = cosmui_scaled.transpose() * actemp_l +
-                                    sinmui_scaled.transpose() * astemp_l;
+      if (!s_.lasym) {
+        Eigen::VectorXd result_ss = sinmui_scaled.transpose() * actemp_l -
+                                    cosmui_scaled.transpose() * astemp_l;
         for (int m = 0; m < mf + 1; ++m) {
           const int idx_amat = (all_n * (mf + 1) + m) * mnpd + mn;
+          amat_sin_sin[idx_amat] = result_ss[m];
+        }
+      } else {
+        // The sin-source kernel grpmn_sin is evaluated on the full theta range
+        // as well, so its poloidal projection folds about theta -> -theta the
+        // same way as the cos-source kernel below: the sin-projection takes
+        // the part of actemp that is odd under the reflection and the part of
+        // astemp that is even, the cos-projection the other two parts.
+        Eigen::VectorXd ac_odd(s_.nThetaReduced), as_even(s_.nThetaReduced);
+        Eigen::VectorXd ac_even(s_.nThetaReduced), as_odd(s_.nThetaReduced);
+        for (int l = 0; l < s_.nThetaReduced; ++l) {
+          const int rl = (s_.nThetaEven - l) % s_.nThetaEven;
+          const double a = actemp[base_idx + l];
+          const double ar = actemp[base_idx + rl];
+          const double b = astemp[base_idx + l];
+          const double br = astemp[base_idx + rl];
+          ac_odd[l] = 0.5 * (a - ar);
+          as_even[l] = 0.5 * (b + br);
+          ac_even[l] = 0.5 * (a + ar);
+          as_odd[l] = 0.5 * (b - br);
+        }
+
+        Eigen::VectorXd result_ss = sinmui_scaled.transpose() * ac_odd -
+                                    cosmui_scaled.transpose() * as_even;
+        Eigen::VectorXd result_sc = cosmui_scaled.transpose() * ac_even +
+                                    sinmui_scaled.transpose() * as_odd;
+        for (int m = 0; m < mf + 1; ++m) {
+          const int idx_amat = (all_n * (mf + 1) + m) * mnpd + mn;
+          amat_sin_sin[idx_amat] = result_ss[m];
           amat_sin_cos[idx_amat] = result_sc[m];
         }
 

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/BUILD.bazel
@@ -75,12 +75,14 @@ cc_test(
     srcs = ["vmec_in_memory_mgrid_test.cc"],
     data = [
         "//vmecpp/test_data:cth_like_free_bdy",
+        "//vmecpp/test_data:cth_like_free_bdy_asym",
         "//vmecpp/test_data:solovev_free_bdy",
     ],
     deps = [
         "//vmecpp/vmec/output_quantities:test_helpers",
         "@googletest//:gtest_main",
         "//util/file_io:file_io",
+        "//util/netcdf_io:netcdf_io",
         "//util/testing:numerical_comparison_lib",
         "//vmecpp/vmec/vmec",
     ],

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_in_memory_mgrid_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_in_memory_mgrid_test.cc
@@ -2,14 +2,18 @@
 // <info@proximafusion.com>
 //
 // SPDX-License-Identifier: MIT
+#include <netcdf.h>
+
 #include <filesystem>
 #include <string>
 #include <vector>
 
 #include "absl/log/check.h"
+#include "absl/strings/str_format.h"
 #include "gmock/gmock.h"  // ElementsAreArray
 #include "gtest/gtest.h"
 #include "util/file_io/file_io.h"
+#include "util/netcdf_io/netcdf_io.h"
 #include "util/testing/numerical_comparison_lib.h"
 #include "vmecpp/common/magnetic_configuration_lib/magnetic_configuration_lib.h"
 #include "vmecpp/common/makegrid_lib/makegrid_lib.h"
@@ -26,6 +30,7 @@ using ::testing::Values;
 using file_io::ReadFile;
 using magnetics::ImportMagneticConfigurationFromCoilsFile;
 using makegrid::ImportMakegridParametersFromFile;
+using testing::IsCloseRelAbs;
 using vmecpp::RadialPartitioning;
 using vmecpp::Sizes;
 using vmecpp::Vmec;
@@ -71,6 +76,144 @@ TEST(TestVmec, InMemoryMgridWithMismatchedNzetaIsRejected) {
   EXPECT_EQ(output.status().code(), absl::StatusCode::kInvalidArgument);
   EXPECT_THAT(std::string(output.status().message()),
               ::testing::HasSubstr("phi grid points"));
+}
+
+// The stellarator-symmetry operation maps toroidal plane k onto (kp - k) % kp
+// and Z onto -Z, negates B_R and leaves B_phi and B_Z unchanged; the
+// stellarator-symmetric mgrid_cth_like.nc satisfies that relation to 2e-15.
+// Applied to the non-stellarator-symmetric mgrid_cth_like_asym.nc it gives the
+// mirror image of that coil field, and the equilibrium it produces has to be
+// the mirror image of the original: every gauge-invariant scalar unchanged,
+// every antisymmetric Fourier array negated. That holds the sin/cos coupling
+// blocks of the vacuum solver to account.
+TEST(TestVmec, LasymFreeBoundaryIsMirrorCovariant) {
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile("vmecpp/test_data/cth_like_free_bdy_asym.json");
+  ASSERT_TRUE(indata_json.ok());
+  const absl::StatusOr<VmecINDATA> maybe_indata =
+      VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(maybe_indata.ok());
+  const VmecINDATA& indata = *maybe_indata;
+  ASSERT_TRUE(indata.lasym);
+
+  // Read the response table of the asymmetric mgrid file.
+  int ncid = 0;
+  ASSERT_EQ(
+      nc_open("vmecpp/test_data/mgrid_cth_like_asym.nc", NC_NOWRITE, &ncid),
+      NC_NOERR);
+  const auto read_int = [&](const char* name) {
+    const absl::StatusOr<int> value = netcdf_io::NetcdfReadInt(ncid, name);
+    CHECK_OK(value);
+    return *value;
+  };
+  const auto read_double = [&](const char* name) {
+    const absl::StatusOr<double> value =
+        netcdf_io::NetcdfReadDouble(ncid, name);
+    CHECK_OK(value);
+    return *value;
+  };
+  const int num_r = read_int("ir");
+  const int num_z = read_int("jz");
+  const int num_phi = read_int("kp");
+  const int nextcur = read_int("nextcur");
+  ASSERT_EQ(nextcur, static_cast<int>(indata.extcur.size()));
+
+  makegrid::MagneticFieldResponseTable table;
+  table.parameters = {.normalize_by_currents = false,
+                      .assume_stellarator_symmetry = false,
+                      .number_of_field_periods = read_int("nfp"),
+                      .r_grid_minimum = read_double("rmin"),
+                      .r_grid_maximum = read_double("rmax"),
+                      .number_of_r_grid_points = num_r,
+                      .z_grid_minimum = read_double("zmin"),
+                      .z_grid_maximum = read_double("zmax"),
+                      .number_of_z_grid_points = num_z,
+                      .number_of_phi_grid_points = num_phi};
+  const int num_grid_points = num_phi * num_z * num_r;
+  table.b_r = vmecpp::RowMatrixXd::Zero(nextcur, num_grid_points);
+  table.b_p = vmecpp::RowMatrixXd::Zero(nextcur, num_grid_points);
+  table.b_z = vmecpp::RowMatrixXd::Zero(nextcur, num_grid_points);
+  for (int i = 0; i < nextcur; ++i) {
+    const auto b_r =
+        netcdf_io::NetcdfReadArray3D(ncid, absl::StrFormat("br_%03d", i + 1));
+    const auto b_p =
+        netcdf_io::NetcdfReadArray3D(ncid, absl::StrFormat("bp_%03d", i + 1));
+    const auto b_z =
+        netcdf_io::NetcdfReadArray3D(ncid, absl::StrFormat("bz_%03d", i + 1));
+    ASSERT_TRUE(b_r.ok() && b_p.ok() && b_z.ok());
+    for (int k = 0; k < num_phi; ++k) {
+      for (int z = 0; z < num_z; ++z) {
+        for (int r = 0; r < num_r; ++r) {
+          const int index = (k * num_z + z) * num_r + r;
+          table.b_r(i, index) = (*b_r)[k][z][r];
+          table.b_p(i, index) = (*b_p)[k][z][r];
+          table.b_z(i, index) = (*b_z)[k][z][r];
+        }
+      }
+    }
+  }
+  ASSERT_EQ(nc_close(ncid), NC_NOERR);
+
+  // Its mirror image.
+  makegrid::MagneticFieldResponseTable mirror = table;
+  for (int i = 0; i < nextcur; ++i) {
+    for (int k = 0; k < num_phi; ++k) {
+      const int k_source = (num_phi - k) % num_phi;
+      for (int z = 0; z < num_z; ++z) {
+        const int z_source = num_z - 1 - z;
+        for (int r = 0; r < num_r; ++r) {
+          const int index = (k * num_z + z) * num_r + r;
+          const int source = (k_source * num_z + z_source) * num_r + r;
+          mirror.b_r(i, index) = -table.b_r(i, source);
+          mirror.b_p(i, index) = table.b_p(i, source);
+          mirror.b_z(i, index) = table.b_z(i, source);
+        }
+      }
+    }
+  }
+
+  const auto original = vmecpp::run(indata, table);
+  ASSERT_TRUE(original.ok()) << original.status();
+  const auto mirrored = vmecpp::run(indata, mirror);
+  ASSERT_TRUE(mirrored.ok()) << mirrored.status();
+  const vmecpp::WOutFileContents& a = original->wout;
+  const vmecpp::WOutFileContents& b = mirrored->wout;
+
+  // The coil field is asymmetric enough to give the equilibrium a measurable
+  // antisymmetric part; otherwise the sign checks below would be empty.
+  ASSERT_GT(a.rmns.cwiseAbs().maxCoeff(), 5.0e-4);
+  ASSERT_GT(a.zmnc.cwiseAbs().maxCoeff(), 5.0e-4);
+
+  const double scalar_tolerance = 1.0e-10;
+  EXPECT_TRUE(IsCloseRelAbs(a.volume, b.volume, scalar_tolerance));
+  EXPECT_TRUE(IsCloseRelAbs(a.aspect, b.aspect, scalar_tolerance));
+  EXPECT_TRUE(IsCloseRelAbs(a.wb, b.wb, scalar_tolerance));
+  EXPECT_TRUE(IsCloseRelAbs(a.rmax_surf, b.rmax_surf, scalar_tolerance));
+  EXPECT_TRUE(IsCloseRelAbs(a.rmin_surf, b.rmin_surf, scalar_tolerance));
+  EXPECT_TRUE(IsCloseRelAbs(a.zmax_surf, b.zmax_surf, scalar_tolerance));
+
+  // Symmetric arrays are unchanged, antisymmetric arrays change sign.
+  const double array_tolerance = 1.0e-9;
+  const auto same = [&](const vmecpp::RowMatrixXd& x,
+                        const vmecpp::RowMatrixXd& y, const char* name) {
+    EXPECT_LE((x - y).cwiseAbs().maxCoeff(),
+              array_tolerance * x.cwiseAbs().maxCoeff())
+        << name;
+  };
+  const auto negated = [&](const vmecpp::RowMatrixXd& x,
+                           const vmecpp::RowMatrixXd& y, const char* name) {
+    EXPECT_LE((x + y).cwiseAbs().maxCoeff(),
+              array_tolerance * x.cwiseAbs().maxCoeff())
+        << name;
+  };
+  same(a.rmnc, b.rmnc, "rmnc");
+  same(a.zmns, b.zmns, "zmns");
+  same(a.lmns, b.lmns, "lmns");
+  same(a.bmnc, b.bmnc, "bmnc");
+  negated(a.rmns, b.rmns, "rmns");
+  negated(a.zmnc, b.zmnc, "zmnc");
+  negated(a.lmnc, b.lmnc, "lmnc");
+  negated(a.bmns, b.bmns, "bmns");
 }
 
 TEST(TestVmec, CheckInMemoryMgrid) {


### PR DESCRIPTION
`LaplaceSolver::PerformPoloidalFourierTransforms` projects the source-side kernel onto the reduced poloidal range `[0, pi]`. For `lasym` that kernel is evaluated on the full range, so each block has to fold it about `theta -> -theta` with the parity its projection needs. The two cos-source blocks do that. The two sin-source blocks did not: `amat_sin_sin` took `actemp` and `astemp` on the reduced range as they stand, and `amat_sin_cos` took the same arrays with cos weights. `fouri.f90:127-141` integrates all four blocks over the full range with plain weights.

On a stellarator-symmetric surface `actemp` is odd and `astemp` even in the source angle, so the full-range integral behind `amat_sin_cos` vanishes while its half-range sum does not. That block maps the cos potential into the sin equation, and the antisymmetric part of the vacuum field therefore leaked into the symmetric potential at first order. `amat_sin_sin` was exact only while the surface stayed symmetric. Nothing in the tree could see either: the degenerate `lasym` tests carry no cos potential, and no asymmetric free-boundary case has a reference.

Measured on `cth_like_free_bdy_asym`, whose mgrid is asymmetric at 2.7e-4 of the field, against its mirror image (plane `k -> (kp - k) % kp`, `Z -> -Z`, `B_R -> -B_R`, the relation the symmetric `mgrid_cth_like.nc` satisfies to 2e-15). At the first vacuum solve the surface is symmetric to 1e-10, so the sin half of `potvac` must be identical for the symmetric, asymmetric and mirrored fields and the cos half must change sign:

| | before | after |
| --- | --- | --- |
| `\|sin(asym) - sin(sym)\|` | 8.1e-3 | 1.1e-15 |
| `\|sin(asym) - sin(mirror)\|` | 1.6e-2 | 2.4e-15 |
| `\|cos(asym) + cos(mirror)\|` | 9.9e-14 | 9.9e-14 |

At convergence (`ftol` 1e-8, 248 iterations both ways), the original and mirrored equilibria:

| | before | after |
| --- | --- | --- |
| `volume`, `aspect`, `wb` | 8.6e-6, 2.1e-5, 6.1e-6 | 1.0e-13, 7.5e-15, 1.2e-15 |
| `rmax_surf`, `rmin_surf`, `zmax_surf` | 1.2e-4, 1.3e-4, 4.8e-4 | 1.7e-13, 4.5e-14, 8.4e-13 |
| `rmns`, `zmnc`, `lmnc`, `bmns` (`\|a+b\|/max\|a\|`) | 5.4e-3, 2.2e-2, 1.2e-2, 1.7e-2 | 1.6e-11, 6.4e-11, 3.4e-11, 5.0e-11 |

educational_VMEC and PARVMEC sit at 1e-11 on those arrays and 1e-13 on those scalars.

Against the other two codes at the same tolerance, as `max|a-b|/max|reference|`:

| | VMEC++ vs edu before | VMEC++ vs edu after | VMEC++ vs PARVMEC after | edu vs PARVMEC |
| --- | --- | --- | --- | --- |
| `rmns` | 2.7e-3 | 4.3e-6 | 3.72e-2 | 3.72e-2 |
| `zmnc` | 1.0e-2 | 1.4e-5 | 1.196e-1 | 1.196e-1 |
| `lmnc` | 5.8e-3 | 8.4e-6 | 5.11e-2 | 5.11e-2 |

So the antisymmetric part now agrees with educational_VMEC to 1e-5, and what remains of the difference #775 measured against PARVMEC is shared by both 8.52-lineage codes to four digits.

The `lasym = false` path is untouched: `cth_like_free_bdy` against the checked-in Fortran wout stays at 1.9e-12. The fixed-boundary `lasym` mirror pair (`cth_like_fixed_bdy_asym` with `rbs`, `zbc`, `raxis_s`, `zaxis_c` negated) is exact to 1e-14 before and after, which confines the change to the vacuum solver.

`LasymFreeBoundaryIsMirrorCovariant` reads `mgrid_cth_like_asym.nc` into a response table, mirrors it in memory, runs both and requires the gauge-invariant scalars to agree to 1e-10, the symmetric arrays to agree and the antisymmetric arrays to change sign to 1e-9 of their scale. Against `main` every one of its fourteen expectations fails.

`laplace_solver_test` (9), `singular_integrals_test` (4), `vmec_in_memory_mgrid_test` (3 plus the new case) and `vmec_test` (14, including both `lasym` free-boundary cases) pass.
