### PR TITLE
Validate VmecINDATA before constructing the solver

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -1341,6 +1341,13 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
                         vmec_indata.nzeta));
   }
 
+  // the free-boundary case additionally requires nvacskip >= 1; see below
+  if (vmec_indata.nvacskip < 0) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "input variable 'nvacskip' needs to be >= 0, but is %d\n",
+        vmec_indata.nvacskip));
+  }
+
   /* --------------------------------- */
 
   const int NS_MIN = 3;

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -147,6 +147,14 @@ absl::StatusOr<std::unique_ptr<Vmec>> Vmec::FromIndata(
     const makegrid::MagneticFieldResponseTable* magnetic_response_table,
     std::optional<int> max_threads, OutputMode verbose,
     InterruptCallback interrupt_callback) {
+  // check the input before the constructor builds Sizes from it; the
+  // informational messages are left to the check in run()
+  absl::Status is_indata_consistent =
+      IsConsistent(indata, /*enable_info_messages=*/false);
+  if (!is_indata_consistent.ok()) {
+    return is_indata_consistent;
+  }
+
   auto v = std::make_unique<Vmec>(indata, max_threads, verbose,
                                   std::move(interrupt_callback));
 

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
@@ -5,7 +5,10 @@
 #include "vmecpp/vmec/vmec/vmec.h"
 
 #include <fstream>
+#include <functional>
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/log/check.h"
@@ -841,3 +844,33 @@ TEST(TestVmec, Threed1FreeBoundaryCoversTheAsymmetricPoloidalRange) {
     }  // l
   }  // k
 }  // Threed1FreeBoundaryCoversTheAsymmetricPoloidalRange
+
+// An inconsistent VmecINDATA must come back as a status from the factory:
+// constructing first ends the process instead of reporting the input error.
+TEST(TestVmec, InconsistentIndataIsRejectedBeforeConstruction) {
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile("vmecpp/test_data/cth_like_fixed_bdy.json");
+  ASSERT_TRUE(indata_json.ok());
+  const absl::StatusOr<VmecINDATA> base_indata =
+      VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(base_indata.ok());
+
+  for (const auto& [description, mutate] :
+       std::vector<std::pair<std::string, std::function<void(VmecINDATA&)>>>{
+           {"nfp = 0", [](VmecINDATA& indata) { indata.nfp = 0; }},
+           {"nfp = -1", [](VmecINDATA& indata) { indata.nfp = -1; }},
+           {"mpol = 0", [](VmecINDATA& indata) { indata.mpol = 0; }},
+           {"mpol = 1", [](VmecINDATA& indata) { indata.mpol = 1; }},
+           {"nvacskip = -1",
+            [](VmecINDATA& indata) { indata.nvacskip = -1; }}}) {
+    VmecINDATA indata = *base_indata;
+    mutate(indata);
+    const absl::StatusOr<std::unique_ptr<Vmec>> maybe_vmec =
+        Vmec::FromIndata(indata);
+    EXPECT_FALSE(maybe_vmec.ok()) << description;
+    if (!maybe_vmec.ok()) {
+      EXPECT_EQ(maybe_vmec.status().code(), absl::StatusCode::kInvalidArgument)
+          << description;
+    }
+  }
+}  // InconsistentIndataIsRejectedBeforeConstruction


### PR DESCRIPTION
`Vmec::FromIndata` constructs the solver first and validates the input afterwards, in `Vmec::run`. The constructor builds `Sizes`, `Boundaries` and the profile objects from the raw `VmecINDATA`, so an inconsistent input reaches the `CHECK`s in `Sizes` and ends the process before `IsConsistent` ever runs. `VmecINDATA::FromJson` and `FromFile` do validate, so this only shows up for an input assembled or modified in memory, which is what `VmecInput` fields are for and what an optimizer does between solves.

From Python, with a `VmecInput` loaded from a shipped test case and one field changed:

| change | before | after |
|---|---|---|
| `nfp = 0` or `nfp = -1` | SIGABRT, `sizes.cc` check failure | `input variable 'nfp' needs to be > 0` |
| `mpol = 0` | SIGABRT, `sizes.cc` check failure | `input variable 'mpol' needs to be >= 2` |
| `mpol = 1` | SIGABRT, `double free or corruption (out)` | `input variable 'mpol' needs to be >= 2` |
| `nvacskip = -1` | SIGABRT, `ideal_mhd_model.cc` check failure whose message reads "should be checked by VmecINDATA" | `input variable 'nvacskip' needs to be >= 0` |

`mpol = 1` passes the `mpol >= 1` check in `Sizes` and then corrupts the heap, since only m = 0 exists and the m = 1 constraint arrays are empty. educational_VMEC dumps core on the same input, so the value is unsupported in the lineage rather than something to make work.

`IsConsistent` already rejects `nfp < 1` and `mpol < 2`; it is now called at the top of `Vmec::FromIndata`, before the constructor, with its informational messages left to the existing call in `run`. `nvacskip` was checked only for a free-boundary run, so a negative value passed through on a fixed-boundary one; the new check is unconditional and rejects only negative values, leaving zero accepted where it is unused. A sweep over about a hundred single-field perturbations, covering the scalars, the profile and axis arrays, and the array shapes, found no other input that ends the process.

The test drives the five inputs through `Vmec::FromIndata` and requires an `InvalidArgument` status; it takes the test binary down with it before the change.

`bazel test --config=opt //vmecpp/... //vmecpp_large_cpp_tests/...` and `pytest` pass.
