### PR TITLE
Add an opt-in undamped lambda preconditioner

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -442,6 +442,9 @@ class VmecInput(BaseModelWithNumpy):
     lforbal: bool = False
     """Hack: directly compute innermost flux surface geometry from radial force balance"""
 
+    undamped_lambda_preconditioner: bool = False
+    """Scale the lambda preconditioner by 1 / lamscale^2 alone."""
+
     return_outputs_even_if_not_converged: bool = False
     """If true, return a wout even if VMEC++ did not converge, instead of raising a
     RuntimeError.

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -227,6 +227,7 @@ VmecINDATA::VmecINDATA() {
   delt = 1.0;
   tcon0 = 1.0;
   lforbal = false;
+  undamped_lambda_preconditioner = false;
   iteration_style = IterationStyle::VMEC_8_52;
   return_outputs_even_if_not_converged = false;
 
@@ -352,6 +353,8 @@ absl::Status VmecINDATA::WriteTo(H5::H5File& file) const {
   WriteH5Dataset(delt, "/indata/delt", file);
   WriteH5Dataset(tcon0, "/indata/tcon0", file);
   WriteH5Dataset(lforbal, "/indata/lforbal", file);
+  WriteH5Dataset(undamped_lambda_preconditioner,
+                 "/indata/undamped_lambda_preconditioner", file);
   WriteH5Dataset(return_outputs_even_if_not_converged,
                  "/indata/return_outputs_even_if_not_converged", file);
 
@@ -454,6 +457,14 @@ absl::Status VmecINDATA::LoadInto(VmecINDATA& m_indata, H5::H5File& from_file) {
   ReadH5Dataset(m_indata.delt, "/indata/delt", from_file);
   ReadH5Dataset(m_indata.tcon0, "/indata/tcon0", from_file);
   ReadH5Dataset(m_indata.lforbal, "/indata/lforbal", from_file);
+  // Legacy way of checking for dataset existence
+  if (H5Lexists(from_file.getId(), "/indata/undamped_lambda_preconditioner",
+                0) == 1) {
+    ReadH5Dataset(m_indata.undamped_lambda_preconditioner,
+                  "/indata/undamped_lambda_preconditioner", from_file);
+  } else {
+    m_indata.undamped_lambda_preconditioner = false;
+  }
 
   // Legacy way of checking for dataset existence
   if (H5Lexists(from_file.getId(),
@@ -930,6 +941,15 @@ absl::StatusOr<VmecINDATA> VmecINDATA::FromJson(
     vmec_indata.lforbal = maybe_lforbal->value();
   }
 
+  auto maybe_undamped_lambda =
+      JsonReadBool(j, "undamped_lambda_preconditioner");
+  if (!maybe_undamped_lambda.ok()) {
+    return maybe_undamped_lambda.status();
+  }
+  if (maybe_undamped_lambda->has_value()) {
+    vmec_indata.undamped_lambda_preconditioner = maybe_undamped_lambda->value();
+  }
+
   auto maybe_iteration_style = JsonReadString(j, "iteration_style");
   if (!maybe_iteration_style.ok()) {
     return maybe_iteration_style.status();
@@ -1253,6 +1273,7 @@ absl::StatusOr<std::string> VmecINDATA::ToJson() const {
   output["delt"] = delt;
   output["tcon0"] = tcon0;
   output["lforbal"] = lforbal;
+  output["undamped_lambda_preconditioner"] = undamped_lambda_preconditioner;
   output["iteration_style"] = ToString(iteration_style);
   output["return_outputs_even_if_not_converged"] =
       return_outputs_even_if_not_converged;

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
@@ -214,6 +214,10 @@ class VmecINDATA {
   // balance
   bool lforbal;
 
+  // Scale the lambda preconditioner by 1 / lamscale^2 alone, dropping the
+  // further factor 0.5 inherited from VMEC.
+  bool undamped_lambda_preconditioner;
+
   // allows to switch between VMEC 8.52 and PARVMEC iteration style
   // default: VMEC 8.52 (Golden Reference for V&V, and what educational_VMEC is
   // based on)

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -40,6 +40,7 @@ using vmecpp::vmec_algorithm_constants::kEvenParity;
 using vmecpp::vmec_algorithm_constants::kLambdaHighMDampingMaxPower;
 using vmecpp::vmec_algorithm_constants::kLambdaHighMDampingReferenceM;
 using vmecpp::vmec_algorithm_constants::kLambdaPreconditionerDampingFactor;
+using vmecpp::vmec_algorithm_constants::kLambdaPreconditionerUndampedFactor;
 using vmecpp::vmec_algorithm_constants::kLambdaPreconditionerZeroGuard;
 using vmecpp::vmec_algorithm_constants::kOddParity;
 
@@ -374,8 +375,10 @@ IdealMhdModel::IdealMhdModel(
 }
 
 void IdealMhdModel::setFromINDATA(int ncurr, double adiabaticIndex,
-                                  double tcon0, bool lforbal) {
+                                  double tcon0, bool lforbal,
+                                  bool undamped_lambda_preconditioner) {
   this->ncurr = ncurr;
+  this->undamped_lambda_preconditioner_ = undamped_lambda_preconditioner;
   this->adiabaticIndex = adiabaticIndex;
   this->tcon0 = tcon0;
   // The m=1 trig weights below are built on the reduced poloidal grid, so the
@@ -2136,8 +2139,11 @@ void IdealMhdModel::updateLambdaPreconditioner() {
   // 1/lamscale^2 converts the stiffness of the internally rescaled lambda
   // coefficients; the remaining kLambdaPreconditionerDampingFactor / 4 = 0.5
   // is an inherited, unexplained damping (see vmec_algorithm_constants.h).
-  const double pFactor = kLambdaPreconditionerDampingFactor /
-                         (4.0 * constants_.lamscale * constants_.lamscale);
+  const double damping = undamped_lambda_preconditioner_
+                             ? kLambdaPreconditionerUndampedFactor
+                             : kLambdaPreconditionerDampingFactor;
+  const double pFactor =
+      damping / (4.0 * constants_.lamscale * constants_.lamscale);
 
   // evaluate preconditioning matrix elements on half-grid
   // on every accessible half-grid point

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
@@ -66,7 +66,7 @@ class IdealMhdModel {
                 VacuumPressureState* m_vacuum_pressure_state);
 
   void setFromINDATA(int ncurr, double adiabaticIndex, double tCon0,
-                     bool lforbal);
+                     bool lforbal, bool undamped_lambda_preconditioner);
 
   // Compute the invariant (i.e., not preconditioned yet) force residuals.
   // Will put them into the provided array as { fsqr, fsqz, fsql }.
@@ -500,6 +500,7 @@ class IdealMhdModel {
   Eigen::VectorXd dLambda;
   Eigen::VectorXd cLambda;
   Eigen::VectorXd lambdaPreconditioner;
+  bool undamped_lambda_preconditioner_ = false;
 
   // R,Z preconditioner
   Eigen::VectorXd ax;

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -620,6 +620,8 @@ PYBIND11_MODULE(_vmecpp, m) {
   pyindata.def_readwrite("delt", &VmecINDATA::delt)
       .def_readwrite("tcon0", &VmecINDATA::tcon0)
       .def_readwrite("lforbal", &VmecINDATA::lforbal)
+      .def_readwrite("undamped_lambda_preconditioner",
+                     &VmecINDATA::undamped_lambda_preconditioner)
       .def_readwrite("iteration_style", &VmecINDATA::iteration_style)
       .def_readwrite("return_outputs_even_if_not_converged",
                      &VmecINDATA::return_outputs_even_if_not_converged)

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -674,7 +674,8 @@ bool Vmec::InitializeRadial(
           vac_num_threads_, kSignOfJacobian, indata_.nvacskip,
           &vacuum_pressure_state_);
       m_[thread_id]->setFromINDATA(indata_.ncurr, indata_.gamma, indata_.tcon0,
-                                   indata_.lforbal);
+                                   indata_.lforbal,
+                                   indata_.undamped_lambda_preconditioner);
     }  // thread_id
 
     if (checkpoint == VmecCheckpoint::SPECTRAL_CONSTRAINT &&

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
@@ -874,6 +874,82 @@ TEST(TestVmec, ToroidalFluxFollowsTheAphiPolynomial) {
   }
 }  // ToroidalFluxFollowsTheAphiPolynomial
 
+// The lambda preconditioner scale multiplies an already assembled force, so it
+// cannot move the invariant residual of the first step.
+TEST(TestVmec, UndampedLambdaPreconditionerLeavesTheFirstForceResidual) {
+  for (const std::string& case_name :
+       {"solovev", "cth_like_fixed_bdy", "cth_like_fixed_bdy_asym"}) {
+    const absl::StatusOr<std::string> indata_json =
+        ReadFile("vmecpp/test_data/" + case_name + ".json");
+    ASSERT_TRUE(indata_json.ok()) << case_name;
+    const absl::StatusOr<VmecINDATA> base_indata =
+        VmecINDATA::FromJson(*indata_json);
+    ASSERT_TRUE(base_indata.ok()) << case_name;
+    const double ftol =
+        base_indata->ftol_array(base_indata->ftol_array.size() - 1);
+
+    VmecINDATA damped = *base_indata;
+    damped.undamped_lambda_preconditioner = false;
+    const auto damped_output = vmecpp::run(damped, std::nullopt, 1);
+    ASSERT_TRUE(damped_output.ok()) << case_name;
+
+    VmecINDATA undamped = *base_indata;
+    undamped.undamped_lambda_preconditioner = true;
+    const auto undamped_output = vmecpp::run(undamped, std::nullopt, 1);
+    ASSERT_TRUE(undamped_output.ok()) << case_name;
+
+    const auto& a = damped_output->wout;
+    const auto& b = undamped_output->wout;
+    ASSERT_GT(a.itfsq, 0) << case_name;
+    ASSERT_GT(b.itfsq, 0) << case_name;
+    EXPECT_EQ(a.fsqt(0), b.fsqt(0)) << case_name;
+    // fsqt sums the three force components that convergence tests one by one,
+    // so it lands within a factor of three of the tolerance.
+    EXPECT_LT(a.fsqt(a.itfsq - 1), 3.0 * ftol) << case_name;
+    EXPECT_LT(b.fsqt(b.itfsq - 1), 3.0 * ftol) << case_name;
+  }
+}  // UndampedLambdaPreconditionerLeavesTheFirstForceResidual
+
+// Both runs are held to ftol 1e-12 because the residual fixes how closely they
+// agree; what remains there is the spectral-condensation angle gauge, which
+// moves the poloidal spectrum without moving the flux surfaces. The bounds are
+// five times the measured deviation.
+TEST(TestVmec, UndampedLambdaPreconditionerConvergesToTheSameEquilibrium) {
+  for (const std::string& case_name :
+       {"solovev", "cth_like_fixed_bdy", "cth_like_fixed_bdy_asym"}) {
+    const absl::StatusOr<std::string> indata_json =
+        ReadFile("vmecpp/test_data/" + case_name + ".json");
+    ASSERT_TRUE(indata_json.ok()) << case_name;
+    absl::StatusOr<VmecINDATA> base_indata = VmecINDATA::FromJson(*indata_json);
+    ASSERT_TRUE(base_indata.ok()) << case_name;
+    base_indata->ftol_array =
+        Eigen::VectorXd::Constant(base_indata->ftol_array.size(), 1.0e-12);
+
+    VmecINDATA damped = *base_indata;
+    damped.undamped_lambda_preconditioner = false;
+    const auto damped_output = vmecpp::run(damped, std::nullopt, 1);
+    ASSERT_TRUE(damped_output.ok()) << case_name;
+
+    VmecINDATA undamped = *base_indata;
+    undamped.undamped_lambda_preconditioner = true;
+    const auto undamped_output = vmecpp::run(undamped, std::nullopt, 1);
+    ASSERT_TRUE(undamped_output.ok()) << case_name;
+
+    const auto& a = damped_output->wout;
+    const auto& b = undamped_output->wout;
+    ASSERT_EQ(a.ns, b.ns) << case_name;
+
+    auto rel_max = [](const auto& x, const auto& y) -> double {
+      const double peak = x.cwiseAbs().maxCoeff();
+      return (x - y).cwiseAbs().maxCoeff() / (peak > 0.0 ? peak : 1.0);
+    };
+    EXPECT_LT(rel_max(a.rmnc, b.rmnc), 2.2e-4) << case_name << " rmnc";
+    EXPECT_LT(rel_max(a.zmns, b.zmns), 1.5e-3) << case_name << " zmns";
+    EXPECT_LT(rel_max(a.iotaf, b.iotaf), 2.6e-5) << case_name << " iotaf";
+    EXPECT_TRUE(IsCloseRelAbs(a.wb, b.wb, 1.2e-7)) << case_name << " wb";
+  }
+}  // UndampedLambdaPreconditionerConvergesToTheSameEquilibrium
+
 // An inconsistent VmecINDATA must come back as a status from the factory:
 // constructing first ends the process instead of reporting the input error.
 TEST(TestVmec, InconsistentIndataIsRejectedBeforeConstruction) {

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec_constants/vmec_algorithm_constants.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec_constants/vmec_algorithm_constants.h
@@ -73,6 +73,13 @@ static constexpr double kIonLarmorRadiusCoefficient = 3.2e-3;
 static constexpr double kLambdaPreconditionerDampingFactor = 2.0;
 
 /**
+ * Lambda preconditioner scale with the inherited factor dropped, so that the
+ * assembled diagonal is multiplied by 1 / lamscale^2 and nothing further.
+ * Selected by VmecINDATA::undamped_lambda_preconditioner.
+ */
+static constexpr double kLambdaPreconditionerUndampedFactor = 4.0;
+
+/**
  * Guard value substituted when an assembled lambda stiffness element is
  * exactly zero, to avoid dividing by zero when the preconditioner inverts
  * it. Negative by convention; the stiffness elements are negative for the


### PR DESCRIPTION
**Change** - `VmecInput.undamped_lambda_preconditioner`, off by default (JSON and HDF5 round trip through `VmecINDATA`). Set, the lambda preconditioner scales its assembled diagonal by `1 / lamscale^2` alone, through `kLambdaPreconditionerUndampedFactor`; unset, the scale stays `kLambdaPreconditionerDampingFactor / (4 lamscale^2)`.

**Cause** - the `1 / lamscale^2` converts the internally rescaled lambda coefficients. The remaining factor of 0.5 comes from VMEC, where `lamcal.f90` sets `damping_fac = 2.0` beside a commented-out `pfactor0/4` marked "sometimes helps convergence"; neither the Fortran nor the VMEC++ comment gives a derivation for it.

**Evidence** - iterations summed over the multigrid schedule, single-threaded, each case at its own ftol. The twelve QUASR configurations of `tests/test_free_boundary_quasr.py`, run in fixed-boundary mode at mpol = ntor = 6 and ns_array = [8, 16, 31]:

| case | off | on |
| --- | --- | --- |
| 954 | 141 | 133 |
| 9914 | 328 | 261 |
| 19493 | 819 | 689 |
| 19609 | 587 | 447 |
| 19940 | 492 | 416 |
| 29346 | 431 | 432 |
| 50136 | 1325 | 1331 |
| 65579 | 905 | 772 |
| 112718 | 636 | 509 |
| 165868 | 441 | 377 |
| 167381 | 464 | 386 |
| 336902 | 461 | 367 |
| total | 7030 | 6120 |

and the fixed-boundary cases of the test suite:

| case | off | on |
| --- | --- | --- |
| solovev | 204 | 217 |
| solovev_analytical | 400 | 397 |
| circular_tokamak | 749 | 589 |
| cma | 207 | 148 |
| cth_like_fixed_bdy | 121 | 113 |
| cth_like_fixed_bdy_iota | 118 | 111 |
| li383_low_res | 124 | 133 |
| up_down_asym | 594 | 635 |
| cth_like_fixed_bdy_asym | 137 | 132 |
| total | 2654 | 2475 |

That is 13 percent fewer iterations over the QUASR set and 7 percent over the test suite, at no cost per iteration, since the change is the value of a scalar computed once per preconditioner update. The gain is not uniform. Three of the nine test-suite cases take more iterations, and on the W7-X example the count is not a smooth function of the factor: scanning 2.0 through 6.0 gives 2954, 2699, 3604, 3616, 3520, 2580, 2609 and 3017, a twenty percent swing in either direction with no trend.

The converged state moves with the descent path. At a case's own ftol the two settings stop about 1e-3 apart in `iotaf`; held to 1e-12 they are 4.1e-6 apart on `cth_like_fixed_bdy` and 5.1e-6 on `cth_like_fixed_bdy_asym`, and the enclosed volume is identical at every tolerance. What remains at 1e-12 is the spectral-condensation angle gauge, which moves the poloidal spectrum without moving the flux surfaces: `zmns` differs by 2.9e-4 where `wb` agrees to 2.3e-8. Changing only the thread count leaves all of these below 3e-14.

**Tests** - in `vmec_test`, on `solovev`, `cth_like_fixed_bdy` and `cth_like_fixed_bdy_asym`: `UndampedLambdaPreconditionerLeavesTheFirstForceResidual` requires `fsqt(0)` to be bit-identical between the two settings, since the scale multiplies an already assembled force, and both runs to reach the tolerance; `UndampedLambdaPreconditionerConvergesToTheSameEquilibrium` compares `rmnc`, `zmns`, `iotaf` and `wb` at ftol 1e-12 against five times the measured deviation.

**Scope** - unset, the assembled preconditioner is bit-identical to the current one, which every case above reproduces exactly.
