### PR TITLE
Reject the unimplemented sum_cossq profile names at input validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ VMEC++:
    * `sum_cossq_s`
    * `sum_cossq_sqrts`
    * `sum_cossq_s_free`
+
+   The `sum_cossq_*` family has no evaluator at all, so those three names are rejected at input validation instead of evaluating to a zero profile.
 - some (rarely used) free-boundary-related output quantities are not implemented yet:
    * `curlabel` - declared but not populated yet
    * `potvac` - declared but not populated yet

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -73,6 +73,13 @@ absl::Status CheckProfile(const std::string& type_key,
         type_key, type_name, ProfileTypeName(profile_type)));
   }
 
+  if (!parameterization->IsImplemented()) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "input variable '%s' is '%s', which Fortran VMEC supports but VMEC++ "
+        "does not implement\n",
+        type_key, type_name));
+  }
+
   if (parameterization->NeedsSplineData()) {
     if (aux_s.size() == 0 || aux_f.size() == 0) {
       return absl::InvalidArgumentError(absl::StrFormat(

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
@@ -246,6 +246,27 @@ TEST(TestVmecINDATA, CheckProfileParameterizationNames) {
   EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
 }
 
+// The sum_cossq_* current profiles are named in the parameterization table
+// because Fortran VMEC accepts them, but evalProfileFunction has no case for
+// them and would return zero for every s. A zero current profile leaves the
+// prescribed curtor unapplied and the run still reports convergence, so these
+// names have to be rejected here.
+TEST(TestVmecINDATA, CheckUnimplementedProfileParameterizationNames) {
+  VmecINDATA indata;
+  indata.ncurr = 1;
+  ASSERT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+
+  for (const char* name :
+       {"sum_cossq_s", "sum_cossq_sqrts", "sum_cossq_s_free"}) {
+    indata.pcurr_type = name;
+    EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok())
+        << "unimplemented pcurr_type accepted: " << name;
+  }
+
+  indata.pcurr_type = "power_series";
+  EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+}
+
 // A spline profile cannot be evaluated without its knots. The polynomial
 // coefficient arrays, by contrast, are zero-padded on read, so an empty one is
 // a valid way to ask for a zero profile.

--- a/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.cc
@@ -97,15 +97,19 @@ std::vector<ProfileParameterizationData> BuildProfileParameterizations() {
   all.emplace_back("nice_quadratic", /*allowedForPres=*/false,
                    /*allowedForCurr*/ false, /*allowedForIota*/ true,
                    /*needsSplineData*/ false);
+  // The three sum_cossq_* current profiles exist in PARVMEC
+  // (Sources/Initialization_Cleanup/profile_functions.f) but have no case in
+  // evalProfileFunction, so they are registered as not implemented and are
+  // rejected at input validation rather than evaluating to zero in the solver.
   all.emplace_back("sum_cossq_s", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*needsSplineData*/ false);
+                   /*needsSplineData*/ false, /*implemented=*/false);
   all.emplace_back("sum_cossq_sqrts", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*needsSplineData*/ false);
+                   /*needsSplineData*/ false, /*implemented=*/false);
   all.emplace_back("sum_cossq_s_free", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*needsSplineData*/ false);
+                   /*needsSplineData*/ false, /*implemented=*/false);
   return all;
 }
 
@@ -113,9 +117,10 @@ std::vector<ProfileParameterizationData> BuildProfileParameterizations() {
 
 ProfileParameterizationData::ProfileParameterizationData(
     const std::string& name, bool allowedForPres, bool allowedForCurr,
-    bool allowedForIota, bool needsSplineData)
+    bool allowedForIota, bool needsSplineData, bool implemented)
     : name_(name),
       needsSplineData_(needsSplineData),
+      implemented_(implemented),
       allowedFor_({.pres = allowedForPres,
                    .curr = allowedForCurr,
                    .iota = allowedForIota}) {}
@@ -129,6 +134,8 @@ bool ProfileParameterizationData::NeedsSplineData() const {
 AllowedFor ProfileParameterizationData::IsAllowedFor() const {
   return allowedFor_;
 }
+
+bool ProfileParameterizationData::IsImplemented() const { return implemented_; }
 
 const std::vector<ProfileParameterizationData>& AllProfileParameterizations() {
   static const std::vector<ProfileParameterizationData>* const kAll =

--- a/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.h
@@ -25,17 +25,22 @@ struct AllowedFor {
 
 class ProfileParameterizationData {
  public:
+  // `implemented` is false for a name that Fortran VMEC accepts but
+  // evalProfileFunction has no case for; such a name must be rejected at input
+  // validation, since the evaluator would return zero for it.
   ProfileParameterizationData(const std::string& name, bool allowedForPres,
                               bool allowedForCurr, bool allowedForIota,
-                              bool needsSplineData);
+                              bool needsSplineData, bool implemented = true);
 
   const std::string& Name() const;
   bool NeedsSplineData() const;
   AllowedFor IsAllowedFor() const;
+  bool IsImplemented() const;
 
  private:
   const std::string name_;
   bool needsSplineData_;
+  bool implemented_;
   AllowedFor allowedFor_;
 };
 


### PR DESCRIPTION
`sum_cossq_s`, `sum_cossq_sqrts` and `sum_cossq_s_free` are registered in `AllProfileParameterizations()` with `allowedForCurr = true`, so `CheckProfile` accepts them as current profiles. `evalProfileFunction` has no case for any of them: they fall through to `default:`, which writes one line to stderr and returns `0.0` for every `s`.

That is the failure the validation added in #719 was meant to prevent, per its own comment: an unrecognized name "reaches the solver as a zero profile, which converges to a silently wrong equilibrium."

With `ncurr = 1` the consequence is that the prescribed net toroidal current is dropped. `evalCurrProfile(1.0)` returns zero, so the `|edgeCurrent| > eps * curtor` guard in `evalRadialProfiles` fails, `Itor` stays zero, and `currH` is zero on every surface. Running `cth_like_fixed_bdy.json` (`ncurr = 1`, `curtor = 4.322908e+04`) unchanged and then with `pcurr_type = "sum_cossq_s"`:

| | `two_power` (as shipped) | `sum_cossq_s` |
|---|---|---|
| `ier_flag` | 0 | 0 |
| `fsqr` | 9.348e-07 | 9.918e-07 |
| `ctor` | +4.322913e+04 A | -2.554651e-11 A |
| max abs `jcurv` | 1.201671e+04 | 2.284859e-10 |

The run terminates normally and writes a `wout` that reports convergence to a zero-current equilibrium while the input asked for 43.2 kA. The only signal is the stderr line, which carries no error flag and is easily lost through the Python API.

The parameterization table now records whether a name has an evaluator, and `CheckProfile` rejects one that does not, so these inputs fail up front instead of solving the wrong problem. The three names stay in the table and keep their enum values, so implementing them later is a local change. The README already listed them as not implemented; it now also says they are rejected rather than evaluated as zero.

The new test fails on all three names without the validation change and passes with it.
