### PR TITLE
Recover the full-grid lambda from the half-grid array when a wout file lacks it

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -803,42 +803,34 @@ def _lambda_on_full_grid(
     phipf: np.ndarray,
     extrapolate_axis: bool = True,
 ) -> np.ndarray:
-    """Invert the radial interpolation that writes lambda onto the half grid."""
-    n_surfaces = lambda_half.shape[1]
-    if n_surfaces < 2:
+    """Invert the radial interpolation that writes lambda onto the half grid.
+
+    Half-grid point j holds (w_out * lambda[j] + w_in * lambda[j - 1]) / 2, the
+    weights being 1 for even m and the sqrt(s) ratios of the odd-m scaling
+    otherwise; on the innermost interval the m <= 1 modes take both values from
+    surface 1 and the higher modes vanish on the axis.
+    """
+    ns = lambda_half.shape[1]
+    if ns < 2:
         return np.zeros_like(lambda_half)
 
-    sqrt_s_full = np.sqrt(np.arange(n_surfaces, dtype=float) / (n_surfaces - 1.0))
-    sqrt_s_full[-1] = 1.0
-    sqrt_s_half = np.sqrt(
-        (np.arange(n_surfaces - 1, dtype=float) + 0.5) / (n_surfaces - 1.0)
-    )
-    # odd-m interpolation weights of the outer and inner surface
-    outer = sqrt_s_half / sqrt_s_full[1:]
-    inner = np.empty_like(outer)
-    inner[1:] = sqrt_s_half[1:] / sqrt_s_full[1:-1]
-    inner[0] = outer[0]
-
-    odd = xm.astype(int) % 2 == 1
-    even = ~odd
-    from_outside = xm <= 1
+    sqrt_s_full = np.sqrt(np.arange(ns, dtype=float) / (ns - 1.0))
+    sqrt_s_half = np.sqrt((np.arange(ns - 1, dtype=float) + 0.5) / (ns - 1.0))
+    sqrt_s_inner = np.concatenate([sqrt_s_full[1:2], sqrt_s_full[1:-1]])
+    odd = (xm.astype(int) % 2 == 1)[:, np.newaxis]
+    w_out = np.where(odd, sqrt_s_half / sqrt_s_full[1:], 1.0)
+    w_in = np.where(odd, sqrt_s_half / sqrt_s_inner, 1.0)
 
     lambda_full = np.zeros_like(lambda_half)
-    first = lambda_half[:, 1]
-    lambda_full[even & from_outside, 1] = first[even & from_outside]
-    lambda_full[odd & from_outside, 1] = (
-        2.0 * first[odd & from_outside] / (outer[0] + inner[0])
-    )
-    lambda_full[even & ~from_outside, 1] = 2.0 * first[even & ~from_outside]
-    lambda_full[odd & ~from_outside, 1] = 2.0 * first[odd & ~from_outside] / outer[0]
-    for j in range(1, n_surfaces - 1):
-        lambda_full[even, j + 1] = 2.0 * lambda_half[even, j + 1] - lambda_full[even, j]
-        lambda_full[odd, j + 1] = (
-            2.0 * lambda_half[odd, j + 1] - inner[j] * lambda_full[odd, j]
-        ) / outer[j]
+    w_axis = np.where(xm <= 1, w_in[:, 0], 0.0)
+    lambda_full[:, 1] = 2.0 * lambda_half[:, 1] / (w_out[:, 0] + w_axis)
+    for j in range(2, ns):
+        lambda_full[:, j] = (
+            2.0 * lambda_half[:, j] - w_in[:, j - 1] * lambda_full[:, j - 1]
+        ) / w_out[:, j - 1]
 
     # the axis value of the m = 0 modes is not represented on the half grid
-    if extrapolate_axis and n_surfaces > 2 and phipf[0] != 0.0:
+    if extrapolate_axis and ns > 2 and phipf[0] != 0.0:
         m_zero = xm == 0
         lambda_full[m_zero, 0] = (
             2.0 * lambda_full[m_zero, 1] * phipf[1] - lambda_full[m_zero, 2] * phipf[2]
@@ -1811,26 +1803,18 @@ class VmecWOut(BaseModelWithNumpy):
                     attrs[var_name] = fnc[var_name][()]
 
         # Fortran VMEC stores lambda on the half grid only.
-        mnmax = attrs["mnmax"]
-        ns = attrs["ns"]
-        recoverable = {"lmns", "xm", "phipf"} <= attrs.keys()
-        if "lmns_full" not in attrs:
-            attrs["lmns_full"] = (
-                _lambda_on_full_grid(attrs["lmns"], attrs["xm"], attrs["phipf"])
-                if recoverable
-                else np.zeros([mnmax, ns])
-            )
-        if attrs["lasym__logical__"] and "lmnc_full" not in attrs:
-            attrs["lmnc_full"] = (
-                _lambda_on_full_grid(
-                    attrs["lmnc"],
-                    attrs["xm"],
-                    attrs["phipf"],
-                    extrapolate_axis=False,
+        halves = [("lmns", "lmns_full", True)]
+        if attrs["lasym__logical__"]:
+            halves.append(("lmnc", "lmnc_full", False))
+        for half, full, extrapolate_axis in halves:
+            if full in attrs:
+                continue
+            if {half, "xm", "phipf"} <= attrs.keys():
+                attrs[full] = _lambda_on_full_grid(
+                    attrs[half], attrs["xm"], attrs["phipf"], extrapolate_axis
                 )
-                if recoverable and "lmnc" in attrs
-                else np.zeros([mnmax, ns])
-            )
+            else:
+                attrs[full] = np.zeros([attrs["mnmax"], attrs["ns"]])
 
         # Backwards compatibility: lrfp flag may not exist in older wout files
         attrs.setdefault("lrfp__logical__", 0)

--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -797,6 +797,56 @@ preset = 21
 ndfmax = 101
 
 
+def _lambda_on_full_grid(
+    lambda_half: np.ndarray,
+    xm: np.ndarray,
+    phipf: np.ndarray,
+    extrapolate_axis: bool = True,
+) -> np.ndarray:
+    """Invert the radial interpolation that writes lambda onto the half grid."""
+    n_surfaces = lambda_half.shape[1]
+    if n_surfaces < 2:
+        return np.zeros_like(lambda_half)
+
+    sqrt_s_full = np.sqrt(np.arange(n_surfaces, dtype=float) / (n_surfaces - 1.0))
+    sqrt_s_full[-1] = 1.0
+    sqrt_s_half = np.sqrt(
+        (np.arange(n_surfaces - 1, dtype=float) + 0.5) / (n_surfaces - 1.0)
+    )
+    # odd-m interpolation weights of the outer and inner surface
+    outer = sqrt_s_half / sqrt_s_full[1:]
+    inner = np.empty_like(outer)
+    inner[1:] = sqrt_s_half[1:] / sqrt_s_full[1:-1]
+    inner[0] = outer[0]
+
+    odd = xm.astype(int) % 2 == 1
+    even = ~odd
+    from_outside = xm <= 1
+
+    lambda_full = np.zeros_like(lambda_half)
+    first = lambda_half[:, 1]
+    lambda_full[even & from_outside, 1] = first[even & from_outside]
+    lambda_full[odd & from_outside, 1] = (
+        2.0 * first[odd & from_outside] / (outer[0] + inner[0])
+    )
+    lambda_full[even & ~from_outside, 1] = 2.0 * first[even & ~from_outside]
+    lambda_full[odd & ~from_outside, 1] = 2.0 * first[odd & ~from_outside] / outer[0]
+    for j in range(1, n_surfaces - 1):
+        lambda_full[even, j + 1] = 2.0 * lambda_half[even, j + 1] - lambda_full[even, j]
+        lambda_full[odd, j + 1] = (
+            2.0 * lambda_half[odd, j + 1] - inner[j] * lambda_full[odd, j]
+        ) / outer[j]
+
+    # the axis value of the m = 0 modes is not represented on the half grid
+    if extrapolate_axis and n_surfaces > 2 and phipf[0] != 0.0:
+        m_zero = xm == 0
+        lambda_full[m_zero, 0] = (
+            2.0 * lambda_full[m_zero, 1] * phipf[1] - lambda_full[m_zero, 2] * phipf[2]
+        ) / phipf[0]
+
+    return lambda_full
+
+
 # NOTE: in the future we want to change the C++ WOutFileContents layout so that it
 # matches the classic Fortran one, so most of the compatibility layer here could
 # disappear.
@@ -1760,13 +1810,27 @@ class VmecWOut(BaseModelWithNumpy):
                 else:
                     attrs[var_name] = fnc[var_name][()]
 
-        # Special handling for variables only present in VMEC++
-        # For now, only special case for lambda coefficients: lambda = 0 is a physically meaningful fall-back value
+        # Fortran VMEC stores lambda on the half grid only.
         mnmax = attrs["mnmax"]
         ns = attrs["ns"]
-        attrs.setdefault("lmns_full", np.zeros([mnmax, ns]))
-        if attrs["lasym__logical__"]:
-            attrs.setdefault("lmnc_full", np.zeros([mnmax, ns]))
+        recoverable = {"lmns", "xm", "phipf"} <= attrs.keys()
+        if "lmns_full" not in attrs:
+            attrs["lmns_full"] = (
+                _lambda_on_full_grid(attrs["lmns"], attrs["xm"], attrs["phipf"])
+                if recoverable
+                else np.zeros([mnmax, ns])
+            )
+        if attrs["lasym__logical__"] and "lmnc_full" not in attrs:
+            attrs["lmnc_full"] = (
+                _lambda_on_full_grid(
+                    attrs["lmnc"],
+                    attrs["xm"],
+                    attrs["phipf"],
+                    extrapolate_axis=False,
+                )
+                if recoverable and "lmnc" in attrs
+                else np.zeros([mnmax, ns])
+            )
 
         # Backwards compatibility: lrfp flag may not exist in older wout files
         attrs.setdefault("lrfp__logical__", 0)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -835,3 +835,86 @@ except KeyboardInterrupt:
         f"Expected KeyboardInterrupt but got:\noutput: {output}"
     )
     assert "RUN_COMPLETED" not in output
+
+
+def _wout_without_full_grid_lambda(source: Path, target: Path) -> None:
+    """Copy a wout file, dropping the full-grid lambda arrays only VMEC++ writes."""
+    dropped = {"lmns_full", "lmnc_full"}
+    with netCDF4.Dataset(source) as src, netCDF4.Dataset(target, "w") as dst:
+        for name, dimension in src.dimensions.items():
+            dst.createDimension(
+                name, None if dimension.isunlimited() else len(dimension)
+            )
+        for name, variable in src.variables.items():
+            if name in dropped:
+                continue
+            src.set_auto_mask(False)
+            created = dst.createVariable(name, variable.datatype, variable.dimensions)
+            created.setncatts({k: variable.getncattr(k) for k in variable.ncattrs()})
+            created[...] = src[name][()]
+
+
+def test_wout_recovers_full_grid_lambda_from_half_grid():
+    """The full-grid lambda is recovered from a wout that stores only the half grid."""
+    wout_path = TEST_DATA_DIR / "wout_cth_like_fixed_bdy_spline_pressure.nc"
+    with netCDF4.Dataset(wout_path) as fnc:
+        assert "lmns_full" not in fnc.variables
+
+    loaded = vmecpp.VmecWOut.from_wout_file(wout_path)
+    computed = vmecpp.run(
+        vmecpp.VmecInput.from_file(
+            TEST_DATA_DIR / "cth_like_fixed_bdy_spline_pressure.json"
+        ),
+        max_threads=1,
+        verbose=False,
+    ).wout
+
+    peak = np.abs(computed.lmns_full).max()
+    assert peak > 0.1
+    np.testing.assert_allclose(loaded.lmns_full, computed.lmns_full, atol=1.0e-8 * peak)
+
+
+def test_wout_recovers_full_grid_lambda_for_asymmetric_equilibrium(tmp_path):
+    """The recovery covers both lambda halves of an asymmetric equilibrium."""
+    computed = vmecpp.run(
+        vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cth_like_fixed_bdy_asym.json"),
+        max_threads=1,
+        verbose=False,
+    ).wout
+    assert computed.lasym
+
+    full = tmp_path / "wout_asym.nc"
+    computed.save(full)
+    half_only = tmp_path / "wout_asym_half_grid_lambda.nc"
+    _wout_without_full_grid_lambda(full, half_only)
+
+    loaded = vmecpp.VmecWOut.from_wout_file(half_only)
+    for recovered, reference in (
+        (loaded.lmns_full, computed.lmns_full),
+        (loaded.lmnc_full, computed.lmnc_full),
+    ):
+        peak = np.abs(reference).max()
+        assert peak > 0.0
+        np.testing.assert_allclose(recovered, reference, atol=1.0e-10 * peak)
+
+
+def test_hot_restart_from_a_wout_without_full_grid_lambda(tmp_path):
+    """A restart from a wout with half-grid lambda only converges at once."""
+    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cth_like_fixed_bdy.json")
+    cold = vmecpp.run(vmec_input, max_threads=1, verbose=False)
+
+    full = tmp_path / "wout_cth.nc"
+    cold.wout.save(full)
+    half_only = tmp_path / "wout_cth_half_grid_lambda.nc"
+    _wout_without_full_grid_lambda(full, half_only)
+
+    restart_from = cold.model_copy(deep=True)
+    restart_from.wout = vmecpp.VmecWOut.from_wout_file(half_only)
+
+    hot_input = vmec_input.model_copy(deep=True)
+    hot_input.ns_array = vmec_input.ns_array[-1:]
+    hot_input.ftol_array = vmec_input.ftol_array[-1:]
+    hot_input.niter_array = vmec_input.niter_array[-1:]
+    hot = vmecpp.run(hot_input, restart_from=restart_from, max_threads=1, verbose=False)
+
+    assert hot.wout.niter < 10


### PR DESCRIPTION
`VmecWOut.from_wout_file` filled `lmns_full`, and `lmnc_full` for an asymmetric run, with zeros whenever the file did not carry them. Fortran VMEC stores lambda on the half grid only, so every wout written outside VMEC++ took that branch, and `run(..., restart_from=...)` then seeded the restart with zero lambda. The restart re-converged the lambda sector from scratch: `cth_like_fixed_bdy` took 122 iterations instead of 2, `solovev` 287 instead of 2, and the two restarts settled on states 4.6e-4 apart in `rmnc`.

The full-grid array is now recovered by inverting the interpolation VMEC applies when it writes the half-grid one: the average over the two adjacent full-grid surfaces for even m, weighted by sqrt(s) for odd m, with the innermost value of the m <= 1 modes taken from the surface outside. The recursion runs outward from the axis, where the m > 0 modes vanish. The axis value of the m = 0 modes is not represented on the half grid; it is extrapolated from the two innermost surfaces for the stellarator-symmetric half, matching the writer, and is left at zero for the antisymmetric half, which the writer does not extrapolate. A file that already carries the full-grid arrays keeps them, and one missing `lmns`, `xm` or `phipf` still falls back to zeros.

Measured against Fortran wout files for the same equilibrium:

| reference | recovered `lmns_full` vs the VMEC++ solve | hot restart |
|---|---|---|
| educational_VMEC `cth_like_fixed_bdy` | 1.2e-13 | 2 iterations (122 before) |
| educational_VMEC `solovev` | 8.1e-12 | 2 iterations (287 before) |
| PARVMEC 10.0 `cth_like_fixed_bdy` | 1.4e-06 | |

The PARVMEC figure is that run's own deviation from VMEC++: its half-grid `lmns` differs by the same 1.4e-06, so the recovery adds nothing.

Three tests cover it, all failing on the zero fallback: the array recovered from the shipped `wout_cth_like_fixed_bdy_spline_pressure.nc`, which stores lambda on the half grid only, against a fresh solve; both halves of an asymmetric equilibrium round-tripped through a wout with the full-grid arrays removed; and a hot restart from such a file, which must converge in under ten iterations.

`pytest` passes.
