### PR TITLE
Report the free-boundary threed1 section over the full asymmetric poloidal range

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -1439,7 +1439,8 @@ vmecpp::Threed1FreeBoundary vmecpp::ComputeThreed1FreeBoundary(
   Threed1FreeBoundary result;
 
   const int num_zeta = s.nZeta;
-  const int num_theta = s.nThetaReduced;
+  // the full poloidal range of an asymmetric run, the half range otherwise
+  const int num_theta = s.nThetaEff;
   result.rb = RowMatrixXd::Zero(num_zeta, num_theta);
   result.phib = RowMatrixXd::Zero(num_zeta, num_theta);
   result.zb = RowMatrixXd::Zero(num_zeta, num_theta);

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
@@ -795,3 +795,49 @@ TEST(TestVmec, MultiGridFreeBoundary) {
   // second stage enters force-balanced instead of kicking the boundary).
   EXPECT_EQ(output->wout.niter, 321);
 }  // MultiGridFreeBoundary
+
+// The free-boundary threed1 section covers the poloidal range the run is solved
+// on, which is the full one for an asymmetric equilibrium, so the boundary it
+// reports must reproduce the wout Fourier series at every point of that range.
+TEST(TestVmec, Threed1FreeBoundaryCoversTheAsymmetricPoloidalRange) {
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile("vmecpp/test_data/cth_like_free_bdy_asym.json");
+  ASSERT_TRUE(indata_json.ok());
+  const absl::StatusOr<VmecINDATA> indata = VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(indata.ok());
+  ASSERT_TRUE(indata->lasym);
+
+  auto maybe_vmec = Vmec::FromIndata(*indata);
+  ASSERT_TRUE(maybe_vmec.ok());
+  Vmec& vmec = **maybe_vmec;
+  ASSERT_TRUE(vmec.run().ok());
+
+  const Sizes& s = vmec.s_;
+  const vmecpp::Threed1FreeBoundary& free_boundary =
+      vmec.output_quantities_.threed1_free_boundary;
+  ASSERT_EQ(free_boundary.rb.rows(), s.nZeta);
+  ASSERT_EQ(free_boundary.rb.cols(), s.nThetaEff);
+  ASSERT_GT(s.nThetaEff, s.nThetaReduced);
+
+  const vmecpp::WOutFileContents& wout = vmec.output_quantities_.wout;
+  const int boundary = wout.ns - 1;
+  for (int k = 0; k < s.nZeta; ++k) {
+    const double zeta = 2.0 * M_PI * k / (s.nZeta * s.nfp);
+    for (int l = 0; l < s.nThetaEff; ++l) {
+      const double theta = 2.0 * M_PI * l / s.nThetaEff;
+      double r = 0.0;
+      double z = 0.0;
+      for (int mn = 0; mn < wout.mnmax; ++mn) {
+        const double angle = wout.xm[mn] * theta - wout.xn[mn] * zeta;
+        r += wout.rmnc(mn, boundary) * std::cos(angle) +
+             wout.rmns(mn, boundary) * std::sin(angle);
+        z += wout.zmns(mn, boundary) * std::sin(angle) +
+             wout.zmnc(mn, boundary) * std::cos(angle);
+      }  // mn
+      EXPECT_TRUE(IsCloseRelAbs(r, free_boundary.rb(k, l), 1.0e-10))
+          << "zeta index " << k << ", theta index " << l;
+      EXPECT_TRUE(IsCloseRelAbs(z, free_boundary.zb(k, l), 1.0e-10))
+          << "zeta index " << k << ", theta index " << l;
+    }  // l
+  }  // k
+}  // Threed1FreeBoundaryCoversTheAsymmetricPoloidalRange


### PR DESCRIPTION
`ComputeThreed1FreeBoundary` sizes its arrays with `s.nThetaReduced` and loops over that many poloidal points. `freeb_data.f90` loops `DO iu = 1, ntheta3`, the poloidal count the run is solved on, which is the reduced range only for a stellarator-symmetric equilibrium and the full range for an asymmetric one. The two agree for every symmetric case, which is what the existing comparison against educational_VMEC covers.

For an asymmetric free-boundary run the section therefore reports `nThetaReduced` of the `nThetaEff` points, so the boundary geometry, the plasma-side and vacuum-side pressures and the edge and vacuum field components stop partway around the poloidal angle. On `cth_like_free_bdy_asym` that is 9 of the 16 points.

The loop body already indexes as the full range does, `k * nThetaEff + l` into the fast-poloidal arrays and `l * nZeta + k` into the ones Nestor hands back, so the count is the only thing that changes; the symmetric cases are untouched because `nThetaEff` equals `nThetaReduced` there.

The test solves `cth_like_free_bdy_asym`, requires the reported array to span `nThetaEff`, and checks the reported boundary against the wout Fourier series evaluated at each reported angle. It fails on the truncated range.

`bazel test --config=opt //vmecpp/... //vmecpp_large_cpp_tests/...` and `pytest` pass.
