### PR TITLE
Write the magnetic axis guess when converting a VMEC++ JSON to INDATA

### DIFF
--- a/src/vmecpp/_util.py
+++ b/src/vmecpp/_util.py
@@ -229,10 +229,10 @@ def vmecpp_json_to_indata(vmecpp_json: dict[str, Any]) -> str:
     indata += _int_to_namelist("nvacskip", vmecpp_json)
 
     indata += "\n  ! initial guess for magnetic axis\n"
-    indata += _float_array_to_namelist("raxis_cc", vmecpp_json)
-    indata += _float_array_to_namelist("zaxis_cs", vmecpp_json)
-    indata += _float_array_to_namelist("raxis_cs", vmecpp_json)
-    indata += _float_array_to_namelist("zaxis_cc", vmecpp_json)
+    indata += _float_array_to_namelist("raxis_c", vmecpp_json, namelist_name="raxis_cc")
+    indata += _float_array_to_namelist("zaxis_s", vmecpp_json, namelist_name="zaxis_cs")
+    indata += _float_array_to_namelist("raxis_s", vmecpp_json, namelist_name="raxis_cs")
+    indata += _float_array_to_namelist("zaxis_c", vmecpp_json, namelist_name="zaxis_cc")
 
     indata += "\n  ! (initial guess for) boundary shape\n"
     indata += _fourier_coefficients_to_namelist("rbc", vmecpp_json)
@@ -284,14 +284,16 @@ def _int_array_to_namelist(varname: str, vmecpp_json: dict[str, Any]) -> str:
     return ""
 
 
-def _float_array_to_namelist(varname: str, vmecpp_json: dict[str, Any]) -> str:
+def _float_array_to_namelist(
+    varname: str, vmecpp_json: dict[str, Any], namelist_name: str | None = None
+) -> str:
     if (
         varname in vmecpp_json
         and vmecpp_json[varname] is not None
         and len(vmecpp_json[varname]) > 0
     ):
         elements = ", ".join([f"{x:.20e}" for x in vmecpp_json[varname]])
-        return f"  {varname} = {elements}\n"
+        return f"  {namelist_name or varname} = {elements}\n"
     return ""
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -615,6 +615,26 @@ def test_ensure_vmec2000_input_with_null():
             assert "rbc" in indata_namelist, indata_namelist
 
 
+def test_ensure_vmec2000_input_keeps_axis():
+    # the JSON axis keys differ from the namelist names
+    reference = vmecpp.VmecInput.from_file(
+        TEST_DATA_DIR / "cth_like_fixed_bdy_asym.json"
+    )
+    assert reference.raxis_s is not None
+    assert reference.zaxis_c is not None
+    reference.raxis_s[1] = 1.0e-3
+    reference.zaxis_c[0] = -2.0e-3
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        vmecpp_input_file = Path(tmp_dir) / "axis.json"
+        reference.save(vmecpp_input_file)
+        with vmecpp.ensure_vmec2000_input(vmecpp_input_file) as indata_file:
+            round_trip = vmecpp.VmecInput.from_file(indata_file)
+    for name in ("raxis_c", "zaxis_s", "raxis_s", "zaxis_c"):
+        np.testing.assert_allclose(
+            getattr(round_trip, name), getattr(reference, name), rtol=1e-15, atol=0
+        )
+
+
 def test_ensure_vmecpp_input_noop():
     vmecpp_input_file = TEST_DATA_DIR / "cma.json"
 


### PR DESCRIPTION
`vmecpp_json_to_indata` looked the axis arrays up under the namelist names `raxis_cc`, `zaxis_cs`, `raxis_cs` and `zaxis_cc`, while a VMEC++ JSON carries them as `raxis_c`, `zaxis_s`, `raxis_s` and `zaxis_c`, so every INDATA file written from a VMEC++ input left the axis guess out and Fortran VMEC started from its own. On `cth_like_fixed_bdy` at ftol 1e-11 that moves the converged poloidal gauge by 4.5e-4 in `rmnc` and 2.4e-2 in `lmns`, the shift VMEC++ itself shows between runs from the two guesses; an input whose initial Jacobian depends on the supplied axis fails outright in the Fortran run.

The converter now writes the four arrays under their namelist names. The new test round-trips an asymmetric input with non-zero `raxis_s` and `zaxis_c` through INDATA and requires all four axis arrays back; it fails on the previous converter.

`tests/test_init.py` passes.
