### PR TITLE
Reject an mgrid whose number of field periods differs from the input

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -236,6 +236,12 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
           "are consistent.",
           mgrid_.numPhi, indata_.nzeta));
     }
+    if (mgrid_.nfp != indata_.nfp) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "MGridProvider has %d field periods, but VmecINDATA has nfp = %d. "
+          "Please ensure that the two are consistent.",
+          mgrid_.nfp, indata_.nfp));
+    }
   }
 
   auto is_indata_consistent =

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_in_memory_mgrid_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_in_memory_mgrid_test.cc
@@ -78,6 +78,46 @@ TEST(TestVmec, InMemoryMgridWithMismatchedNzetaIsRejected) {
               ::testing::HasSubstr("phi grid points"));
 }
 
+// The number of field periods of the vacuum field sets the toroidal extent of
+// its planes, so it has to be the one the solver runs with.
+TEST(TestVmec, InMemoryMgridWithMismatchedNfpIsRejected) {
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile("vmecpp/test_data/cth_like_free_bdy.json");
+  ASSERT_TRUE(indata_json.ok());
+  absl::StatusOr<VmecINDATA> maybe_indata = VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(maybe_indata.ok());
+  const VmecINDATA& indata = maybe_indata.value();
+
+  const auto maybe_magnetic_configuration =
+      magnetics::ImportMagneticConfigurationFromCoilsFile(
+          "vmecpp/test_data/coils.cth_like");
+  ASSERT_TRUE(maybe_magnetic_configuration.ok());
+
+  auto maybe_makegrid_params = makegrid::ImportMakegridParametersFromFile(
+      "vmecpp/test_data/makegrid_parameters_cth_like.json");
+  ASSERT_TRUE(maybe_makegrid_params.ok());
+  makegrid::MakegridParameters makegrid_params = *maybe_makegrid_params;
+
+  // One field period more than the input, with the toroidal resolution the
+  // input asks for, on a coarse R-Z grid so that building the table stays
+  // cheap.
+  ASSERT_EQ(makegrid_params.number_of_field_periods, indata.nfp);
+  ASSERT_EQ(makegrid_params.number_of_phi_grid_points, indata.nzeta);
+  makegrid_params.number_of_field_periods = indata.nfp + 1;
+  makegrid_params.number_of_r_grid_points = 5;
+  makegrid_params.number_of_z_grid_points = 5;
+
+  const auto maybe_response_table = makegrid::ComputeMagneticFieldResponseTable(
+      makegrid_params, *maybe_magnetic_configuration);
+  ASSERT_TRUE(maybe_response_table.ok());
+
+  const auto output = vmecpp::run(indata, *maybe_response_table);
+  ASSERT_FALSE(output.ok());
+  EXPECT_EQ(output.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(std::string(output.status().message()),
+              ::testing::HasSubstr("field periods"));
+}
+
 // The stellarator-symmetry operation maps toroidal plane k onto (kp - k) % kp
 // and Z onto -Z, negates B_R and leaves B_phi and B_Z unchanged; the
 // stellarator-symmetric mgrid_cth_like.nc satisfies that relation to 2e-15.


### PR DESCRIPTION
`MGridProvider` reads `nfp` from the mgrid file, or takes it from the in-memory response table, and `Vmec::run` never compared it with `VmecINDATA::nfp`. The vacuum field was then laid over the input's field period whatever the table was computed for: `cth_like_free_bdy` run against `mgrid_cth_like.nc` with its `nfp` header changed from 5 to 10 converges to the same equilibrium as with the file as shipped. LIBSTELL's `read_mgrid` stops on that mismatch.

`Vmec::run` now returns `kInvalidArgument` naming both values, beside the existing `nzeta` check. The new test builds the cth_like response table with one field period more than the input and requires the rejection; on the previous code that run converges.

`bazel test --config=opt //vmecpp/vmec/vmec/...` and `tests/test_free_boundary.py` pass.
