### PR TITLE
Reject a multigrid schedule array shorter than ns_array

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -1388,6 +1388,19 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
                         vmec_indata.ns_array.size()));
   }
 
+  if (vmec_indata.ftol_array.size() < vmec_indata.ns_array.size()) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "input variable 'ftol_array' needs an entry for every 'ns_array' "
+        "entry, but has %ld against %ld\n",
+        vmec_indata.ftol_array.size(), vmec_indata.ns_array.size()));
+  }
+  if (vmec_indata.niter_array.size() < vmec_indata.ns_array.size()) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "input variable 'niter_array' needs an entry for every 'ns_array' "
+        "entry, but has %ld against %ld\n",
+        vmec_indata.niter_array.size(), vmec_indata.ns_array.size()));
+  }
+
   // ftol_array
   for (Eigen::VectorXi::Index idx = 0; idx < vmec_indata.ns_array.size();
        ++idx) {


### PR DESCRIPTION
`IsConsistent` validates `ftol_array` and `niter_array` by indexing them over `ns_array.size()`, without checking they are that long. `VmecINDATA::FromJson` compares the lengths, so this only shows up for an input assembled or modified in memory, which is what `VmecInput` fields are for and what an optimizer does between solves.

Under asan the read is a heap-buffer-overflow inside `IsConsistent`:

```
ERROR: AddressSanitizer: heap-buffer-overflow on address 0x503000006e38
READ of size 8 at 0x503000006e38 thread T0
SUMMARY: AddressSanitizer: heap-buffer-overflow in vmecpp::IsConsistent(vmecpp::VmecINDATA const&, bool)
```

From Python, with a `VmecInput` loaded from a shipped test case and the arrays set to disagree:

```python
bad.ns_array    = np.array([5, 11, 25])
bad.ftol_array  = np.array([1.0e-12])
bad.niter_array = np.array([1000])
vmecpp.run(bad)
```

The pydantic model accepts the assignment, since the shared `num_grids` dimension of the three annotations does not bind across fields, and the run then reports

```
input variable 'niter_array' need to be positive, but value 0 was found at index 1
```

for a one-element array. That 0 is whatever the heap held past the end; a different layout gives a positive number and the run proceeds with garbage `ftol` and `niter` for the second and third grid steps.

`IsConsistent` now rejects an array shorter than `ns_array`. A longer one stays acceptable: the entries past the last grid step are not part of the schedule and nothing reads them, and `_step_input` in the Fourier continuation leaves them in place when it collapses `ns_array` to a single step.

The test builds the three arrays at length 3, shortens each in turn, and requires a rejection; it reports the overflow above under asan before the change and passes after. The longer-array case is pinned as accepted.

`bazel test --config=opt //vmecpp/... //vmecpp_large_cpp_tests/...` and `pytest` pass, and `bazel test --config=asan //vmecpp/common/vmec_indata:vmec_indata_test` is clean.
