### PR TITLE
Evaluate and integrate a line-segment profile over the same interpolant

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
@@ -954,8 +954,8 @@ double RadialProfiles::evalRational(const Eigen::VectorXd& coeffs, double x) {
                               : std::numeric_limits<double>::max();
 }
 
-// Linear interpolation between the two knots that bracket x.
-// Clamp the profile if x is outside the range of knots.
+// Linear interpolation between the two knots that bracket x, continued along
+// the first or last segment for an x outside the knots.
 double RadialProfiles::evalLineSegment(const Eigen::VectorXd& splineKnots,
                                        const Eigen::VectorXd& splineValues,
                                        double x) {
@@ -963,26 +963,25 @@ double RadialProfiles::evalLineSegment(const Eigen::VectorXd& splineKnots,
   if (n < 2 || n != static_cast<int>(splineValues.size())) {
     return 0.0;
   }
-  if (x <= splineKnots[0]) {
-    return splineValues[0];
-  }
+  int ilow = 0;
   if (x >= splineKnots[n - 1]) {
-    return splineValues[n - 1];
+    ilow = n - 2;
+  } else if (x > splineKnots[0]) {
+    // the first knot strictly above x, so the interval below it encloses x and
+    // has positive length
+    const auto upper =
+        std::upper_bound(splineKnots.begin(), splineKnots.end(), x);
+    ilow = static_cast<int>(std::distance(splineKnots.begin(), upper)) - 1;
   }
-  // The first knot strictly above x and the knot before it, which is the last
-  // one at or below x, enclose x, so the interval has positive length.
-  const auto upper =
-      std::upper_bound(splineKnots.begin(), splineKnots.end(), x);
-  const int ihigh = static_cast<int>(std::distance(splineKnots.begin(), upper));
-  const int ilow = ihigh - 1;
   const double x0 = splineKnots[ilow];
-  const double x1 = splineKnots[ihigh];
+  const double x1 = splineKnots[ilow + 1];
   const double y0 = splineValues[ilow];
-  const double y1 = splineValues[ihigh];
+  const double y1 = splineValues[ilow + 1];
   const double t = (x - x0) / (x1 - x0);
   return (1.0 - t) * y0 + t * y1;
 }
 
+// Integral of evalLineSegment from 0 to x.
 double RadialProfiles::evalLineSegmentIntegrated(
     const Eigen::VectorXd& splineKnots, const Eigen::VectorXd& splineValues,
     double x) {
@@ -991,38 +990,24 @@ double RadialProfiles::evalLineSegmentIntegrated(
     return 0.0;
   }
 
-  auto integrate_segment = [](double x0, double x1, double y0, double y1) {
-    const double m = (y1 - y0) / (x1 - x0);
-    const double b = y0 - m * x0;
-    return m * 0.5 * (x1 * x1 - x0 * x0) + b * (x1 - x0);
+  const auto value_at = [this, &splineKnots, &splineValues](double xi) {
+    return evalLineSegment(splineKnots, splineValues, xi);
   };
 
-  double xi = x;
+  // The interpolant is linear between consecutive knots and along the
+  // continued end segments outside them, so the trapezoidal rule is exact on
+  // every piece the knots inside (0, x) cut the interval into.
   double result = 0.0;
-
-  if (xi <= splineKnots[0]) {
-    result += integrate_segment(0.0, xi, splineValues[0],
-                                evalLineSegment(splineKnots, splineValues, xi));
-    return result;
+  double lower = 0.0;
+  for (int i = 0; i < n && splineKnots[i] < x; ++i) {
+    if (splineKnots[i] <= lower) {
+      continue;
+    }
+    const double upper = splineKnots[i];
+    result += 0.5 * (upper - lower) * (value_at(lower) + value_at(upper));
+    lower = upper;
   }
-
-  int idx = 0;
-  while (idx < n - 1 && xi > splineKnots[idx + 1]) {
-    result += integrate_segment(splineKnots[idx], splineKnots[idx + 1],
-                                splineValues[idx], splineValues[idx + 1]);
-    ++idx;
-  }
-
-  const double x0 = splineKnots[idx];
-  const double x1 = std::min(xi, splineKnots[idx + 1]);
-  const double y0 = splineValues[idx];
-  const double y1 = splineValues[idx + 1];
-  result += integrate_segment(x0, x1, y0, y1);
-
-  if (xi > splineKnots[n - 1]) {
-    result += integrate_segment(splineKnots[n - 1], xi, splineValues[n - 1],
-                                evalLineSegment(splineKnots, splineValues, xi));
-  }
+  result += 0.5 * (x - lower) * (value_at(lower) + value_at(x));
 
   return result;
 }

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles_test.cc
@@ -139,7 +139,7 @@ TEST_F(RadialProfilesTest, SplineTooFewPointsReturnsZero) {
 // ---- line_segment: interpolate on the knot interval that brackets x ---------
 // Inside [k_i, k_{i+1}] the value is the linear interpolation between those two
 // knots, the knots themselves are reproduced, and outside the knot range the
-// profile is clamped to the end values.
+// first and last segments continue.
 TEST_F(RadialProfilesTest, LineSegmentInterpolatesOnBracketingInterval) {
   const Eigen::VectorXd knots = Vec({0.0, 0.25, 0.5, 0.75, 1.0});
   const Eigen::VectorXd values = Vec({1.0, 0.9, 0.6, 0.2, 0.0});
@@ -158,8 +158,44 @@ TEST_F(RadialProfilesTest, LineSegmentInterpolatesOnBracketingInterval) {
                 1e-12)
         << "line_segment knot " << i;
   }
-  EXPECT_EQ(profiles_->evalLineSegment(knots, values, -0.1), values[0]);
-  EXPECT_EQ(profiles_->evalLineSegment(knots, values, 1.2), values[4]);
+  // outside the knots the first and last segments continue
+  EXPECT_NEAR(profiles_->evalLineSegment(knots, values, -0.1), 1.04, 1e-12);
+  EXPECT_NEAR(profiles_->evalLineSegment(knots, values, 1.2), -0.16, 1e-12);
+}
+
+// ---- line_segment integral: the integral of that same interpolant ----------
+// evalLineSegmentIntegrated returns the integral from 0 to x of the profile
+// evalLineSegment evaluates, so it carries the piece below the first knot and
+// the continued end segments and agrees with a fine quadrature of that profile.
+TEST_F(RadialProfilesTest, LineSegmentIntegralFollowsTheInterpolant) {
+  // knots reaching neither end of [0, 1], so both continued segments and the
+  // piece below the first knot enter the integral
+  const Eigen::VectorXd knots = Vec({0.2, 0.35, 0.6, 0.8});
+  const Eigen::VectorXd values = Vec({1.0, 0.7, 0.5, 0.2});
+
+  // the first segment continues to y(0) = 1.4, so the integral up to the first
+  // knot is 1.4 * 0.2 - 0.2^2
+  EXPECT_NEAR(profiles_->evalLineSegmentIntegrated(knots, values, 0.2), 0.24,
+              1e-12);
+
+  const auto quadrature = [&](double x) {
+    const int num_panels = 200000;
+    double sum = 0.0;
+    for (int i = 0; i < num_panels; ++i) {
+      const double xa = x * i / num_panels;
+      const double xb = x * (i + 1) / num_panels;
+      sum += 0.5 * (xb - xa) *
+             (profiles_->evalLineSegment(knots, values, xa) +
+              profiles_->evalLineSegment(knots, values, xb));
+    }
+    return sum;
+  };
+
+  for (const double x : {0.05, 0.2, 0.3, 0.35, 0.5, 0.6, 0.7, 0.8, 1.0, 1.3}) {
+    EXPECT_NEAR(profiles_->evalLineSegmentIntegrated(knots, values, x),
+                quadrature(x), 1e-9)
+        << "line_segment integral x=" << x;
+  }
 }
 
 // ---- corrected Akima right edge: the interpolant is reflection-symmetric ---


### PR DESCRIPTION
The two `line_segment` evaluators disagreed about what profile they represent.

`evalLineSegment` returned the first or last knot value outside the knots, where Fortran VMEC's `line_seg` continues the first or last segment, taking `ilow, ihigh = 1, 2` below the knots and `n-1, n` above them.

`evalLineSegmentIntegrated` integrated something else again. It started the sum at the first knot, so the piece from `s = 0` up to that knot was dropped; below the first knot it drew a line from `(0, values[0])` to the evaluation point, which is the clamped value rather than the profile's own value at zero; and the truncated last piece took its upper value from the next knot instead of from the evaluation point, so that piece carried the wrong slope. The walk also read one past the end of both arrays beyond the last knot.

Both now describe one interpolant: linear on each knot interval and continued along the first and last segments outside them. `evalLineSegmentIntegrated` integrates that interpolant from 0 to x, splitting at the knots that fall inside the interval and taking every endpoint value from `evalLineSegment`, which is exact because each piece is linear.

Measured against educational_VMEC reading the same INDATA file, largest relative deviation over the wout, with iteration counts in brackets.

`PMASS_TYPE = 'line_segment'` with nine knots on `[0.1, 0.9]`, a cth-like fixed-boundary case:

| quantity | before | after |
|---|---|---|
| `DWell` | 8.98e-01 | 2.46e-12 |
| `DCurr` | 5.93e-01 | 1.10e-10 |
| `betaxis` | 8.40e-02 | 1.75e-14 |
| `presf` | 8.34e-02 | 3.79e-16 |
| `iotaf` | 4.47e-04 | 4.47e-14 |
| iterations | [414] | [415], as Fortran |

`PCURR_TYPE = 'line_segment_ip'` on the same case, which is the only profile reaching the integrated path:

| quantity | before | after |
|---|---|---|
| `DCurr` | 7.17e-01 | 9.75e-12 |
| `iotaf` | 1.80e-02 | 4.37e-14 |
| `jcurv` | 1.57e-02 | 4.95e-14 |
| `ctor` | 8.60e-04 | 2.02e-15 |
| `rmnc` | 3.72e-05 | 2.46e-14 |
| iterations | [413] | [413] |

Every wout field of both cases now agrees below 1e-10, and so do `line_segment_i` and the same pressure profile with knots reaching `[0.0, 1.0]`, which is what every shipped input uses and which is unchanged. The nine other current parameterizations, `akima_spline_ip` and `cubic_spline_ip` among them, already agreed and still do.

The test compares the integrated form against a fine quadrature of `evalLineSegment` itself, on knots, between them, below the first knot and beyond the last, with knots that reach neither end of the domain; it fails on the previous integral at every one of those points. The direct evaluator keeps its existing test, with the two points outside the knots pinned to the continued values instead of the clamped ones.

This supersedes #811, which fixed the truncated last piece alone.

`bazel test --config=opt //vmecpp/... //vmecpp_large_cpp_tests/...` and `pytest` pass.
