### PR TITLE
Integrate the line-segment profile to the evaluation point, not the next knot

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
@@ -982,37 +982,32 @@ double RadialProfiles::evalLineSegmentIntegrated(
   }
 
   auto integrate_segment = [](double x0, double x1, double y0, double y1) {
+    if (x1 == x0) {
+      return 0.0;
+    }
     const double m = (y1 - y0) / (x1 - x0);
     const double b = y0 - m * x0;
     return m * 0.5 * (x1 * x1 - x0 * x0) + b * (x1 - x0);
   };
+  auto value_at = [&](double s) {
+    return evalLineSegment(splineKnots, splineValues, s);
+  };
 
-  double xi = x;
+  // integrate the interpolant from 0 to x, one straight piece at a time
+  double lower = 0.0;
   double result = 0.0;
-
-  if (xi <= splineKnots[0]) {
-    result += integrate_segment(0.0, xi, splineValues[0],
-                                evalLineSegment(splineKnots, splineValues, xi));
-    return result;
+  for (int i = 0; i < n; ++i) {
+    const double knot = splineKnots[i];
+    if (knot <= lower) {
+      continue;
+    }
+    if (knot >= x) {
+      break;
+    }
+    result += integrate_segment(lower, knot, value_at(lower), splineValues[i]);
+    lower = knot;
   }
-
-  int idx = 0;
-  while (idx < n - 1 && xi > splineKnots[idx + 1]) {
-    result += integrate_segment(splineKnots[idx], splineKnots[idx + 1],
-                                splineValues[idx], splineValues[idx + 1]);
-    ++idx;
-  }
-
-  const double x0 = splineKnots[idx];
-  const double x1 = std::min(xi, splineKnots[idx + 1]);
-  const double y0 = splineValues[idx];
-  const double y1 = splineValues[idx + 1];
-  result += integrate_segment(x0, x1, y0, y1);
-
-  if (xi > splineKnots[n - 1]) {
-    result += integrate_segment(splineKnots[n - 1], xi, splineValues[n - 1],
-                                evalLineSegment(splineKnots, splineValues, xi));
-  }
+  result += integrate_segment(lower, x, value_at(lower), value_at(x));
 
   return result;
 }

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles_test.cc
@@ -490,4 +490,30 @@ TEST_F(RadialProfilesTest, AnalyticProfilesRouteThroughDispatch) {
   }
 }
 
+// ---- the integrated line segments are the exact area under them ------------
+TEST_F(RadialProfilesTest, LineSegmentIntegralIsExact) {
+  const Eigen::VectorXd knots = Vec({0.1, 0.3, 0.6, 1.0});
+  const Eigen::VectorXd values = Vec({1.0, 0.7, 0.5, 0.2});
+
+  // area from 0 to x under the interpolant, which extrapolates the end
+  // segments outside the knots
+  auto area = [&](double x) {
+    const int samples = 2000001;
+    const double h = x / (samples - 1);
+    double sum = 0.0;
+    for (int i = 0; i < samples; ++i) {
+      const double weight = (i == 0 || i == samples - 1) ? 0.5 : 1.0;
+      sum += weight * profiles_->evalLineSegment(knots, values, i * h);
+    }
+    return sum * h;
+  };
+
+  // between knots, on knots, before the first and past the last
+  for (double x : {0.05, 0.1, 0.2, 0.3, 0.45, 0.6, 0.85, 1.0, 1.3}) {
+    EXPECT_NEAR(profiles_->evalLineSegmentIntegrated(knots, values, x), area(x),
+                1e-10)
+        << "x = " << x;
+  }
+}
+
 }  // namespace vmecpp


### PR DESCRIPTION
`evalLineSegmentIntegrated` builds the last, truncated piece of the integral from the value at the *next knot* rather than the value at the truncation point, so the straight line it integrates has the wrong slope whenever the evaluation point falls between two knots. The result is exact on the knots and wrong in between.

For knots at `0, 0.1, ..., 1.0` and values `1.0, 0.95, 0.86, 0.74, 0.60, 0.46, 0.33, 0.21, 0.12, 0.06, 0.03`:

| s | before | exact |
|---|---|---|
| 0.05 | 4.875000e-02 | 4.937500e-02 |
| 0.25 | 2.280000e-01 | 2.295000e-01 |
| 0.50 | 3.880000e-01 | 3.880000e-01 |
| 0.75 | 4.627500e-01 | 4.638750e-01 |
| 1.00 | 4.845000e-01 | 4.845000e-01 |

`pcurr_type = 'line_segment_ip'` is the only profile that reaches this path. On `cth_like_fixed_bdy` with `ncurr = 1` and the current derivative above, the converged equilibrium differed from educational_VMEC by 1.8e-02 in `iotaf`, 1.6e-02 in `jcurv`, 8.6e-04 in `ctor` and 3.7e-05 in `rmnc`, and by 7.2e-01 in `DCurr`. Every field now agrees below 1e-09 with the iteration count unchanged at 413. The other nine current parameterizations, including `akima_spline_ip` and `cubic_spline_ip`, already agreed and still do.

The walk over the knots also read one past the end of both arrays when the evaluation point lay beyond the last knot, and added that piece twice.

The rewritten loop integrates the interpolant from 0 to x piece by piece, taking each endpoint value from the interpolant itself, which also covers the extrapolation below the first knot and above the last. The test compares it against a fine trapezoidal quadrature of the same interpolant on and between the knots and outside both ends.

`bazel test --config=opt //vmecpp/... //vmecpp_large_cpp_tests/...` and `pytest` pass.
