### PR TITLE
Fill and sum every toroidal plane in the 2D transforms

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/sizes/sizes.cc
+++ b/src/vmecpp/cpp/vmecpp/common/sizes/sizes.cc
@@ -64,9 +64,8 @@ void Sizes::computeDerivedSizes() {
 
   // nzeta
   if (ntor == 0 && nZeta < 1) {
-    // Tokamak (ntor=0) needs (at least) nzeta=1
-    // I think this implies that (in principle, not reasonable) one could do an
-    // axisymmetric run with nzeta > 1 ...
+    // Tokamak (ntor=0) needs (at least) nzeta=1; a larger nzeta is allowed and
+    // carries the same geometry in every toroidal plane.
     nZeta = 1;
   }
 

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -1171,16 +1171,16 @@ void IdealMhdModel::dft_FourierToReal_3d_asymm(
 // compute inv-DFTs on unique radial grid points
 void IdealMhdModel::dft_FourierToReal_2d_symm(
     const FourierGeometry& physical_x) {
-  // can safely assume lthreed == false in here
+  // ntor == 0: no toroidal modes, but nZeta may exceed 1
 
-  const int num_realsp = (r_.nsMaxF1 - r_.nsMinF1) * s_.nThetaEff;
+  const int num_realsp = (r_.nsMaxF1 - r_.nsMinF1) * s_.nZnT;
 
   for (auto* v :
        {&r1_e, &r1_o, &ru_e, &ru_o, &z1_e, &z1_o, &zu_e, &zu_o, &lu_e, &lu_o}) {
     absl::c_fill_n(*v, num_realsp, 0);
   }
 
-  int num_con = (r_.nsMaxFIncludingLcfs - r_.nsMinF) * s_.nThetaEff;
+  int num_con = (r_.nsMaxFIncludingLcfs - r_.nsMinF) * s_.nZnT;
   absl::c_fill_n(rCon, num_con, 0);
   absl::c_fill_n(zCon, num_con, 0);
 
@@ -1254,17 +1254,21 @@ void IdealMhdModel::dft_FourierToReal_2d_symm(
         lnksc_m[m_parity] += src_lsc[m] * cosmum;
       }
 
-      const int idx_jl = (jF - r_.nsMinF1) * s_.nThetaEff + l;
-      r1_e[idx_jl] += rnkcc[kEvenParity];
-      ru_e[idx_jl] += rnkcc_m[kEvenParity];
-      z1_e[idx_jl] += znksc[kEvenParity];
-      zu_e[idx_jl] += znksc_m[kEvenParity];
-      lu_e[idx_jl] += lnksc_m[kEvenParity];
-      r1_o[idx_jl] += rnkcc[kOddParity];
-      ru_o[idx_jl] += rnkcc_m[kOddParity];
-      z1_o[idx_jl] += znksc[kOddParity];
-      zu_o[idx_jl] += znksc_m[kOddParity];
-      lu_o[idx_jl] += lnksc_m[kOddParity];
+      // ntor == 0: the same values go into every toroidal plane
+      for (int k = 0; k < s_.nZeta; ++k) {
+        const int idx_jkl =
+            ((jF - r_.nsMinF1) * s_.nZeta + k) * s_.nThetaEff + l;
+        r1_e[idx_jkl] += rnkcc[kEvenParity];
+        ru_e[idx_jkl] += rnkcc_m[kEvenParity];
+        z1_e[idx_jkl] += znksc[kEvenParity];
+        zu_e[idx_jkl] += znksc_m[kEvenParity];
+        lu_e[idx_jkl] += lnksc_m[kEvenParity];
+        r1_o[idx_jkl] += rnkcc[kOddParity];
+        ru_o[idx_jkl] += rnkcc_m[kOddParity];
+        z1_o[idx_jkl] += znksc[kOddParity];
+        zu_o[idx_jkl] += znksc_m[kOddParity];
+        lu_o[idx_jkl] += lnksc_m[kOddParity];
+      }  // k
     }  // l
   }  // j
 
@@ -1320,19 +1324,25 @@ void IdealMhdModel::dft_FourierToReal_2d_symm(
       const double scale =
           xmpq[m] * (1 - m_parity + m_parity * m_p_.sqrtSF[jF - r_.nsMinF1]);
 
-      for (int l = 0; l < s_.nThetaReduced; ++l) {
-        const int idx_ml = m * s_.nThetaReduced + l;
-        const double cosmu = t_.cosmu[idx_ml];
-        const int idx_con = (jF - r_.nsMinF) * s_.nThetaEff + l;
-        rCon[idx_con] += src_rcc[m] * cosmu * scale;
-      }  // l
+      for (int k = 0; k < s_.nZeta; ++k) {
+        for (int l = 0; l < s_.nThetaReduced; ++l) {
+          const int idx_ml = m * s_.nThetaReduced + l;
+          const double cosmu = t_.cosmu[idx_ml];
+          const int idx_con =
+              ((jF - r_.nsMinF) * s_.nZeta + k) * s_.nThetaEff + l;
+          rCon[idx_con] += src_rcc[m] * cosmu * scale;
+        }  // l
+      }  // k
 
-      for (int l = 0; l < s_.nThetaReduced; ++l) {
-        const int idx_ml = m * s_.nThetaReduced + l;
-        const double sinmu = t_.sinmu[idx_ml];
-        const int idx_con = (jF - r_.nsMinF) * s_.nThetaEff + l;
-        zCon[idx_con] += src_zsc[m] * sinmu * scale;
-      }  // l
+      for (int k = 0; k < s_.nZeta; ++k) {
+        for (int l = 0; l < s_.nThetaReduced; ++l) {
+          const int idx_ml = m * s_.nThetaReduced + l;
+          const double sinmu = t_.sinmu[idx_ml];
+          const int idx_con =
+              ((jF - r_.nsMinF) * s_.nZeta + k) * s_.nThetaEff + l;
+          zCon[idx_con] += src_zsc[m] * sinmu * scale;
+        }  // l
+      }  // k
     }  // m
   }  // jF
 }  // dft_FourierToReal_2d_symm
@@ -1344,14 +1354,14 @@ void IdealMhdModel::dft_FourierToReal_2d_symm(
 // the *_asym scratch arrays on the reduced poloidal interval [0, pi].
 void IdealMhdModel::dft_FourierToReal_2d_asymm(
     const FourierGeometry& physical_x) {
-  const int num_realsp = (r_.nsMaxF1 - r_.nsMinF1) * s_.nThetaEff;
+  const int num_realsp = (r_.nsMaxF1 - r_.nsMinF1) * s_.nZnT;
 
   for (auto* v : {&r1_asym_e, &r1_asym_o, &ru_asym_e, &ru_asym_o, &z1_asym_e,
                   &z1_asym_o, &zu_asym_e, &zu_asym_o, &lu_asym_e, &lu_asym_o}) {
     absl::c_fill_n(*v, num_realsp, 0);
   }
 
-  int num_con = (r_.nsMaxFIncludingLcfs - r_.nsMinF) * s_.nThetaEff;
+  int num_con = (r_.nsMaxFIncludingLcfs - r_.nsMinF) * s_.nZnT;
   absl::c_fill_n(rCon_asym, num_con, 0);
   absl::c_fill_n(zCon_asym, num_con, 0);
 
@@ -1402,17 +1412,21 @@ void IdealMhdModel::dft_FourierToReal_2d_asymm(
         lnkcc_m[m_parity] += src_lcc[m] * t_.sinmum[idx_ml];
       }
 
-      const int idx_jl = (jF - r_.nsMinF1) * s_.nThetaEff + l;
-      r1_asym_e[idx_jl] += rnksc[kEvenParity];
-      ru_asym_e[idx_jl] += rnksc_m[kEvenParity];
-      z1_asym_e[idx_jl] += znkcc[kEvenParity];
-      zu_asym_e[idx_jl] += znkcc_m[kEvenParity];
-      lu_asym_e[idx_jl] += lnkcc_m[kEvenParity];
-      r1_asym_o[idx_jl] += rnksc[kOddParity];
-      ru_asym_o[idx_jl] += rnksc_m[kOddParity];
-      z1_asym_o[idx_jl] += znkcc[kOddParity];
-      zu_asym_o[idx_jl] += znkcc_m[kOddParity];
-      lu_asym_o[idx_jl] += lnkcc_m[kOddParity];
+      // ntor == 0: the same values go into every toroidal plane
+      for (int k = 0; k < s_.nZeta; ++k) {
+        const int idx_jkl =
+            ((jF - r_.nsMinF1) * s_.nZeta + k) * s_.nThetaEff + l;
+        r1_asym_e[idx_jkl] += rnksc[kEvenParity];
+        ru_asym_e[idx_jkl] += rnksc_m[kEvenParity];
+        z1_asym_e[idx_jkl] += znkcc[kEvenParity];
+        zu_asym_e[idx_jkl] += znkcc_m[kEvenParity];
+        lu_asym_e[idx_jkl] += lnkcc_m[kEvenParity];
+        r1_asym_o[idx_jkl] += rnksc[kOddParity];
+        ru_asym_o[idx_jkl] += rnksc_m[kOddParity];
+        z1_asym_o[idx_jkl] += znkcc[kOddParity];
+        zu_asym_o[idx_jkl] += znkcc_m[kOddParity];
+        lu_asym_o[idx_jkl] += lnkcc_m[kOddParity];
+      }  // k
     }  // l
   }  // jF
 
@@ -1431,16 +1445,22 @@ void IdealMhdModel::dft_FourierToReal_2d_asymm(
       const double scale =
           xmpq[m] * (1 - m_parity + m_parity * m_p_.sqrtSF[jF - r_.nsMinF1]);
 
-      for (int l = 0; l < s_.nThetaReduced; ++l) {
-        const int idx_ml = m * s_.nThetaReduced + l;
-        const int idx_con = (jF - r_.nsMinF) * s_.nThetaEff + l;
-        rCon_asym[idx_con] += src_rsc[m] * t_.sinmu[idx_ml] * scale;
-      }  // l
-      for (int l = 0; l < s_.nThetaReduced; ++l) {
-        const int idx_ml = m * s_.nThetaReduced + l;
-        const int idx_con = (jF - r_.nsMinF) * s_.nThetaEff + l;
-        zCon_asym[idx_con] += src_zcc[m] * t_.cosmu[idx_ml] * scale;
-      }  // l
+      for (int k = 0; k < s_.nZeta; ++k) {
+        for (int l = 0; l < s_.nThetaReduced; ++l) {
+          const int idx_ml = m * s_.nThetaReduced + l;
+          const int idx_con =
+              ((jF - r_.nsMinF) * s_.nZeta + k) * s_.nThetaEff + l;
+          rCon_asym[idx_con] += src_rsc[m] * t_.sinmu[idx_ml] * scale;
+        }  // l
+      }  // k
+      for (int k = 0; k < s_.nZeta; ++k) {
+        for (int l = 0; l < s_.nThetaReduced; ++l) {
+          const int idx_ml = m * s_.nThetaReduced + l;
+          const int idx_con =
+              ((jF - r_.nsMinF) * s_.nZeta + k) * s_.nThetaEff + l;
+          zCon_asym[idx_con] += src_zcc[m] * t_.cosmu[idx_ml] * scale;
+        }  // l
+      }  // k
     }  // m
   }  // jF
 }  // dft_FourierToReal_2d_asymm
@@ -2777,20 +2797,23 @@ void IdealMhdModel::dft_ForcesToFourierTranspose_2d_symm(
       const int idx_jm = (jF - r_.nsMinF) * s_.mpol + m;
       const double fr = m_coeff_bar.frcc[idx_jm];
       const double fz = m_coeff_bar.fzsc[idx_jm];
-      for (int l = 0; l < s_.nThetaReduced; ++l) {
-        const int idx_jl = (jF - r_.nsMinF) * s_.nThetaEff + l;
-        const int idx_ml = m * s_.nThetaReduced + l;
-        const double cosmui = t_.cosmui[idx_ml];
-        const double sinmumi = t_.sinmumi[idx_ml];
-        const double sinmui = t_.sinmui[idx_ml];
-        const double cosmumi = t_.cosmumi[idx_ml];
-        armn[idx_jl] += fr * cosmui;
-        brmn[idx_jl] += fr * sinmumi;
-        frcon[idx_jl] += fr * xmpq[m] * cosmui;
-        azmn[idx_jl] += fz * sinmui;
-        bzmn[idx_jl] += fz * cosmumi;
-        fzcon[idx_jl] += fz * xmpq[m] * sinmui;
-      }  // l
+      for (int k = 0; k < s_.nZeta; ++k) {
+        for (int l = 0; l < s_.nThetaReduced; ++l) {
+          const int idx_jl =
+              ((jF - r_.nsMinF) * s_.nZeta + k) * s_.nThetaEff + l;
+          const int idx_ml = m * s_.nThetaReduced + l;
+          const double cosmui = t_.cosmui[idx_ml];
+          const double sinmumi = t_.sinmumi[idx_ml];
+          const double sinmui = t_.sinmui[idx_ml];
+          const double cosmumi = t_.cosmumi[idx_ml];
+          armn[idx_jl] += fr * cosmui;
+          brmn[idx_jl] += fr * sinmumi;
+          frcon[idx_jl] += fr * xmpq[m] * cosmui;
+          azmn[idx_jl] += fz * sinmui;
+          bzmn[idx_jl] += fz * cosmumi;
+          fzcon[idx_jl] += fz * xmpq[m] * sinmui;
+        }  // l
+      }  // k
     }  // m
   }  // jF
   for (int jF = std::max(1, r_.nsMinF); jF < r_.nsMaxFIncludingLcfs; ++jF) {
@@ -2799,11 +2822,14 @@ void IdealMhdModel::dft_ForcesToFourierTranspose_2d_symm(
       auto& blmn = m_even ? blmn_e : blmn_o;
       const int idx_jm = (jF - r_.nsMinF) * s_.mpol + m;
       const double fl = m_coeff_bar.flsc[idx_jm];
-      for (int l = 0; l < s_.nThetaReduced; ++l) {
-        const int idx_jl = (jF - r_.nsMinF) * s_.nThetaEff + l;
-        const double cosmumi = t_.cosmumi[m * s_.nThetaReduced + l];
-        blmn[idx_jl] += fl * cosmumi;
-      }  // l
+      for (int k = 0; k < s_.nZeta; ++k) {
+        for (int l = 0; l < s_.nThetaReduced; ++l) {
+          const int idx_jl =
+              ((jF - r_.nsMinF) * s_.nZeta + k) * s_.nThetaEff + l;
+          const double cosmumi = t_.cosmumi[m * s_.nThetaReduced + l];
+          blmn[idx_jl] += fl * cosmumi;
+        }  // l
+      }  // k
     }  // m
   }  // jF
 }
@@ -2818,27 +2844,30 @@ void IdealMhdModel::dft_FourierToRealTranspose_2d_symm(
     double* dst_rcc = &(m_coeff_bar_out.rmncc[(jF - r_.nsMinF1) * s_.mnsize]);
     double* dst_zsc = &(m_coeff_bar_out.zmnsc[(jF - r_.nsMinF1) * s_.mnsize]);
     double* dst_lsc = &(m_coeff_bar_out.lmnsc[(jF - r_.nsMinF1) * s_.mnsize]);
-    for (int l = 0; l < s_.nThetaReduced; ++l) {
-      const int idx_jl = (jF - r_.nsMinF1) * s_.nThetaEff + l;
-      const double r1eb = r1_e[idx_jl], rueb = ru_e[idx_jl],
-                   z1eb = z1_e[idx_jl], zueb = zu_e[idx_jl],
-                   lueb = lu_e[idx_jl];
-      const double r1ob = r1_o[idx_jl], ruob = ru_o[idx_jl],
-                   z1ob = z1_o[idx_jl], zuob = zu_o[idx_jl],
-                   luob = lu_o[idx_jl];
-      const int num_m = (jF == 0) ? 2 : s_.mpol;
-      for (int m = 0; m < num_m; ++m) {
-        const int p = m % 2;
-        const int idx_ml = m * s_.nThetaReduced + l;
-        const double cosmu = t_.cosmu[idx_ml];
-        const double sinmum = t_.sinmum[idx_ml];
-        const double sinmu = t_.sinmu[idx_ml];
-        const double cosmum = t_.cosmum[idx_ml];
-        dst_rcc[m] += (p ? r1ob : r1eb) * cosmu + (p ? ruob : rueb) * sinmum;
-        dst_zsc[m] += (p ? z1ob : z1eb) * sinmu + (p ? zuob : zueb) * cosmum;
-        dst_lsc[m] += (p ? luob : lueb) * cosmum;
-      }  // m
-    }  // l
+    for (int k = 0; k < s_.nZeta; ++k) {
+      for (int l = 0; l < s_.nThetaReduced; ++l) {
+        const int idx_jl =
+            ((jF - r_.nsMinF1) * s_.nZeta + k) * s_.nThetaEff + l;
+        const double r1eb = r1_e[idx_jl], rueb = ru_e[idx_jl],
+                     z1eb = z1_e[idx_jl], zueb = zu_e[idx_jl],
+                     lueb = lu_e[idx_jl];
+        const double r1ob = r1_o[idx_jl], ruob = ru_o[idx_jl],
+                     z1ob = z1_o[idx_jl], zuob = zu_o[idx_jl],
+                     luob = lu_o[idx_jl];
+        const int num_m = (jF == 0) ? 2 : s_.mpol;
+        for (int m = 0; m < num_m; ++m) {
+          const int p = m % 2;
+          const int idx_ml = m * s_.nThetaReduced + l;
+          const double cosmu = t_.cosmu[idx_ml];
+          const double sinmum = t_.sinmum[idx_ml];
+          const double sinmu = t_.sinmu[idx_ml];
+          const double cosmum = t_.cosmum[idx_ml];
+          dst_rcc[m] += (p ? r1ob : r1eb) * cosmu + (p ? ruob : rueb) * sinmum;
+          dst_zsc[m] += (p ? z1ob : z1eb) * sinmu + (p ? zuob : zueb) * cosmum;
+          dst_lsc[m] += (p ? luob : lueb) * cosmum;
+        }  // m
+      }  // l
+    }  // k
   }  // jF
   for (int jF = r_.nsMinF; jF < r_.nsMaxFIncludingLcfs; ++jF) {
     double* dst_rcc = &(m_coeff_bar_out.rmncc[(jF - r_.nsMinF1) * s_.mnsize]);
@@ -2847,12 +2876,15 @@ void IdealMhdModel::dft_FourierToRealTranspose_2d_symm(
     for (int m = 0; m < num_m; ++m) {
       const int p = m % 2;
       const double scale = xmpq[m] * (1 - p + p * m_p_.sqrtSF[jF - r_.nsMinF1]);
-      for (int l = 0; l < s_.nThetaReduced; ++l) {
-        const int idx_ml = m * s_.nThetaReduced + l;
-        const int idx_con = (jF - r_.nsMinF) * s_.nThetaEff + l;
-        dst_rcc[m] += rCon[idx_con] * t_.cosmu[idx_ml] * scale;
-        dst_zsc[m] += zCon[idx_con] * t_.sinmu[idx_ml] * scale;
-      }  // l
+      for (int k = 0; k < s_.nZeta; ++k) {
+        for (int l = 0; l < s_.nThetaReduced; ++l) {
+          const int idx_ml = m * s_.nThetaReduced + l;
+          const int idx_con =
+              ((jF - r_.nsMinF) * s_.nZeta + k) * s_.nThetaEff + l;
+          dst_rcc[m] += rCon[idx_con] * t_.cosmu[idx_ml] * scale;
+          dst_zsc[m] += zCon[idx_con] * t_.sinmu[idx_ml] * scale;
+        }  // l
+      }  // k
     }  // m
   }  // jF
 }
@@ -3347,7 +3379,7 @@ void IdealMhdModel::dft_ForcesToFourier_3d_asymm(FourierForces& m_physical_f) {
 }
 
 void IdealMhdModel::dft_ForcesToFourier_2d_symm(FourierForces& m_physical_f) {
-  // in here, we can safely assume lthreed == false
+  // ntor == 0: no toroidal modes, but nZeta may exceed 1
 
   // fill target force arrays with zeros
   m_physical_f.setZero();
@@ -3385,30 +3417,33 @@ void IdealMhdModel::dft_ForcesToFourier_2d_symm(FourierForces& m_physical_f) {
       const auto& frcon = m_even ? frcon_e : frcon_o;
       const auto& fzcon = m_even ? fzcon_e : fzcon_o;
 
-      for (int l = 0; l < s_.nThetaReduced; ++l) {
-        const int idx_jl = (jF - r_.nsMinF) * s_.nThetaEff + l;
+      for (int k = 0; k < s_.nZeta; ++k) {
+        for (int l = 0; l < s_.nThetaReduced; ++l) {
+          const int idx_jl =
+              ((jF - r_.nsMinF) * s_.nZeta + k) * s_.nThetaEff + l;
 
-        const double rnkcc = armn[idx_jl];
-        const double rnkcc_m = brmn[idx_jl];
-        const double znksc = azmn[idx_jl];
-        const double znksc_m = bzmn[idx_jl];
+          const double rnkcc = armn[idx_jl];
+          const double rnkcc_m = brmn[idx_jl];
+          const double znksc = azmn[idx_jl];
+          const double znksc_m = bzmn[idx_jl];
 
-        const double rcon_cc = frcon[idx_jl];
-        const double zcon_sc = fzcon[idx_jl];
+          const double rcon_cc = frcon[idx_jl];
+          const double zcon_sc = fzcon[idx_jl];
 
-        const int idx_ml = m * s_.nThetaReduced + l;
-        const double cosmui = t_.cosmui[idx_ml];
-        const double sinmumi = t_.sinmumi[idx_ml];
-        const double sinmui = t_.sinmui[idx_ml];
-        const double cosmumi = t_.cosmumi[idx_ml];
-        // assemble effective R and Z forces from MHD and spectral condensation
-        // contributions
-        const double _rcc = rnkcc + xmpq[m] * rcon_cc;
-        m_physical_f.frcc[idx_jm] += _rcc * cosmui + rnkcc_m * sinmumi;
+          const int idx_ml = m * s_.nThetaReduced + l;
+          const double cosmui = t_.cosmui[idx_ml];
+          const double sinmumi = t_.sinmumi[idx_ml];
+          const double sinmui = t_.sinmui[idx_ml];
+          const double cosmumi = t_.cosmumi[idx_ml];
+          // assemble effective R and Z forces from MHD and spectral
+          // condensation contributions
+          const double _rcc = rnkcc + xmpq[m] * rcon_cc;
+          m_physical_f.frcc[idx_jm] += _rcc * cosmui + rnkcc_m * sinmumi;
 
-        const double _zsc = znksc + xmpq[m] * zcon_sc;
-        m_physical_f.fzsc[idx_jm] += _zsc * sinmui + znksc_m * cosmumi;
-      }  // m
+          const double _zsc = znksc + xmpq[m] * zcon_sc;
+          m_physical_f.fzsc[idx_jm] += _zsc * sinmui + znksc_m * cosmumi;
+        }  // l
+      }  // k
     }  // l
   }  // jF
 
@@ -3422,13 +3457,16 @@ void IdealMhdModel::dft_ForcesToFourier_2d_symm(FourierForces& m_physical_f) {
       const auto& blmn = m_even ? blmn_e : blmn_o;
       const int idx_jm = (jF - r_.nsMinF) * s_.mpol + m;
 
-      for (int l = 0; l < s_.nThetaReduced; ++l) {
-        const int idx_jl = (jF - r_.nsMinF) * s_.nThetaEff + l;
-        const double lnksc_m = blmn[idx_jl];
+      for (int k = 0; k < s_.nZeta; ++k) {
+        for (int l = 0; l < s_.nThetaReduced; ++l) {
+          const int idx_jl =
+              ((jF - r_.nsMinF) * s_.nZeta + k) * s_.nThetaEff + l;
+          const double lnksc_m = blmn[idx_jl];
 
-        const double cosmumi = t_.cosmumi[m * s_.nThetaReduced + l];
-        m_physical_f.flsc[idx_jm] += lnksc_m * cosmumi;
-      }  // m
+          const double cosmumi = t_.cosmumi[m * s_.nThetaReduced + l];
+          m_physical_f.flsc[idx_jm] += lnksc_m * cosmumi;
+        }  // l
+      }  // k
     }  // l
   }  // jF
 }  // dft_ForcesToFourier_2d_symm
@@ -3534,28 +3572,31 @@ void IdealMhdModel::dft_ForcesToFourier_2d_asymm(FourierForces& m_physical_f) {
       const auto& frcon = m_even ? frcon_asym_e : frcon_asym_o;
       const auto& fzcon = m_even ? fzcon_asym_e : fzcon_asym_o;
 
-      for (int l = 0; l < s_.nThetaReduced; ++l) {
-        const int idx_jl = (jF - r_.nsMinF) * s_.nThetaEff + l;
+      for (int k = 0; k < s_.nZeta; ++k) {
+        for (int l = 0; l < s_.nThetaReduced; ++l) {
+          const int idx_jl =
+              ((jF - r_.nsMinF) * s_.nZeta + k) * s_.nThetaEff + l;
 
-        const double rnksc = armn[idx_jl];
-        const double rnksc_m = brmn[idx_jl];
-        const double znkcc = azmn[idx_jl];
-        const double znkcc_m = bzmn[idx_jl];
-        const double rcon_sc = frcon[idx_jl];
-        const double zcon_cc = fzcon[idx_jl];
+          const double rnksc = armn[idx_jl];
+          const double rnksc_m = brmn[idx_jl];
+          const double znkcc = azmn[idx_jl];
+          const double znkcc_m = bzmn[idx_jl];
+          const double rcon_sc = frcon[idx_jl];
+          const double zcon_cc = fzcon[idx_jl];
 
-        const int idx_ml = m * s_.nThetaReduced + l;
-        const double cosmui = t_.cosmui[idx_ml];
-        const double sinmui = t_.sinmui[idx_ml];
-        const double cosmumi = t_.cosmumi[idx_ml];
-        const double sinmumi = t_.sinmumi[idx_ml];
+          const int idx_ml = m * s_.nThetaReduced + l;
+          const double cosmui = t_.cosmui[idx_ml];
+          const double sinmui = t_.sinmui[idx_ml];
+          const double cosmumi = t_.cosmumi[idx_ml];
+          const double sinmumi = t_.sinmumi[idx_ml];
 
-        const double _rsc = rnksc + xmpq[m] * rcon_sc;
-        m_physical_f.frsc[idx_jm] += _rsc * sinmui + rnksc_m * cosmumi;
+          const double _rsc = rnksc + xmpq[m] * rcon_sc;
+          m_physical_f.frsc[idx_jm] += _rsc * sinmui + rnksc_m * cosmumi;
 
-        const double _zcc = znkcc + xmpq[m] * zcon_cc;
-        m_physical_f.fzcc[idx_jm] += _zcc * cosmui + znkcc_m * sinmumi;
-      }  // l
+          const double _zcc = znkcc + xmpq[m] * zcon_cc;
+          m_physical_f.fzcc[idx_jm] += _zcc * cosmui + znkcc_m * sinmumi;
+        }  // l
+      }  // k
     }  // m
   }  // jF
 
@@ -3566,13 +3607,16 @@ void IdealMhdModel::dft_ForcesToFourier_2d_asymm(FourierForces& m_physical_f) {
       const auto& blmn = m_even ? blmn_asym_e : blmn_asym_o;
       const int idx_jm = (jF - r_.nsMinF) * s_.mpol + m;
 
-      for (int l = 0; l < s_.nThetaReduced; ++l) {
-        const int idx_jl = (jF - r_.nsMinF) * s_.nThetaEff + l;
-        const double lnkcc_m = blmn[idx_jl];
+      for (int k = 0; k < s_.nZeta; ++k) {
+        for (int l = 0; l < s_.nThetaReduced; ++l) {
+          const int idx_jl =
+              ((jF - r_.nsMinF) * s_.nZeta + k) * s_.nThetaEff + l;
+          const double lnkcc_m = blmn[idx_jl];
 
-        const double sinmumi = t_.sinmumi[m * s_.nThetaReduced + l];
-        m_physical_f.flcc[idx_jm] += lnkcc_m * sinmumi;
-      }  // l
+          const double sinmumi = t_.sinmumi[m * s_.nThetaReduced + l];
+          m_physical_f.flcc[idx_jm] += lnkcc_m * sinmumi;
+        }  // l
+      }  // k
     }  // m
   }  // jF
 }  // dft_ForcesToFourier_2d_asymm

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -4096,9 +4096,9 @@ vmecpp::ComputeThreed1GeometricMagneticQuantities(
   }  // jH
 
   // Compute Waist thickness and height in \f$\varphi = 0, \pi\f$ symmetry
-  // planes.
+  // planes; the second plane exists only on a toroidal grid.
   int symmetry_planes_count = 1;
-  if (s.ntor > 0) {
+  if (s.nZeta > 1) {
     symmetry_planes_count = 2;
   }
   result.waist = VectorXd::Zero(symmetry_planes_count);

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities_test.cc
@@ -582,10 +582,10 @@ TEST_P(Threed1HeightTest, HeightIsTwiceTheLargestAbsoluteZ) {
   const Threed1GeometricAndMagneticQuantities& geomag =
       vmec.output_quantities_.threed1_geometric_magnetic;
 
-  // The reported planes are zeta = 0 and, for a three-dimensional case, the
-  // plane at toroidal index nZeta / 2.
+  // The reported planes are zeta = 0 and, on a toroidal grid, the plane at
+  // toroidal index nZeta / 2.
   std::vector<int> plane_indices = {0};
-  if (s.ntor > 0) {
+  if (s.nZeta > 1) {
     plane_indices.push_back(s.nZeta / 2);
   }
   ASSERT_EQ(geomag.height.size(), static_cast<int>(plane_indices.size()));

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
@@ -360,6 +360,75 @@ void CheckPrescribedIotaProfile(const vmecpp::WOutFileContents& w,
 
 }  // namespace
 
+// A run without toroidal modes gives the same equilibrium on a toroidal grid
+// as on a single plane: the 2D transforms fill and sum every plane, as totzsps
+// and tomnsps do for nzeta > 1 with ntor = 0.
+TEST(TestVmec, AxisymmetricRunIsIndependentOfNzeta) {
+  struct Case {
+    std::string filename;
+    int nzeta;
+  };
+  for (const Case& c : {Case{"vmecpp/test_data/solovev.json", 8},
+                        Case{"vmecpp/test_data/up_down_asym.json", 6}}) {
+    absl::StatusOr<std::string> indata_json = ReadFile(c.filename);
+    ASSERT_TRUE(indata_json.ok());
+    absl::StatusOr<VmecINDATA> indata = VmecINDATA::FromJson(*indata_json);
+    ASSERT_TRUE(indata.ok());
+    ASSERT_EQ(indata->ntor, 0);
+
+    const auto single_plane = vmecpp::run(*indata);
+    ASSERT_TRUE(single_plane.ok()) << c.filename;
+
+    VmecINDATA indata_planes = *indata;
+    indata_planes.nzeta = c.nzeta;
+    const auto planes = vmecpp::run(indata_planes);
+    ASSERT_TRUE(planes.ok()) << c.filename << ": " << planes.status();
+
+    const auto& a = single_plane->wout;
+    const auto& b = planes->wout;
+
+    // The sum over identical planes changes the round-off, which the descent
+    // carries into lambda at the 1e-9 level.
+    const double kTol = 1.0e-8;
+    auto rel_max = [](const auto& x, const auto& y) -> double {
+      const double peak = x.cwiseAbs().maxCoeff();
+      return (x - y).cwiseAbs().maxCoeff() / (peak > 0.0 ? peak : 1.0);
+    };
+    EXPECT_TRUE(IsCloseRelAbs(a.wb, b.wb, kTol)) << c.filename;
+    EXPECT_TRUE(IsCloseRelAbs(a.volume, b.volume, kTol)) << c.filename;
+    EXPECT_LT(rel_max(a.rmnc, b.rmnc), kTol) << c.filename;
+    EXPECT_LT(rel_max(a.zmns, b.zmns), kTol) << c.filename;
+    EXPECT_LT(rel_max(a.lmns_full, b.lmns_full), kTol) << c.filename;
+    EXPECT_LT(rel_max(a.iotaf, b.iotaf), kTol) << c.filename;
+    EXPECT_LT(rel_max(a.jcurv, b.jcurv), kTol) << c.filename;
+    if (indata->lasym) {
+      EXPECT_LT(rel_max(a.rmns, b.rmns), kTol) << c.filename;
+      EXPECT_LT(rel_max(a.zmnc, b.zmnc), kTol) << c.filename;
+      EXPECT_LT(rel_max(a.lmnc_full, b.lmnc_full), kTol) << c.filename;
+    }
+
+    // The Nyquist spectrum grows with nzeta: its n = 0 rows follow the
+    // single-plane spectrum in order, and the other rows stay at zero.
+    const double b_peak = a.bmnc.cwiseAbs().maxCoeff();
+    int mn_single = 0;
+    for (int mn = 0; mn < b.mnmax_nyq; ++mn) {
+      if (b.xn_nyq[mn] != 0) {
+        EXPECT_LT(b.bmnc.row(mn).cwiseAbs().maxCoeff() / b_peak, kTol)
+            << c.filename;
+        continue;
+      }
+      ASSERT_LT(mn_single, a.mnmax_nyq);
+      ASSERT_EQ(b.xm_nyq[mn], a.xm_nyq[mn_single]);
+      EXPECT_LT((a.bmnc.row(mn_single) - b.bmnc.row(mn)).cwiseAbs().maxCoeff() /
+                    b_peak,
+                kTol)
+          << c.filename;
+      mn_single++;
+    }
+    EXPECT_EQ(mn_single, a.mnmax_nyq);
+  }
+}
+
 // lasym = F, lthreed = T, ncurr = 0, lfreeb = F.
 // Every other three-dimensional case in the suite constrains the current, so
 // this is the only place the constrained-iota path runs in 3D.


### PR DESCRIPTION
An axisymmetric input with `nzeta > 1` aborted in the first iterations. The 2D transforms in `ideal_mhd_model.cc` wrote and read one toroidal plane per surface while the real-space arrays, the metric, the forces and the integration weights span all `nzeta` planes, so the geometry past the first plane stayed at zero and the forward transform, whose weights carry `1/nzeta`, returned the Fourier forces at `1/nzeta` of their value. Fortran VMEC accepts the input (`read_indata.f` sets `nzeta = 1` only when it is absent), and `totzsps` and `tomnsps` loop over every plane.

The six 2D routines now fill every plane in the inverse direction and sum every plane in the forward direction, with the index formula of the 3D transforms; the two autodiff transposes get the transposed treatment. The threed1 waist and height are reported for both symmetry planes whenever the grid has more than one, as the cross-section table below them already does; their vectors were sized by `ntor` and overflowed on this input.

`solovev` at `nzeta` 1, 7 and 8 and `up_down_asym` at `nzeta` 1 and 6 converge in the same number of iterations to the same equilibrium, within 4e-13 in the geometry and 2e-9 in lambda, with the added Nyquist rows at zero. The new test holds both cases to 1e-8 and fails on the previous transforms, where the multi-plane run aborts. `solovev_free_bdy` on the shipped mgrid replicated to eight planes agrees with educational_VMEC on the same file and `NZETA = 8` to 1.7e-6 in `rmnc` and 1e-16 in `iotaf`; both codes place that equilibrium 1.4 per cent from the single-plane one, since `nvper` drops from 64 images to `nfp` on a toroidal grid.

`bazel test --config=opt //vmecpp/...` passes, as do the large ideal_mhd_model, vmec, output_quantities and hot-restart suites and `tests/test_init.py`, `tests/test_lasym.py` and `tests/test_free_boundary.py`.
