### PR TITLE
Reject a profile that its evaluator cannot evaluate

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -44,17 +44,19 @@ std::string ProfileTypeName(vmecpp::ProfileType profile_type) {
 }
 
 // Checks that `type_name` names a profile parameterization that may be used for
-// `profile_type`, and that a spline parameterization was given its knots. An
-// unrecognized name otherwise reaches the solver as a zero profile, which
-// converges to a silently wrong equilibrium.
+// `profile_type`, that a spline parameterization was given its knots, and that
+// a closed-form parameterization was given the coefficients it needs. An
+// unrecognized name or a profile short of its data otherwise reaches the
+// solver as a zero profile, which converges to a silently wrong equilibrium.
 //
-// The polynomial coefficient arrays are deliberately not required to be
-// non-empty: they are zero-padded on read, so an empty array is a valid way to
-// specify a zero profile.
+// The polynomial coefficient arrays are zero-padded on read, so an empty
+// array is a valid way to specify a zero power series; the closed forms that
+// raise to a coefficient or divide by one need their full set.
 absl::Status CheckProfile(const std::string& type_key,
                           const std::string& type_name,
                           vmecpp::ProfileType profile_type,
-                          const std::string& aux_key,
+                          const std::string& coefficient_key,
+                          const Eigen::VectorXd& coefficients,
                           const Eigen::VectorXd& aux_s,
                           const Eigen::VectorXd& aux_f) {
   const vmecpp::ProfileParameterizationData* const parameterization =
@@ -73,25 +75,55 @@ absl::Status CheckProfile(const std::string& type_key,
         type_key, type_name, ProfileTypeName(profile_type)));
   }
 
+  const int minimum_coefficients = parameterization->MinimumCoefficients();
+  if (coefficients.size() < minimum_coefficients) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "'%s' is '%s', which needs at least %d coefficients, but '%s' has "
+        "%d\n",
+        type_key, type_name, minimum_coefficients, coefficient_key,
+        coefficients.size()));
+  }
+
   if (parameterization->NeedsSplineData()) {
     if (aux_s.size() == 0 || aux_f.size() == 0) {
       return absl::InvalidArgumentError(absl::StrFormat(
           "'%s' is '%s', which is a spline profile, so '%s_aux_s' and "
           "'%s_aux_f' must be given\n",
-          type_key, type_name, aux_key, aux_key));
+          type_key, type_name, coefficient_key, coefficient_key));
     }
     if (aux_s.size() != aux_f.size()) {
       return absl::InvalidArgumentError(absl::StrFormat(
           "'%s_aux_s' and '%s_aux_f' must have the same number of entries, "
           "but have %d and %d\n",
-          aux_key, aux_key, aux_s.size(), aux_f.size()));
+          coefficient_key, coefficient_key, aux_s.size(), aux_f.size()));
     }
     const int minimum_points = parameterization->MinimumSplinePoints();
     if (aux_s.size() < minimum_points) {
       return absl::InvalidArgumentError(absl::StrFormat(
           "'%s' is '%s', which needs at least %d spline points, but "
           "'%s_aux_s' has %d\n",
-          type_key, type_name, minimum_points, aux_key, aux_s.size()));
+          type_key, type_name, minimum_points, coefficient_key, aux_s.size()));
+    }
+    for (Eigen::Index i = 1; i < aux_s.size(); ++i) {
+      if (aux_s[i] <= aux_s[i - 1]) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "'%s_aux_s' must increase strictly, but entries %d and %d are "
+            "%g and %g\n",
+            coefficient_key, i - 1, i, aux_s[i - 1], aux_s[i]));
+      }
+    }
+    // The Akima and cubic evaluators return zero outside their knots; the
+    // line segments continue their end segments instead.
+    const bool zero_outside_knots =
+        type_name.compare(0, 12, "akima_spline") == 0 ||
+        type_name.compare(0, 12, "cubic_spline") == 0;
+    if (zero_outside_knots &&
+        (aux_s[0] > 0.0 || aux_s[aux_s.size() - 1] < 1.0)) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "'%s' is '%s', which is evaluated only inside its knots, so "
+          "'%s_aux_s' must run from 0 to 1, but runs from %g to %g\n",
+          type_key, type_name, coefficient_key, aux_s[0],
+          aux_s[aux_s.size() - 1]));
     }
   }
 
@@ -1432,7 +1464,7 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
   // pmass_type, am_aux_s, am_aux_f
   if (absl::Status status = CheckProfile(
           "pmass_type", vmec_indata.pmass_type, ProfileType::PRESSURE, "am",
-          vmec_indata.am_aux_s, vmec_indata.am_aux_f);
+          vmec_indata.am, vmec_indata.am_aux_s, vmec_indata.am_aux_f);
       !status.ok()) {
     return status;
   }
@@ -1462,9 +1494,9 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
 
   // piota_type, ai_aux_s, ai_aux_f. Checked for either ncurr: piota is the
   // initial guess for the iota profile even in a current-constrained run.
-  if (absl::Status status =
-          CheckProfile("piota_type", vmec_indata.piota_type, ProfileType::IOTA,
-                       "ai", vmec_indata.ai_aux_s, vmec_indata.ai_aux_f);
+  if (absl::Status status = CheckProfile(
+          "piota_type", vmec_indata.piota_type, ProfileType::IOTA, "ai",
+          vmec_indata.ai, vmec_indata.ai_aux_s, vmec_indata.ai_aux_f);
       !status.ok()) {
     return status;
   }
@@ -1472,7 +1504,7 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
   // pcurr_type, ac_aux_s, ac_aux_f. Ignored for ncurr == 0, still checked.
   if (absl::Status status = CheckProfile(
           "pcurr_type", vmec_indata.pcurr_type, ProfileType::CURRENT, "ac",
-          vmec_indata.ac_aux_s, vmec_indata.ac_aux_f);
+          vmec_indata.ac, vmec_indata.ac_aux_s, vmec_indata.ac_aux_f);
       !status.ok()) {
     return status;
   }

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -86,6 +86,13 @@ absl::Status CheckProfile(const std::string& type_key,
           "but have %d and %d\n",
           aux_key, aux_key, aux_s.size(), aux_f.size()));
     }
+    const int minimum_points = parameterization->MinimumSplinePoints();
+    if (aux_s.size() < minimum_points) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "'%s' is '%s', which needs at least %d spline points, but "
+          "'%s_aux_s' has %d\n",
+          type_key, type_name, minimum_points, aux_key, aux_s.size()));
+    }
   }
 
   return absl::OkStatus();

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
@@ -267,6 +267,49 @@ TEST(TestVmecINDATA, CheckSplineProfilesNeedKnots) {
   EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
 }
 
+// Below its knot count a spline evaluator returns zero for every s, so the run
+// converges to an equilibrium without the requested profile. The cubic and
+// Akima families need four knots, the line segments two.
+TEST(TestVmecINDATA, CheckSplineProfilesNeedEnoughKnots) {
+  struct Case {
+    std::string name;
+    int minimum;
+  };
+  for (const Case& c : {Case{"akima_spline", 4}, Case{"cubic_spline", 4},
+                        Case{"line_segment", 2}}) {
+    VmecINDATA indata;
+    indata.pmass_type = c.name;
+
+    indata.am_aux_s = Eigen::VectorXd::LinSpaced(c.minimum - 1, 0.0, 1.0);
+    indata.am_aux_f = Eigen::VectorXd::Zero(c.minimum - 1);
+    EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok())
+        << c.name;
+
+    indata.am_aux_s = Eigen::VectorXd::LinSpaced(c.minimum, 0.0, 1.0);
+    indata.am_aux_f = Eigen::VectorXd::Zero(c.minimum);
+    EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok())
+        << c.name;
+  }
+
+  // the current and iota profiles are held to the same counts
+  for (const Case& c :
+       {Case{"akima_spline_ip", 4}, Case{"line_segment_i", 2}}) {
+    VmecINDATA indata;
+    indata.ncurr = 1;
+    indata.pcurr_type = c.name;
+    indata.ac_aux_s = Eigen::VectorXd::LinSpaced(c.minimum - 1, 0.0, 1.0);
+    indata.ac_aux_f = Eigen::VectorXd::Zero(c.minimum - 1);
+    EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok())
+        << c.name;
+  }
+
+  VmecINDATA iota_indata;
+  iota_indata.piota_type = "cubic_spline";
+  iota_indata.ai_aux_s = Eigen::VectorXd::LinSpaced(3, 0.0, 1.0);
+  iota_indata.ai_aux_f = Eigen::VectorXd::Zero(3);
+  EXPECT_FALSE(IsConsistent(iota_indata, /*enable_info_messages=*/false).ok());
+}
+
 TEST(TestVmecINDATA, ToJson) {
   const absl::StatusOr<std::string> indata_json =
       ReadFile("vmecpp/test_data/cth_like_free_bdy.json");

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
@@ -7,6 +7,7 @@
 #include <H5File.h>
 
 #include <filesystem>
+#include <initializer_list>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -308,6 +309,71 @@ TEST(TestVmecINDATA, CheckSplineProfilesNeedEnoughKnots) {
   iota_indata.ai_aux_s = Eigen::VectorXd::LinSpaced(3, 0.0, 1.0);
   iota_indata.ai_aux_f = Eigen::VectorXd::Zero(3);
   EXPECT_FALSE(IsConsistent(iota_indata, /*enable_info_messages=*/false).ok());
+}
+
+// Below its coefficient count a closed-form evaluator returns zero for every
+// s, so the run converges to an equilibrium without the requested profile.
+// gauss_trunc needs 2 coefficients, two_power and two_power_gs 3 and
+// two_lorentz 8; the zero-padded power series accept any count.
+TEST(TestVmecINDATA, CheckClosedFormProfilesNeedEnoughCoefficients) {
+  struct Case {
+    std::string name;
+    int minimum;
+  };
+  for (const Case& c : {Case{"gauss_trunc", 2}, Case{"two_power", 3},
+                        Case{"two_power_gs", 3}, Case{"two_lorentz", 8}}) {
+    VmecINDATA indata;
+    indata.pmass_type = c.name;
+    indata.am = Eigen::VectorXd::Ones(c.minimum - 1);
+    EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok())
+        << c.name;
+    indata.am = Eigen::VectorXd::Ones(c.minimum);
+    EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok())
+        << c.name;
+  }
+
+  // the current profile is held to the same counts
+  VmecINDATA current_indata;
+  current_indata.ncurr = 1;
+  current_indata.pcurr_type = "two_power";
+  current_indata.ac = Eigen::VectorXd::Ones(2);
+  EXPECT_FALSE(
+      IsConsistent(current_indata, /*enable_info_messages=*/false).ok());
+  current_indata.ac = Eigen::VectorXd::Ones(3);
+  EXPECT_TRUE(
+      IsConsistent(current_indata, /*enable_info_messages=*/false).ok());
+}
+
+// The spline evaluators walk the knots in order and, for the Akima and cubic
+// families, return zero outside them where Fortran VMEC stops; the line
+// segments continue their end segments and may stop short of the radius.
+TEST(TestVmecINDATA, CheckSplineKnotsIncreaseAndSpanTheRadius) {
+  const auto knots = [](std::initializer_list<double> values) {
+    Eigen::VectorXd v(static_cast<Eigen::Index>(values.size()));
+    Eigen::Index i = 0;
+    for (double value : values) v[i++] = value;
+    return v;
+  };
+  VmecINDATA indata;
+  indata.pmass_type = "cubic_spline";
+  indata.am_aux_f = Eigen::VectorXd::Zero(5);
+  indata.am_aux_s = knots({0.0, 0.25, 0.5, 0.75, 1.0});
+  EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+  indata.am_aux_s = knots({0.0, 0.5, 0.25, 0.75, 1.0});
+  EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+  indata.am_aux_s = knots({0.0, 0.25, 0.25, 0.75, 1.0});
+  EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+  indata.am_aux_s = knots({0.0, 0.2, 0.4, 0.6, 0.9});
+  EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+  indata.am_aux_s = knots({0.1, 0.3, 0.5, 0.7, 1.0});
+  EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+
+  indata.pmass_type = "line_segment";
+  indata.am_aux_f = Eigen::VectorXd::Zero(3);
+  indata.am_aux_s = knots({0.1, 0.5, 0.9});
+  EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+  indata.am_aux_s = knots({0.1, 0.9, 0.5});
+  EXPECT_FALSE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
 }
 
 TEST(TestVmecINDATA, ToJson) {

--- a/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.cc
@@ -39,73 +39,96 @@ std::vector<ProfileParameterizationData> BuildProfileParameterizations() {
   all.reserve(NUM_PARAM);
   all.emplace_back("---invalid---", /*allowedForPres=*/false,
                    /*allowedForCurr*/ false, /*allowedForIota*/ false,
-                   /*minimumSplinePoints*/ 0);
+                   /*minimumSplinePoints*/ 0,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("power_series", /*allowedForPres=*/true,
                    /*allowedForCurr*/ true, /*allowedForIota*/ true,
-                   /*minimumSplinePoints*/ 0);
+                   /*minimumSplinePoints*/ 0,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("power_series_i", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*minimumSplinePoints*/ 0);
+                   /*minimumSplinePoints*/ 0,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("gauss_trunc", /*allowedForPres=*/true,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*minimumSplinePoints*/ 0);
+                   /*minimumSplinePoints*/ 0,
+                   /*minimumCoefficients*/ 2);
   all.emplace_back("sum_atan", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ true,
-                   /*minimumSplinePoints*/ 0);
+                   /*minimumSplinePoints*/ 0,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("two_lorentz", /*allowedForPres=*/true,
                    /*allowedForCurr*/ false, /*allowedForIota*/ false,
-                   /*minimumSplinePoints*/ 0);
+                   /*minimumSplinePoints*/ 0,
+                   /*minimumCoefficients*/ 8);
   all.emplace_back("two_power", /*allowedForPres=*/true,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*minimumSplinePoints*/ 0);
+                   /*minimumSplinePoints*/ 0,
+                   /*minimumCoefficients*/ 3);
   all.emplace_back("two_power_gs", /*allowedForPres=*/true,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*minimumSplinePoints*/ 0);
+                   /*minimumSplinePoints*/ 0,
+                   /*minimumCoefficients*/ 3);
   all.emplace_back("akima_spline", /*allowedForPres=*/true,
                    /*allowedForCurr*/ false, /*allowedForIota*/ true,
-                   /*minimumSplinePoints*/ 4);
+                   /*minimumSplinePoints*/ 4,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("akima_spline_i", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*minimumSplinePoints*/ 4);
+                   /*minimumSplinePoints*/ 4,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("akima_spline_ip", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*minimumSplinePoints*/ 4);
+                   /*minimumSplinePoints*/ 4,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("cubic_spline", /*allowedForPres=*/true,
                    /*allowedForCurr*/ false, /*allowedForIota*/ true,
-                   /*minimumSplinePoints*/ 4);
+                   /*minimumSplinePoints*/ 4,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("cubic_spline_i", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*minimumSplinePoints*/ 4);
+                   /*minimumSplinePoints*/ 4,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("cubic_spline_ip", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*minimumSplinePoints*/ 4);
+                   /*minimumSplinePoints*/ 4,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("pedestal", /*allowedForPres=*/true,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*minimumSplinePoints*/ 0);
+                   /*minimumSplinePoints*/ 0,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("rational", /*allowedForPres=*/true,
                    /*allowedForCurr*/ true, /*allowedForIota*/ true,
-                   /*minimumSplinePoints*/ 0);
+                   /*minimumSplinePoints*/ 0,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("line_segment", /*allowedForPres=*/true,
                    /*allowedForCurr*/ false, /*allowedForIota*/ true,
-                   /*minimumSplinePoints*/ 2);
+                   /*minimumSplinePoints*/ 2,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("line_segment_i", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*minimumSplinePoints*/ 2);
+                   /*minimumSplinePoints*/ 2,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("line_segment_ip", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*minimumSplinePoints*/ 2);
+                   /*minimumSplinePoints*/ 2,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("nice_quadratic", /*allowedForPres=*/false,
                    /*allowedForCurr*/ false, /*allowedForIota*/ true,
-                   /*minimumSplinePoints*/ 0);
+                   /*minimumSplinePoints*/ 0,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("sum_cossq_s", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*minimumSplinePoints*/ 0);
+                   /*minimumSplinePoints*/ 0,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("sum_cossq_sqrts", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*minimumSplinePoints*/ 0);
+                   /*minimumSplinePoints*/ 0,
+                   /*minimumCoefficients*/ 0);
   all.emplace_back("sum_cossq_s_free", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*minimumSplinePoints*/ 0);
+                   /*minimumSplinePoints*/ 0,
+                   /*minimumCoefficients*/ 0);
   return all;
 }
 
@@ -113,9 +136,10 @@ std::vector<ProfileParameterizationData> BuildProfileParameterizations() {
 
 ProfileParameterizationData::ProfileParameterizationData(
     const std::string& name, bool allowedForPres, bool allowedForCurr,
-    bool allowedForIota, int minimumSplinePoints)
+    bool allowedForIota, int minimumSplinePoints, int minimumCoefficients)
     : name_(name),
       minimumSplinePoints_(minimumSplinePoints),
+      minimumCoefficients_(minimumCoefficients),
       allowedFor_({.pres = allowedForPres,
                    .curr = allowedForCurr,
                    .iota = allowedForIota}) {}
@@ -124,6 +148,10 @@ const std::string& ProfileParameterizationData::Name() const { return name_; }
 
 int ProfileParameterizationData::MinimumSplinePoints() const {
   return minimumSplinePoints_;
+}
+
+int ProfileParameterizationData::MinimumCoefficients() const {
+  return minimumCoefficients_;
 }
 
 bool ProfileParameterizationData::NeedsSplineData() const {

--- a/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.cc
@@ -39,73 +39,73 @@ std::vector<ProfileParameterizationData> BuildProfileParameterizations() {
   all.reserve(NUM_PARAM);
   all.emplace_back("---invalid---", /*allowedForPres=*/false,
                    /*allowedForCurr*/ false, /*allowedForIota*/ false,
-                   /*needsSplineData*/ false);
+                   /*minimumSplinePoints*/ 0);
   all.emplace_back("power_series", /*allowedForPres=*/true,
                    /*allowedForCurr*/ true, /*allowedForIota*/ true,
-                   /*needsSplineData*/ false);
+                   /*minimumSplinePoints*/ 0);
   all.emplace_back("power_series_i", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*needsSplineData*/ false);
+                   /*minimumSplinePoints*/ 0);
   all.emplace_back("gauss_trunc", /*allowedForPres=*/true,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*needsSplineData*/ false);
+                   /*minimumSplinePoints*/ 0);
   all.emplace_back("sum_atan", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ true,
-                   /*needsSplineData*/ false);
+                   /*minimumSplinePoints*/ 0);
   all.emplace_back("two_lorentz", /*allowedForPres=*/true,
                    /*allowedForCurr*/ false, /*allowedForIota*/ false,
-                   /*needsSplineData*/ false);
+                   /*minimumSplinePoints*/ 0);
   all.emplace_back("two_power", /*allowedForPres=*/true,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*needsSplineData*/ false);
+                   /*minimumSplinePoints*/ 0);
   all.emplace_back("two_power_gs", /*allowedForPres=*/true,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*needsSplineData*/ false);
+                   /*minimumSplinePoints*/ 0);
   all.emplace_back("akima_spline", /*allowedForPres=*/true,
                    /*allowedForCurr*/ false, /*allowedForIota*/ true,
-                   /*needsSplineData*/ true);
+                   /*minimumSplinePoints*/ 4);
   all.emplace_back("akima_spline_i", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*needsSplineData*/ true);
+                   /*minimumSplinePoints*/ 4);
   all.emplace_back("akima_spline_ip", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*needsSplineData*/ true);
+                   /*minimumSplinePoints*/ 4);
   all.emplace_back("cubic_spline", /*allowedForPres=*/true,
                    /*allowedForCurr*/ false, /*allowedForIota*/ true,
-                   /*needsSplineData*/ true);
+                   /*minimumSplinePoints*/ 4);
   all.emplace_back("cubic_spline_i", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*needsSplineData*/ true);
+                   /*minimumSplinePoints*/ 4);
   all.emplace_back("cubic_spline_ip", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*needsSplineData*/ true);
+                   /*minimumSplinePoints*/ 4);
   all.emplace_back("pedestal", /*allowedForPres=*/true,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*needsSplineData*/ false);
+                   /*minimumSplinePoints*/ 0);
   all.emplace_back("rational", /*allowedForPres=*/true,
                    /*allowedForCurr*/ true, /*allowedForIota*/ true,
-                   /*needsSplineData*/ false);
+                   /*minimumSplinePoints*/ 0);
   all.emplace_back("line_segment", /*allowedForPres=*/true,
                    /*allowedForCurr*/ false, /*allowedForIota*/ true,
-                   /*needsSplineData*/ true);
+                   /*minimumSplinePoints*/ 2);
   all.emplace_back("line_segment_i", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*needsSplineData*/ true);
+                   /*minimumSplinePoints*/ 2);
   all.emplace_back("line_segment_ip", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*needsSplineData*/ true);
+                   /*minimumSplinePoints*/ 2);
   all.emplace_back("nice_quadratic", /*allowedForPres=*/false,
                    /*allowedForCurr*/ false, /*allowedForIota*/ true,
-                   /*needsSplineData*/ false);
+                   /*minimumSplinePoints*/ 0);
   all.emplace_back("sum_cossq_s", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*needsSplineData*/ false);
+                   /*minimumSplinePoints*/ 0);
   all.emplace_back("sum_cossq_sqrts", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*needsSplineData*/ false);
+                   /*minimumSplinePoints*/ 0);
   all.emplace_back("sum_cossq_s_free", /*allowedForPres=*/false,
                    /*allowedForCurr*/ true, /*allowedForIota*/ false,
-                   /*needsSplineData*/ false);
+                   /*minimumSplinePoints*/ 0);
   return all;
 }
 
@@ -113,17 +113,21 @@ std::vector<ProfileParameterizationData> BuildProfileParameterizations() {
 
 ProfileParameterizationData::ProfileParameterizationData(
     const std::string& name, bool allowedForPres, bool allowedForCurr,
-    bool allowedForIota, bool needsSplineData)
+    bool allowedForIota, int minimumSplinePoints)
     : name_(name),
-      needsSplineData_(needsSplineData),
+      minimumSplinePoints_(minimumSplinePoints),
       allowedFor_({.pres = allowedForPres,
                    .curr = allowedForCurr,
                    .iota = allowedForIota}) {}
 
 const std::string& ProfileParameterizationData::Name() const { return name_; }
 
+int ProfileParameterizationData::MinimumSplinePoints() const {
+  return minimumSplinePoints_;
+}
+
 bool ProfileParameterizationData::NeedsSplineData() const {
-  return needsSplineData_;
+  return minimumSplinePoints_ > 0;
 }
 
 AllowedFor ProfileParameterizationData::IsAllowedFor() const {

--- a/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.h
@@ -27,15 +27,18 @@ class ProfileParameterizationData {
  public:
   ProfileParameterizationData(const std::string& name, bool allowedForPres,
                               bool allowedForCurr, bool allowedForIota,
-                              bool needsSplineData);
+                              int minimumSplinePoints);
 
   const std::string& Name() const;
+  // Number of knots the evaluator needs; 0 for a parameterization that takes
+  // polynomial coefficients instead.
+  int MinimumSplinePoints() const;
   bool NeedsSplineData() const;
   AllowedFor IsAllowedFor() const;
 
  private:
   const std::string name_;
-  bool needsSplineData_;
+  int minimumSplinePoints_;
   AllowedFor allowedFor_;
 };
 

--- a/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.h
@@ -27,18 +27,22 @@ class ProfileParameterizationData {
  public:
   ProfileParameterizationData(const std::string& name, bool allowedForPres,
                               bool allowedForCurr, bool allowedForIota,
-                              int minimumSplinePoints);
+                              int minimumSplinePoints, int minimumCoefficients);
 
   const std::string& Name() const;
   // Number of knots the evaluator needs; 0 for a parameterization that takes
   // polynomial coefficients instead.
   int MinimumSplinePoints() const;
   bool NeedsSplineData() const;
+  // Number of coefficients the closed-form evaluator needs before it can
+  // form its powers and ratios; 0 for the zero-padded polynomial families.
+  int MinimumCoefficients() const;
   AllowedFor IsAllowedFor() const;
 
  private:
   const std::string name_;
   int minimumSplinePoints_;
+  int minimumCoefficients_;
   AllowedFor allowedFor_;
 };
 


### PR DESCRIPTION
**Change** - `IsConsistent` rejects a profile its evaluator cannot evaluate. The parameterization table records, per name, the knots a spline evaluator needs (4 for the Akima and cubic families, 2 for the line segments) and the coefficients a closed form needs (`gauss_trunc` 2, `two_power` and `two_power_gs` 3, `two_lorentz` 8; the zero-padded power series accept any count), and `CheckProfile` rejects an input that carries fewer. Spline knots must increase strictly, and the Akima and cubic families, which are evaluated only inside their knots, must run from 0 to 1; the line segments continue their end segments and may stop short. `NeedsSplineData()` becomes the knot count being positive, so its one caller is unchanged.

**Cause** - `CheckProfile` required a spline profile to carry knots and the two arrays to have the same length, but not to be long enough to evaluate. Below their counts the evaluators return `0.0` for every `s` after one warning: `evalAkima` and `evalCubic` need four knots, `evalLineSegment` two, and `gauss_trunc`, `two_power`, `two_power_gs` and `two_lorentz` need 2, 3, 3 and 8 coefficients. The Akima and cubic evaluators also return `0.0` outside their knots. That is the failure the validation added in #719 exists to prevent, in its own words: an unusable parameterization "reaches the solver as a zero profile, which converges to a silently wrong equilibrium." Fortran VMEC halts instead. `profile_functions.f` counts the knots and stops before the evaluator: `IF (i < 4) STOP 'pcurr: check s-grid for curr-grid values!'`, with the same guard on the pressure and iota branches.

**Evidence** - `cth_like_fixed_bdy.json` unchanged, and then with `pmass_type = "cubic_spline"` over three and four knots, on main:

| | `two_power` (as shipped) | `cubic_spline`, 3 knots | `cubic_spline`, 4 knots |
|---|---|---|---|
| exit | converged | converged | converged |
| `presf(0)` | 4.322928e+02 | 0.000000e+00 | 4.322908e+02 |
| `betatotal` | 1.926384e-03 | 0.000000e+00 | 1.681736e-03 |
| iterations | 121 | 119 | 121 |

The three-knot run writes a `wout` reporting a converged zero-pressure equilibrium while the input asked for 432 Pa. With `ncurr = 1` the same holds for the prescribed current, as in #798.

**Tests** - in `vmec_indata_test`: `CheckSplineProfilesNeedEnoughKnots` drives the three spline families one knot short of and at their minimum for the pressure profile and holds the current and iota profiles to the same counts; `CheckClosedFormProfilesNeedEnoughCoefficients` does the same for the four closed forms; `CheckSplineKnotsIncreaseAndSpanTheRadius` rejects unordered and repeated knots and Akima or cubic knots that stop short of 0 or 1, and accepts line segments that do.

**Scope** - validation only; the evaluators are untouched. An input rejected now is one whose profile evaluated to zero over part or all of the radius.
