### PR TITLE
Take indata2json at the commit that keeps a trailing zero spline value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   indata2json
   GIT_REPOSITORY https://github.com/jonathanschilling/indata2json.git
-  GIT_TAG f59e3ddd66486b63536f141a786d39c23d654c77
+  GIT_TAG df7e911bb5badef1e071252f85cd1f9bf3b6c4f7
   GIT_SHALLOW TRUE
 )
 FetchContent_Declare(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -637,6 +637,18 @@ def test_ensure_vmec2000_input_keeps_axis():
         np.testing.assert_allclose(
             getattr(round_trip, name), getattr(reference, name), rtol=1e-15, atol=0
         )
+def test_ensure_vmecpp_input_keeps_trailing_zero_spline_value():
+    # a spline profile whose last value is exactly zero keeps all its knots
+    vmec2000_input_file = TEST_DATA_DIR / "input.cth_like_fixed_bdy_spline_pressure"
+    vmec_input = vmecpp.VmecInput.from_file(vmec2000_input_file)
+    reference = vmecpp.VmecInput.from_file(
+        TEST_DATA_DIR / "cth_like_fixed_bdy_spline_pressure.json"
+    )
+    assert len(vmec_input.am_aux_f) == len(vmec_input.am_aux_s) == 201
+    np.testing.assert_array_equal(vmec_input.am_aux_s, reference.am_aux_s)
+    np.testing.assert_allclose(
+        vmec_input.am_aux_f, reference.am_aux_f, rtol=1e-12, atol=0
+    )
 
 
 def test_ensure_vmecpp_input_noop():

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -637,6 +637,8 @@ def test_ensure_vmec2000_input_keeps_axis():
         np.testing.assert_allclose(
             getattr(round_trip, name), getattr(reference, name), rtol=1e-15, atol=0
         )
+
+
 def test_ensure_vmecpp_input_keeps_trailing_zero_spline_value():
     # a spline profile whose last value is exactly zero keeps all its knots
     vmec2000_input_file = TEST_DATA_DIR / "input.cth_like_fixed_bdy_spline_pressure"


### PR DESCRIPTION
**Change** - the `indata2json` pin moves from `f59e3dd` to `df7e911`, the commit of jonathanschilling/indata2json#12, which sizes both arrays of a spline pair from the knot array.

**Cause** - at `f59e3dd` the converter trimmed the trailing zeros of `am_aux_f`, `ai_aux_f` and `ac_aux_f` independently of their knot arrays. An INDATA file whose spline profile ends at exactly zero, the ordinary case for a pressure or current profile, converted to a JSON with one value fewer than knots, and `VmecINDATA::FromJson` rejected it.

**Evidence** - the shipped `input.cth_like_fixed_bdy_spline_pressure` could not be loaded through `VmecInput.from_file`; at the new pin it loads with all 201 knots and values.

**Tests** - `test_ensure_vmecpp_input_keeps_trailing_zero_spline_value` in `tests/test_init.py` loads the shipped spline INDATA and requires 201 knots and values equal to the shipped JSON; it fails at the previous pin.

**Scope** - the INDATA conversion only; JSON inputs do not pass through `indata2json`.
