### PR TITLE
Keep the full vacuum update every iteration until the free-boundary residuals settle

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/util/util.h
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.h
@@ -204,9 +204,13 @@ enum class VacuumPressureState : std::int8_t {
   // process of reducing rCon0,zCon0 *= 0.9;
   kInitialized = 1,
 
-  // vacuum pressure turned on
-  // in the process of reducing rCon0,zCon0 *= 0.9;
-  kActive = 2
+  // vacuum pressure turned on, R and Z force residuals still above 1e-3
+  // full vacuum update in every iteration; ivac == 2 in VMEC 8.52
+  kActive = 2,
+
+  // vacuum pressure turned on, R and Z force residuals below 1e-3
+  // vacuum update every nvacskip iterations; ivac > 2 in VMEC 8.52
+  kSettled = 3
 };
 
 int VmecStatusCode(const VmecStatus vmec_status);

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/dft_toroidal.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/dft_toroidal.cc
@@ -24,9 +24,7 @@ void ForcesToFourier3DSymmFastPoloidal(
 
   int jMaxRZ = std::min(rp.nsMaxF, fc.ns - 1);
 
-  if (fc.lfreeb &&
-      (vacuum_pressure_state == VacuumPressureState::kInitialized ||
-       vacuum_pressure_state == VacuumPressureState::kActive)) {
+  if (fc.lfreeb && vacuum_pressure_state >= VacuumPressureState::kInitialized) {
     // free-boundary: up to jMaxRZ=ns
     jMaxRZ = std::min(rp.nsMaxF, fc.ns);
   }
@@ -500,9 +498,7 @@ void ForcesToFourier3DAsymFastPoloidal(
   // can safely assume lthreed == true in here
 
   int jMaxRZ = std::min(rp.nsMaxF, fc.ns - 1);
-  if (fc.lfreeb &&
-      (vacuum_pressure_state == VacuumPressureState::kInitialized ||
-       vacuum_pressure_state == VacuumPressureState::kActive)) {
+  if (fc.lfreeb && vacuum_pressure_state >= VacuumPressureState::kInitialized) {
     jMaxRZ = std::min(rp.nsMaxF, fc.ns);
   }
 

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/fft_toroidal.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/fft_toroidal.cc
@@ -383,9 +383,7 @@ void ForcesToFourier3DSymmFastPoloidalFft(
   m_physical_forces.setZero();
 
   int jMaxRZ = std::min(rp.nsMaxF, fc.ns - 1);
-  if (fc.lfreeb &&
-      (vacuum_pressure_state == VacuumPressureState::kInitialized ||
-       vacuum_pressure_state == VacuumPressureState::kActive)) {
+  if (fc.lfreeb && vacuum_pressure_state >= VacuumPressureState::kInitialized) {
     jMaxRZ = std::min(rp.nsMaxF, fc.ns);
   }
 

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -640,8 +640,8 @@ absl::StatusOr<bool> IdealMhdModel::update(
   // end of bcovar
 
   // back in funct3d, free-boundary force contribution active?
-  // This can even happen in the first iteration when hot-restarted.
-  if (m_fc_.lfreeb && (iter2 > 1 || m_vacuum_pressure_state_ ==
+  // in the first iteration only when the vacuum pressure is already on
+  if (m_fc_.lfreeb && (iter2 > 1 || m_vacuum_pressure_state_ >=
                                         VacuumPressureState::kInitialized)) {
 // protect read of m_vacuum_pressure_state_ below from write above
 #ifdef _OPENMP
@@ -650,22 +650,25 @@ absl::StatusOr<bool> IdealMhdModel::update(
 
     ivacskip = (iter2 - iter1) % nvacskip;
     // when R+Z force residuals are <1e-3, enable vacuum contribution
-    if (m_vacuum_pressure_state_ != VacuumPressureState::kActive &&
+    if (m_vacuum_pressure_state_ != VacuumPressureState::kSettled &&
         m_fc_.fsqr + m_fc_.fsqz < 1.0e-3) {
-// protect read of m_vacuum_pressure_state_ below from write above
+// protect read of m_vacuum_pressure_state_ in the condition above from the
+// write below
 #ifdef _OPENMP
 #pragma omp barrier
 #endif  // _OPENMP
 
-      // vacuum pressure not fully turned on yet
-      // Do full vacuum calc on every iteration
-      ivacskip = 0;
 #ifdef _OPENMP
 #pragma omp single
 #endif  // _OPENMP
-      // Increment ivac, never exceeding VacuumPressureState::kActive
+      // Increment ivac, never exceeding VacuumPressureState::kSettled
       m_vacuum_pressure_state_ = static_cast<VacuumPressureState>(
           static_cast<int>(m_vacuum_pressure_state_) + 1);
+    }
+
+    // full vacuum calc on every iteration until the residuals have settled
+    if (m_vacuum_pressure_state_ <= VacuumPressureState::kActive) {
+      ivacskip = 0;
     }
 
     // EXTEND NVACSKIP AS EQUILIBRIUM CONVERGES
@@ -2508,8 +2511,7 @@ void IdealMhdModel::assembleTotalForces() {
 
   // free-boundary contribution: include force on boundary from NESTOR
   if (m_fc_.lfreeb &&
-      (m_vacuum_pressure_state_ == VacuumPressureState::kInitialized ||
-       m_vacuum_pressure_state_ == VacuumPressureState::kActive) &&
+      m_vacuum_pressure_state_ >= VacuumPressureState::kInitialized &&
       r_.nsMaxF1 == m_fc_.ns) {
     for (int kl = 0; kl < s_.nZnT; ++kl) {
       int idx_kl = (r_.nsMaxF - 1 - r_.nsMinF) * s_.nZnT + kl;
@@ -2752,8 +2754,7 @@ void IdealMhdModel::dft_ForcesToFourierTranspose_2d_symm(
   }
   int jMaxRZ = std::min(r_.nsMaxF, m_fc_.ns - 1);
   if (m_fc_.lfreeb &&
-      (m_vacuum_pressure_state_ == VacuumPressureState::kInitialized ||
-       m_vacuum_pressure_state_ == VacuumPressureState::kActive)) {
+      m_vacuum_pressure_state_ >= VacuumPressureState::kInitialized) {
     jMaxRZ = std::min(r_.nsMaxF, m_fc_.ns);
   }
   for (int jF = r_.nsMinF; jF < jMaxRZ; ++jF) {
@@ -2876,8 +2877,7 @@ void IdealMhdModel::dft_ForcesToFourierTranspose_3d_symm(
   const int ntorp1 = s_.ntor + 1;
   int jMaxRZ = std::min(r_.nsMaxF, m_fc_.ns - 1);
   if (m_fc_.lfreeb &&
-      (m_vacuum_pressure_state_ == VacuumPressureState::kInitialized ||
-       m_vacuum_pressure_state_ == VacuumPressureState::kActive)) {
+      m_vacuum_pressure_state_ >= VacuumPressureState::kInitialized) {
     jMaxRZ = std::min(r_.nsMaxF, m_fc_.ns);
   }
   const int jMinL = 1;
@@ -3362,8 +3362,7 @@ void IdealMhdModel::dft_ForcesToFourier_2d_symm(FourierForces& m_physical_f) {
 
   int jMaxRZ = std::min(r_.nsMaxF, m_fc_.ns - 1);
   if (m_fc_.lfreeb &&
-      (m_vacuum_pressure_state_ == VacuumPressureState::kInitialized ||
-       m_vacuum_pressure_state_ == VacuumPressureState::kActive)) {
+      m_vacuum_pressure_state_ >= VacuumPressureState::kInitialized) {
     // free-boundary: up to jMaxRZ=ns
     jMaxRZ = std::min(r_.nsMaxF, m_fc_.ns);
   }
@@ -3522,8 +3521,7 @@ void IdealMhdModel::symforce() {
 void IdealMhdModel::dft_ForcesToFourier_2d_asymm(FourierForces& m_physical_f) {
   int jMaxRZ = std::min(r_.nsMaxF, m_fc_.ns - 1);
   if (m_fc_.lfreeb &&
-      (m_vacuum_pressure_state_ == VacuumPressureState::kInitialized ||
-       m_vacuum_pressure_state_ == VacuumPressureState::kActive)) {
+      m_vacuum_pressure_state_ >= VacuumPressureState::kInitialized) {
     jMaxRZ = std::min(r_.nsMaxF, m_fc_.ns);
   }
 
@@ -3652,8 +3650,7 @@ void IdealMhdModel::assembleRZPreconditioner() {
 
   int jMax = m_fc_.ns - 1;
   if (m_fc_.lfreeb &&
-      (m_vacuum_pressure_state_ == VacuumPressureState::kInitialized ||
-       m_vacuum_pressure_state_ == VacuumPressureState::kActive)) {
+      m_vacuum_pressure_state_ >= VacuumPressureState::kInitialized) {
     jMax = m_fc_.ns;
   }
 
@@ -3818,8 +3815,7 @@ absl::Status IdealMhdModel::applyRZPreconditioner(
 
   int jMax = m_fc_.ns - 1;
   if (m_fc_.lfreeb &&
-      (m_vacuum_pressure_state_ == VacuumPressureState::kInitialized ||
-       m_vacuum_pressure_state_ == VacuumPressureState::kActive)) {
+      m_vacuum_pressure_state_ >= VacuumPressureState::kInitialized) {
     jMax = m_fc_.ns;
   }
 
@@ -3975,7 +3971,7 @@ void IdealMhdModel::applyLambdaPreconditioner(FourierForces& m_decomposed_f) {
 double IdealMhdModel::get_delbsq() const {
   double delBSqAvg = 0.0;
   if (m_fc_.lfreeb &&
-      m_vacuum_pressure_state_ == VacuumPressureState::kActive) {
+      m_vacuum_pressure_state_ >= VacuumPressureState::kActive) {
     double delBSqNorm = 0.0;
     for (int kl = 0; kl < s_.nZnT; ++kl) {
       int l = kl % s_.nThetaEff;

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -3875,7 +3875,7 @@ vmecpp::ComputeIntermediateThreed1GeometricMagneticQuantities(
     intermediate.redge[kl] =
         vmec_internal_results.r_e(lcfs_kl) + vmec_internal_results.r_o(lcfs_kl);
   }  // kl
-  if (fc.lfreeb && vacuum_pressure_state == VacuumPressureState::kActive) {
+  if (fc.lfreeb && vacuum_pressure_state >= VacuumPressureState::kActive) {
     for (int k = 0; k < s.nZeta; ++k) {
       for (int l = 0; l < s.nThetaEff; ++l) {
         // FIXME(eguiraud) slow loop for nestor
@@ -4428,7 +4428,7 @@ vmecpp::Threed1ShafranovIntegrals vmecpp::ComputeThreed1ShafranovIntegrals(
   // Phys. Fluids B, Vol 5 (1993) p 3121, Eq. 9a-9d
   std::vector<double> bpol2vac(s.nZnT, 0.0);
   if (fc.lfreeb &&
-      vacuum_pressure_state == vmecpp::VacuumPressureState::kActive) {
+      vacuum_pressure_state >= vmecpp::VacuumPressureState::kActive) {
     for (int l = 0; l < s.nThetaEff; ++l) {
       for (int k = 0; k < s.nZeta; ++k) {
         // FIXME(eguiraud) slow loop for nestor

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/BUILD.bazel
@@ -43,6 +43,7 @@ cc_test(
         "//vmecpp/test_data:cth_like_free_bdy",
         "//vmecpp/test_data:cth_like_free_bdy_asym",
         "//vmecpp/test_data:cth_like_free_bdy_multigrid",
+        "//vmecpp/test_data:solovev_free_bdy",
     ],
     deps = [
         "//vmecpp/vmec/output_quantities:test_helpers",

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -554,24 +554,6 @@ bool Vmec::InitializeRadial(
   fc_.res1 = -1;
   m_delt0 = indata_.delt;
 
-  // On a free-boundary multigrid continuation stage, the vacuum solution of
-  // the converged coarser stage is still exactly valid, because the radial
-  // interpolation changes neither the angular grid nor the LCFS geometry.
-  // Re-marking the vacuum state as kInitialized here (mirroring the
-  // hot-restart path in run()) makes the first iteration of the new stage
-  // run the free-boundary block, so the LCFS force enters balanced by the
-  // vacuum magnetic pressure. Otherwise iteration 1 skips the vacuum update
-  // (the `iter2 > 1` gate in IdealMhdModel::update) and applies the edge
-  // force with rBSq = 0 -- the raw, unbalanced plasma pressure -- which
-  // kicks the boundary in a single step and costs a long NESTOR ring-down
-  // afterwards (stage-entry FSQR ~ 9 instead of the interpolation-error
-  // level, W_MHD -12 percent in one step, DELBSQ ~ 400x its converged
-  // value).
-  if (fc_.lfreeb && ns_old != 0 && ns_old < nsval &&
-      vacuum_pressure_state_ == VacuumPressureState::kActive) {
-    vacuum_pressure_state_ = VacuumPressureState::kInitialized;
-  }
-
   // INITIALIZE MESH-DEPENDENT SCALARS
 
   // *THIS* actually sets the global ns value for the main physics algorithm

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
@@ -903,3 +903,57 @@ TEST(TestVmec, InconsistentIndataIsRejectedBeforeConstruction) {
     }
   }
 }  // InconsistentIndataIsRejectedBeforeConstruction
+
+// The nvacskip cadence only starts once the R and Z force residuals have
+// settled, so two free-boundary runs that differ only in nvacskip share the
+// same force-residual history up to that evaluation.
+TEST(TestVmec, VacuumUpdateCadenceStartsWhenResidualsSettle) {
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile("vmecpp/test_data/solovev_free_bdy.json");
+  ASSERT_TRUE(indata_json.ok());
+  const absl::StatusOr<VmecINDATA> base_indata =
+      VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(base_indata.ok());
+
+  // a single grid step, to keep the multi-grid transitions out of it
+  auto solve = [&](int nvacskip) {
+    VmecINDATA indata = *base_indata;
+    indata.ns_array = Eigen::VectorXi::Constant(1, 16);
+    indata.ftol_array = Eigen::VectorXd::Constant(1, 1.0e-10);
+    indata.niter_array = Eigen::VectorXi::Constant(1, 5000);
+    indata.nvacskip = nvacskip;
+    return vmecpp::run(indata, std::nullopt, 1);
+  };
+
+  const auto every_iteration = solve(1);
+  ASSERT_TRUE(every_iteration.ok());
+  const auto strided = solve(24);
+  ASSERT_TRUE(strided.ok());
+
+  const Eigen::VectorXd& fsqr = every_iteration->wout.force_residual_r;
+  const Eigen::VectorXd& fsqz = every_iteration->wout.force_residual_z;
+  const Eigen::VectorXd& fsqr_strided = strided->wout.force_residual_r;
+  const Eigen::VectorXd& fsqz_strided = strided->wout.force_residual_z;
+
+  // The vacuum pressure is switched on at the first evaluation below the
+  // threshold; the cadence can first take effect at the second one.
+  int below_threshold = 0;
+  int settled = -1;
+  for (int i = 0; i < fsqr.size(); ++i) {
+    if (fsqr(i) + fsqz(i) < 1.0e-3) {
+      ++below_threshold;
+      if (below_threshold == 2) {
+        settled = i;
+        break;
+      }
+    }
+  }
+  ASSERT_GE(settled, 20) << "the free-boundary transient is too short to "
+                            "distinguish the two cadences";
+  ASSERT_LE(settled, fsqr_strided.size());
+
+  for (int i = 0; i < settled; ++i) {
+    EXPECT_EQ(fsqr(i), fsqr_strided(i)) << "evaluation " << i;
+    EXPECT_EQ(fsqz(i), fsqz_strided(i)) << "evaluation " << i;
+  }
+}  // VacuumUpdateCadenceStartsWhenResidualsSettle


### PR DESCRIPTION
VMEC 8.52 forces a full Nestor update in every iteration while `ivac <= 2`, and `ivac` only grows past 2 in an iteration whose R and Z force residuals are below `1e-3` (`funct3d.f90`). `VacuumPressureState` capped at `kActive`, so the increment stopped as soon as the vacuum pressure was switched on and the `nvacskip` cadence started one iteration later, while the free-boundary transient was still one to three orders of magnitude above that threshold. Every Nestor call in that window reused the Green's function matrices instead of recomputing them.

`kSettled` marks the state after the residuals have settled, and the full update is forced while the state is at most `kActive`. The remaining comparisons against `kInitialized` and `kActive` become `>=`, so the new state keeps the vacuum pressure in the force balance, in the free-boundary edge outputs and in `DELBSQ`. The multigrid seeding of the vacuum state is dropped: the state carries over into the continuation stage by itself, as in Fortran, and the first iteration of the new stage still runs the free-boundary block through the widened gate. `cth_like_free_bdy_multigrid` converges in the same 321 iterations.

Largest relative deviation in `rmnc` from educational_VMEC on the single-grid free-boundary Solovev case (`ns = 16`, `ftol = 1e-12`), both codes reading the same INDATA file, with the iteration counts in brackets:

| nvacskip | before | after | Fortran |
|---|---|---|---|
| 1  | 1.3e-12 [514] | 1.3e-12 [514] | [514] |
| 3  | 9.1e-08 [519] | 5.8e-12 [521] | [521] |
| 6  | 1.1e-06 [525] | 4.8e-12 [529] | [529] |
| 12 | 2.2e-06 [530] | 8.9e-13 [526] | [526] |
| 24 | 4.2e-06 [552] | 1.6e-12 [538] | [538] |

At `nvacskip = 24` the deviation before the change reaches `2.0e-05` in `lmns` and `1.7e-05` in `jcurv`. `nvacskip = 1` is the control, where the two cadences coincide. `cth_like_free_bdy` is unchanged at every `nvacskip` tested (1, 9, 24), since its vacuum pressure switches on when the residuals are already below the threshold; it stays at `1.8e-13` in `rmnc` and reproduces the Fortran iteration count.

The new test solves the case twice, with `nvacskip` 1 and 24, and requires the force-residual history to agree exactly up to the evaluation at which the residuals settle. It fails on the previous cadence.

`bazel test --config=opt //vmecpp/... //vmecpp_large_cpp_tests/...` and `pytest` pass.
