### PR TITLE
Scale the enclosed toroidal flux by the bloating factor

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
@@ -335,7 +335,9 @@ std::string RadialProfiles::profileTypeToString(ProfileType profileType) {
 
 /** Compute the maximum toroidal and poloidal magnetic fluxes. */
 void RadialProfiles::computeMagneticFluxes() {
-  maxToroidalFlux = signOfJacobian * id_.phiedge / (2.0 * M_PI);
+  // the bloating factor scales the enclosed toroidal flux
+  const double phiedge = id_.phiedge * id_.bloat;
+  maxToroidalFlux = signOfJacobian * phiedge / (2.0 * M_PI);
   double edgeToroidalFluxFromProfile = torflux(1.0);
   if (edgeToroidalFluxFromProfile != 0.0) {
     maxToroidalFlux /= edgeToroidalFluxFromProfile;

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
@@ -957,3 +957,33 @@ TEST(TestVmec, VacuumUpdateCadenceStartsWhenResidualsSettle) {
     EXPECT_EQ(fsqz(i), fsqz_strided(i)) << "evaluation " << i;
   }
 }  // VacuumUpdateCadenceStartsWhenResidualsSettle
+
+// The bloating factor scales the enclosed toroidal flux, so the edge value of
+// phi comes out as phiedge * bloat.
+TEST(TestVmec, BloatScalesTheEnclosedToroidalFlux) {
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile("vmecpp/test_data/cth_like_fixed_bdy.json");
+  ASSERT_TRUE(indata_json.ok());
+  const absl::StatusOr<VmecINDATA> base_indata =
+      VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(base_indata.ok());
+
+  // bloat is only accepted for a constrained toroidal current
+  ASSERT_EQ(base_indata->ncurr, 1);
+
+  for (const double bloat : {1.0, 1.5, 0.5}) {
+    VmecINDATA indata = *base_indata;
+    indata.ns_array = Eigen::VectorXi::Constant(1, 9);
+    indata.ftol_array = Eigen::VectorXd::Constant(1, 1.0e-8);
+    indata.niter_array = Eigen::VectorXi::Constant(1, 4000);
+    indata.bloat = bloat;
+
+    const auto output = vmecpp::run(indata, std::nullopt, 1);
+    ASSERT_TRUE(output.ok()) << "bloat = " << bloat;
+
+    const Eigen::VectorXd& phi = output->wout.phi;
+    EXPECT_TRUE(
+        IsCloseRelAbs(indata.phiedge * bloat, phi[phi.size() - 1], 1.0e-14))
+        << "bloat = " << bloat;
+  }
+}  // BloatScalesTheEnclosedToroidalFlux


### PR DESCRIPTION
`bloat` expands the profiles into a larger enclosed toroidal flux. Fortran VMEC applies it in two places: `readin` scales `phiedge` by it, and `pcurr`/`pmass` evaluate the profile at `min(|s * bloat|, 1)`. VMEC++ has the second and not the first, so the flux stays at `phiedge` and the equilibrium is not the one either Fortran implementation computes.

Against PARVMEC 10.0 on `cth_like_fixed_bdy`, which has `ncurr = 1` as `bloat` requires, reading the same INDATA file:

| bloat | edge phi, PARVMEC | edge phi, VMEC++ before | largest deviation before | after |
|---|---|---|---|---|
| 1.0 | -3.500e-02 | -3.500e-02 | 3.9e-08 | 3.9e-08 |
| 1.5 | -5.250e-02 | -3.500e-02 | 1.2e+00 in `betatotal` | 2.7e-07 |
| 0.5 | -1.750e-02 | -3.500e-02 | 2.9e+00 in `wb` | 3.7e-07 |

The remaining 1e-7 is PARVMEC's own deviation from VMEC++ on this case, the same at `bloat = 1` where nothing changes. The iteration counts also match exactly after the change: 649, 682 and 717 for the three values.

educational_VMEC cannot referee this input. It scales `phiedge` in `readin.f90` but its `profile_functions.f90` carries no `bloat` at all, so it implements the other half of the pair; a `bloat != 1` run there differs from PARVMEC as well.

The factor enters at the single place `phiedge` is consumed, the maximum toroidal flux in `RadialProfiles::computeMagneticFluxes`, rather than mutating the input as Fortran does, so a `VmecInput` still round-trips to the values the user supplied. The test runs the case at `ns = 9` for `bloat` 1, 1.5 and 0.5 and requires the edge value of `phi` to be `phiedge * bloat`; it fails at 1.5 and 0.5 before the change.

`bazel test --config=opt //vmecpp/... //vmecpp_large_cpp_tests/...` and `pytest` pass.
