### PR TITLE
Default tcon0 to 0.5

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -436,7 +436,7 @@ class VmecInput(BaseModelWithNumpy):
     delt: float = 1.0
     """Initial value for artificial time step in iterative solver."""
 
-    tcon0: float = 1.0
+    tcon0: float = 0.5
     """Constraint force scaling factor for ns --> 0."""
 
     lforbal: bool = False
@@ -2451,8 +2451,8 @@ def run(
         >>> path = "examples/data/solovev.json"
         >>> vmec_input = vmecpp.VmecInput.from_file(path)
         >>> output = vmecpp.run(vmec_input, verbose=False, max_threads=1)
-        >>> round(output.wout.b0, 10) # Exact value may differ by C library
-        0.2033313711
+        >>> round(output.wout.b0, 6) # Exact value may differ by C library
+        0.203331
     """
     input = VmecInput.model_validate(input)
 

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -225,7 +225,7 @@ VmecINDATA::VmecINDATA() {
   aphi.resize(1);
   aphi[0] = 1.0;
   delt = 1.0;
-  tcon0 = 1.0;
+  tcon0 = 0.5;
   lforbal = false;
   iteration_style = IterationStyle::VMEC_8_52;
   return_outputs_even_if_not_converged = false;

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
@@ -162,7 +162,7 @@ TEST(TestVmecINDATA, CheckDefaults) {
   EXPECT_EQ(indata.nstep, 10);
   EXPECT_THAT(indata.aphi, ElementsAre(1.0));
   EXPECT_EQ(indata.delt, 1.0);
-  EXPECT_EQ(indata.tcon0, 1.0);
+  EXPECT_EQ(indata.tcon0, 0.5);
   EXPECT_EQ(indata.lforbal, false);
 
   // initial guess for magnetic axis


### PR DESCRIPTION
**Change** - changes the `tcon0` default in `VmecINDATA` and `VmecInput` from 1.0 to 0.5.

**Cause** - 1.0 is inherited from VMEC and underived; #818 names it as the example of an empirically chosen term. It also sits beside a cliff: at 1.5 and 2.0 none of the 21 configurations below converge.

**Evidence** - iterations summed over the multigrid schedule, single-threaded, each case at its own ftol, over the 9 fixed-boundary test-suite cases and the 12 QUASR configurations of `tests/test_free_boundary_quasr.py` run fixed-boundary. Every row converges 21/21:

| tcon0 | lambda scale | iterations |
| --- | --- | --- |
| 1.0 | inherited | 9684 |
| 0.5 | inherited | 8244 |
| 1.0 | undamped (#820) | 8595 |
| 0.5 | undamped (#820) | 7459 |

15 percent on its own, and independent of #820. A coordinate sweep over `kNDamp`, the preconditioner update interval, `delt` and the two high-m lambda damping terms found those already at or beside their best values, so `tcon0` and the lambda scale are the two that move.

**Tests** - every input under `test_data` sets `tcon0` explicitly, so no reference comparison moves; `TestVmecINDATA.CheckDefaults` is updated to 0.5. Both C++ suites pass, 44/44. `examples/data/solovev.json` omits `tcon0`, so the `run` doctest sees the new default and `b0` moves from 0.2033313711 to 0.2033305335; the example now rounds to six digits, 0.203331, which both values share and which also covers the C library variation its comment already notes.

**Scope** - affects only inputs that omit `tcon0`. Fortran clamps the value to `<= 1`, so 0.5 stays in range.
