### PR TITLE
Integrate the toroidal flux with the half-grid flux derivative

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/geometry/vmec_geometry.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/geometry/vmec_geometry.cc
@@ -91,7 +91,7 @@ Geometry MakeGeometry(const VmecINDATA& indata,
       result.toroidal_flux[j] =
           result.toroidal_flux[j - 1] + internal.sign_of_jacobian * 2.0 *
                                             std::numbers::pi * delta_s *
-                                            internal.phipF[j - 1];
+                                            internal.phipH[j - 1];
     }
   }
   for (int j = 1; j < internal.num_full; ++j) {

--- a/src/vmecpp/cpp/vmecpp/vmec/geometry/vmec_geometry_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/geometry/vmec_geometry_test.cc
@@ -45,6 +45,46 @@ TEST(VmecGeometryTest, ConvertsInternalScalingWithoutWout) {
   EXPECT_NEAR(point.poloidal_flux[1], -1.6 * M_PI, 1e-14);
 }
 
+// With no phiF to copy, the adapter integrates the enclosed toroidal flux from
+// the half-grid dphi/ds between the two surfaces. That is exact for a linear
+// dphi/ds, where the value at the inner endpoint of each interval is not.
+TEST(VmecGeometryTest, DerivesToroidalFluxFromTheHalfGridDerivative) {
+  VmecINDATA indata;
+  indata.nfp = 1;
+  indata.mpol = 2;
+  indata.ntor = 0;
+
+  const int num_full = 4;
+  const double delta_s = 1.0 / (num_full - 1);
+  VmecInternalResults internal;
+  internal.sign_of_jacobian = 1;
+  internal.lamscale = 1.0;
+  internal.num_full = num_full;
+  // dphi/ds = 1 + 3 s, so the enclosed flux is 2 pi (s + 3 s^2 / 2)
+  internal.phiF = Eigen::VectorXd::Zero(num_full);
+  internal.phipF = Eigen::VectorXd(num_full);
+  for (int jF = 0; jF < num_full; ++jF) {
+    internal.phipF[jF] = 1.0 + 3.0 * jF * delta_s;
+  }
+  internal.phipH = Eigen::VectorXd(num_full - 1);
+  for (int jH = 0; jH < num_full - 1; ++jH) {
+    internal.phipH[jH] = 1.0 + 3.0 * (jH + 0.5) * delta_s;
+  }
+  internal.iotaH = Eigen::VectorXd::Zero(num_full - 1);
+  internal.rmncc = RowMatrixXd::Zero(num_full, 2);
+  internal.zmnsc = RowMatrixXd::Zero(num_full, 2);
+  internal.lmnsc = RowMatrixXd::Zero(num_full, 2);
+
+  const Geometry geometry = MakeGeometry(indata, internal);
+  ASSERT_EQ(geometry.toroidal_flux.size(), static_cast<std::size_t>(num_full));
+  for (int jF = 0; jF < num_full; ++jF) {
+    const double s = jF * delta_s;
+    EXPECT_NEAR(geometry.toroidal_flux[jF], 2.0 * M_PI * (s + 1.5 * s * s),
+                1e-13)
+        << "surface " << jF;
+  }
+}
+
 TEST(VmecGeometryTest, SolverAndPhysicalStatesAgree) {
   VmecINDATA indata;
   indata.mpol = 2;

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -2033,11 +2033,12 @@ void vmecpp::FixupPoloidalCurrent(
 
 void vmecpp::RecomputeToroidalFlux(
     const FlowControl& fc, VmecInternalResults& m_vmec_internal_results) {
-  // quadrature in radial direction
+  // radial quadrature over the half-grid dphi/ds between the two full-grid
+  // surfaces, which is exact for a linear dphi/ds
   m_vmec_internal_results.phiF[0] = 0.0;
   for (int jF = 1; jF < fc.ns; ++jF) {
     m_vmec_internal_results.phiF[jF] = m_vmec_internal_results.phiF[jF - 1] +
-                                       m_vmec_internal_results.phipF[jF - 1];
+                                       m_vmec_internal_results.phipH[jF - 1];
   }  // jF
 
   // now apply scaling

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
@@ -841,3 +841,32 @@ TEST(TestVmec, Threed1FreeBoundaryCoversTheAsymmetricPoloidalRange) {
     }  // l
   }  // k
 }  // Threed1FreeBoundaryCoversTheAsymmetricPoloidalRange
+
+// The enclosed toroidal flux is the integral of the aphi polynomial, normalized
+// to phiedge at the boundary. A linear dphi/ds is integrated exactly.
+TEST(TestVmec, ToroidalFluxFollowsTheAphiPolynomial) {
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile("vmecpp/test_data/cth_like_fixed_bdy.json");
+  ASSERT_TRUE(indata_json.ok());
+  absl::StatusOr<VmecINDATA> indata = VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(indata.ok());
+
+  const int ns = 9;
+  indata->ns_array = Eigen::VectorXi::Constant(1, ns);
+  indata->ftol_array = Eigen::VectorXd::Constant(1, 1.0e-8);
+  indata->niter_array = Eigen::VectorXi::Constant(1, 4000);
+  // phi(s) = phiedge * (s + s^2 / 2) / (3 / 2)
+  indata->aphi = Eigen::VectorXd(2);
+  indata->aphi << 1.0, 0.5;
+
+  const auto output = vmecpp::run(*indata, std::nullopt, 1);
+  ASSERT_TRUE(output.ok());
+
+  const Eigen::VectorXd& phi = output->wout.phi;
+  ASSERT_EQ(phi.size(), ns);
+  for (int jF = 0; jF < ns; ++jF) {
+    const double s = static_cast<double>(jF) / (ns - 1);
+    const double expected = indata->phiedge * (s + 0.5 * s * s) / 1.5;
+    EXPECT_TRUE(IsCloseRelAbs(expected, phi[jF], 1.0e-13)) << "jF = " << jF;
+  }
+}  // ToroidalFluxFollowsTheAphiPolynomial


### PR DESCRIPTION
`RecomputeToroidalFlux` accumulates the full-grid `dphi/ds` at the inner endpoint of each interval, a left-endpoint rectangle rule. Fortran VMEC accumulates the half-grid `phip` between the two surfaces (`fileout.f90`), the midpoint rule, which is exact for a linear `dphi/ds`. The two agree only when `dphi/ds` is constant, which is the default `aphi = [1]` that every shipped case uses.

With any other `aphi` the reported flux is wrong at first order in the radial step. On `cth_like_fixed_bdy` at `ns = 15` with `aphi = [1, 0.5]`, whose flux profile is `phiedge (s + s^2/2) / 1.5`:

| quantity | before | after |
|---|---|---|
| edge value of `phi` | -3.4167e-02 against phiedge -3.5000e-02 | -3.5000e-02 |
| `phi` | 2.4e-02 | below 1e-09 |
| `currumnc` | 7.1e-01 | below 1e-09 |
| `bsubsmns` | 3.2e-01 | below 1e-09 |
| `currvmnc` | 2.5e-01 | below 1e-09 |
| `bdotb` | 2.5e-02 | below 1e-09 |

Relative to educational_VMEC reading the same INDATA file.

Agreement across `aphi` depends on the degree of `dphi/ds`, and only the linear cases reach round-off. With `aphi` of `[1]` and `[1, 0.5]` every wout field agrees at the 1e-07 residual level with matching iteration counts, apart from the axis `chipf` that the reference leaves at zero. `[1, -0.3, 0.3]` leaves 2.4e-04 in the worst field and 1.5e-05 in `phi`, and `[1, 0, 0, 0.5]` 2.4e-04.

That remainder is the reference, not this change. Fortran's `torflux` (`magnetic_fluxes.f90`) integrates the `aphi` polynomial with a fixed 100-panel trapezoid, which is exact only up to a linear integrand, and the result normalizes its enclosed flux. The error is independent of the radial grid: the code-to-code deviation in `phi` for `[1, -0.3, 0.3]` is 1.500e-05 at ns = 15, 29 and 57 alike, which is the trapezoid error `a_2 / 20000` for that coefficient. VMEC++ integrates the polynomial in closed form, so its own edge flux converges on `phiedge` as the radial grid refines, at 3.8e-04, 9.6e-05 and 2.4e-05 for those three resolutions, second order in the step, where the reference stalls against its quadrature floor.

The equilibrium itself is unaffected: `phi` is post-processing, and `rmnc`, `zmns` and the geometry were already within 1e-09. The same accumulation in the geometry adapter, used when `phiF` has not been filled, is switched over as well.

Two tests, each failing on the rectangle rule. `ToroidalFluxFollowsTheAphiPolynomial` solves the case at `ns = 9` with `aphi = [1, 0.5]` and requires `phi` to equal the analytic integral at every surface, which the rectangle rule misses by 2 percent. `DerivesToroidalFluxFromTheHalfGridDerivative` drives `MakeGeometry` with no `phiF` to copy, so the adapter's own accumulation runs, over a linear `dphi/ds` whose integral is known in closed form.

`bazel test --config=opt //vmecpp/... //vmecpp_large_cpp_tests/...` and `pytest` pass.
