### PR TITLE
Scale the sum_atan arctangent terms by 2/pi

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
@@ -567,6 +567,8 @@ double RadialProfiles::evalGaussTrunc(const Eigen::VectorXd& coeffs, double x,
 }
 
 double RadialProfiles::evalSumAtan(const Eigen::VectorXd& coeffs, double x) {
+  // c0 + (2/pi) * sum_i c_i * atan(c_{i+1} * x^c_{i+2} / (1 - x)^c_{i+3}) for
+  // i = 1, 5, 9, 13, 17; each term rises from 0 at x = 0 to c_i at x = 1.
   double ret = 0.0;
 
   if (coeffs.size() > 0) {
@@ -590,26 +592,28 @@ double RadialProfiles::evalSumAtan(const Eigen::VectorXd& coeffs, double x) {
       ret += coeffs[17];
     }
   } else {
+    double atan_sum = 0.0;
     if (coeffs.size() >= 5) {
-      ret += coeffs[1] * std::atan(coeffs[2] * std::pow(x, coeffs[3]) /
-                                   std::pow(1 - x, coeffs[4]));
+      atan_sum += coeffs[1] * std::atan(coeffs[2] * std::pow(x, coeffs[3]) /
+                                        std::pow(1 - x, coeffs[4]));
     }
     if (coeffs.size() >= 9) {
-      ret += coeffs[5] * std::atan(coeffs[6] * std::pow(x, coeffs[7]) /
-                                   std::pow(1 - x, coeffs[8]));
+      atan_sum += coeffs[5] * std::atan(coeffs[6] * std::pow(x, coeffs[7]) /
+                                        std::pow(1 - x, coeffs[8]));
     }
     if (coeffs.size() >= 13) {
-      ret += coeffs[9] * std::atan(coeffs[10] * std::pow(x, coeffs[11]) /
-                                   std::pow(1 - x, coeffs[12]));
+      atan_sum += coeffs[9] * std::atan(coeffs[10] * std::pow(x, coeffs[11]) /
+                                        std::pow(1 - x, coeffs[12]));
     }
     if (coeffs.size() >= 17) {
-      ret += coeffs[13] * std::atan(coeffs[14] * std::pow(x, coeffs[15]) /
-                                    std::pow(1 - x, coeffs[16]));
+      atan_sum += coeffs[13] * std::atan(coeffs[14] * std::pow(x, coeffs[15]) /
+                                         std::pow(1 - x, coeffs[16]));
     }
     if (coeffs.size() >= 21) {
-      ret += coeffs[17] * std::atan(coeffs[18] * std::pow(x, coeffs[19]) /
-                                    std::pow(1 - x, coeffs[20]));
+      atan_sum += coeffs[17] * std::atan(coeffs[18] * std::pow(x, coeffs[19]) /
+                                         std::pow(1 - x, coeffs[20]));
     }
+    ret += 2.0 / M_PI * atan_sum;
   }
 
   return ret;

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles_test.cc
@@ -238,6 +238,31 @@ TEST_F(RadialProfilesTest, NiceQuadratic) {
   EXPECT_NEAR(profiles_->evalNiceQuadratic(c, 0.5), 1.2, 1e-12);
 }
 
+// ---- sum_atan --------------------------------------------------------------
+// Each arctangent term carries the factor 2/pi, so it rises from 0 at s = 0 to
+// its amplitude at s = 1, where the closed-form branch sums the amplitudes.
+TEST_F(RadialProfilesTest, SumAtanTermsScaledByTwoOverPi) {
+  // iota(s) = a0 + (2/pi) * a1 * atan(a2 * s^a3 / (1 - s)^a4)
+  const Eigen::VectorXd c = Vec({0.3, 0.8, 1.0, 1.0, 1.0});
+  EXPECT_NEAR(profiles_->evalSumAtan(c, 0.0), 0.3, 1e-12);
+  // atan(1) = pi/4: the term is at half its amplitude at s = 1/2
+  EXPECT_NEAR(profiles_->evalSumAtan(c, 0.5), 0.3 + 0.4, 1e-12);
+  EXPECT_NEAR(profiles_->evalSumAtan(c, 0.25),
+              0.3 + 0.8 * 2.0 / M_PI * std::atan(0.25 / 0.75), 1e-12);
+  EXPECT_NEAR(profiles_->evalSumAtan(c, 1.0), 1.1, 1e-12);
+  EXPECT_NEAR(profiles_->evalSumAtan(c, 1.0 - 1e-9), 1.1, 1e-8);
+
+  // two terms with general exponents
+  const Eigen::VectorXd d = Vec({0.1, 0.5, 2.0, 1.5, 0.5, -0.2, 3.0, 2.0, 1.0});
+  const double x = 0.4;
+  const double expected =
+      0.1 + 2.0 / M_PI *
+                (0.5 * std::atan(2.0 * std::pow(x, 1.5) / std::pow(0.6, 0.5)) -
+                 0.2 * std::atan(3.0 * std::pow(x, 2.0) / std::pow(0.6, 1.0)));
+  EXPECT_NEAR(profiles_->evalSumAtan(d, x), expected, 1e-12);
+  EXPECT_NEAR(profiles_->evalSumAtan(d, 1.0), 0.1 + 0.5 - 0.2, 1e-12);
+}
+
 // ---- rational --------------------------------------------------------------
 TEST_F(RadialProfilesTest, Rational) {
   // numerator = 1 + 2x (c0,c1), denominator = 3 (c10) -> (1 + 2x)/3.


### PR DESCRIPTION
`evalSumAtan` summed the arctangent terms without the `2/pi` factor that Fortran VMEC applies in `piota` and `pcurr` for `sum_atan` (profile_functions.f), so each term reached `pi/2` times its amplitude instead of the amplitude, and the profile jumped at `s = 1`, where the closed-form branch sums the bare amplitudes. An iota or current profile of this type therefore converged to a different equilibrium than the same input in Fortran VMEC.

The factor is applied to the sum of the terms. The new test pins a unit-exponent term at half its amplitude at `s = 1/2`, checks a two-term profile against the closed form, and requires continuity with the `s >= 1` branch; it fails on the previous evaluator.

`bazel test --config=opt //vmecpp/...` passes.
