### PR TITLE
Interpolate line_segment profiles on the bracketing knot interval

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
@@ -944,7 +944,7 @@ double RadialProfiles::evalRational(const Eigen::VectorXd& coeffs, double x) {
                               : std::numeric_limits<double>::max();
 }
 
-// Linear interpolation between closest points and associated knots.
+// Linear interpolation between the two knots that bracket x.
 // Clamp the profile if x is outside the range of knots.
 double RadialProfiles::evalLineSegment(const Eigen::VectorXd& splineKnots,
                                        const Eigen::VectorXd& splineValues,
@@ -953,20 +953,22 @@ double RadialProfiles::evalLineSegment(const Eigen::VectorXd& splineKnots,
   if (n < 2 || n != static_cast<int>(splineValues.size())) {
     return 0.0;
   }
-  auto it = std::lower_bound(splineKnots.begin(), splineKnots.end(), x);
-  if (it >= (splineKnots.end() - 1)) {
-    // x is out of bounds (or x1 = it+1 would be out of bounds)
-    return splineValues[n - 1];
-  }
-  if (it == splineKnots.begin()) {
-    // x is below the first knot
+  if (x <= splineKnots[0]) {
     return splineValues[0];
   }
-  const double x0 = *it;
-  const double x1 = *(it + 1);
-  int ilow = static_cast<int>(std::distance(splineKnots.begin(), it));
+  if (x >= splineKnots[n - 1]) {
+    return splineValues[n - 1];
+  }
+  // The first knot strictly above x and the knot before it, which is the last
+  // one at or below x, enclose x, so the interval has positive length.
+  const auto upper =
+      std::upper_bound(splineKnots.begin(), splineKnots.end(), x);
+  const int ihigh = static_cast<int>(std::distance(splineKnots.begin(), upper));
+  const int ilow = ihigh - 1;
+  const double x0 = splineKnots[ilow];
+  const double x1 = splineKnots[ihigh];
   const double y0 = splineValues[ilow];
-  const double y1 = splineValues[ilow + 1];
+  const double y1 = splineValues[ihigh];
   const double t = (x - x0) / (x1 - x0);
   return (1.0 - t) * y0 + t * y1;
 }

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles_test.cc
@@ -136,6 +136,32 @@ TEST_F(RadialProfilesTest, SplineTooFewPointsReturnsZero) {
   EXPECT_EQ(profiles_->evalCubicIntegrated(knots, values, 0.5), 0.0);
 }
 
+// ---- line_segment: interpolate on the knot interval that brackets x ---------
+// Inside [k_i, k_{i+1}] the value is the linear interpolation between those two
+// knots, the knots themselves are reproduced, and outside the knot range the
+// profile is clamped to the end values.
+TEST_F(RadialProfilesTest, LineSegmentInterpolatesOnBracketingInterval) {
+  const Eigen::VectorXd knots = Vec({0.0, 0.25, 0.5, 0.75, 1.0});
+  const Eigen::VectorXd values = Vec({1.0, 0.9, 0.6, 0.2, 0.0});
+  struct Pt {
+    double x;
+    double expected;
+  };
+  for (const Pt& p : {Pt{0.1, 0.96}, Pt{0.3, 0.84}, Pt{0.6, 0.44},
+                      Pt{0.8, 0.16}, Pt{0.95, 0.04}}) {
+    EXPECT_NEAR(profiles_->evalLineSegment(knots, values, p.x), p.expected,
+                1e-12)
+        << "line_segment x=" << p.x;
+  }
+  for (int i = 0; i < knots.size(); ++i) {
+    EXPECT_NEAR(profiles_->evalLineSegment(knots, values, knots[i]), values[i],
+                1e-12)
+        << "line_segment knot " << i;
+  }
+  EXPECT_EQ(profiles_->evalLineSegment(knots, values, -0.1), values[0]);
+  EXPECT_EQ(profiles_->evalLineSegment(knots, values, 1.2), values[4]);
+}
+
 // ---- corrected Akima right edge: the interpolant is reflection-symmetric ---
 // educational_VMEC's spline_akima.f reuses the left-edge curvature on the right
 // edge, so its interpolant depends on the orientation of the data. The


### PR DESCRIPTION
`RadialProfiles::evalLineSegment` picks the interval that starts at the first knot at or above `x`, so an `x` strictly between two knots is extrapolated backward from the following interval, and an `x` inside the last interval returns the end value. `line_segment` and `line_segment_i` profiles are therefore only correct exactly at the knots.

The evaluator now interpolates between the two knots that bracket `x`, which is what educational_VMEC `line_seg` does; clamping outside the knot range is unchanged. The new unit test checks hand-computed values inside every interval, the knots themselves, and the clamped ends.
