### PR TITLE
Scale extcur with the magnetic field when rescaling a free-boundary equilibrium

### DIFF
--- a/src/vmecpp/_rescale.py
+++ b/src/vmecpp/_rescale.py
@@ -5,7 +5,7 @@ import typing
 import numpy as np
 
 if typing.TYPE_CHECKING:
-    from vmecpp import VmecOutput
+    from vmecpp import MagneticFieldResponseTable, VmecOutput
 
 
 def rescale(
@@ -13,6 +13,7 @@ def rescale(
     b_scale: float,
     r_scale: float,
     scale_pressure: bool = True,
+    magnetic_field: "MagneticFieldResponseTable | None" = None,
 ) -> "VmecOutput":
     from . import run  # noqa: PLC0415
 
@@ -26,6 +27,8 @@ def rescale(
         b_scale: factor to scale the magnetic field by.
         r_scale: factor to scale the major radius by.
         scale_pressure: whether to scale pressure to maintain force balance (default: True).
+        magnetic_field: the in-memory response table of a free-boundary run, when the
+            equilibrium was computed from one instead of from the mgrid file in its input.
 
     Returns:
         A new VmecOutput object with all derived parameters properly rescaled.
@@ -89,4 +92,6 @@ def rescale(
     intermediate_output.wout = scaled_wout
 
     # Call run with 0 iterations
-    return run(scaled_input, restart_from=intermediate_output)
+    return run(
+        scaled_input, magnetic_field=magnetic_field, restart_from=intermediate_output
+    )

--- a/src/vmecpp/_rescale.py
+++ b/src/vmecpp/_rescale.py
@@ -32,12 +32,26 @@ def rescale(
     """
     # Scale INDATA parameters
     scaled_input = output.input.model_copy(deep=True)
+
+    if scaled_input.lfreeb and r_scale != 1.0:
+        msg = (
+            "rescale cannot apply r_scale != 1 to a free-boundary equilibrium: the "
+            "vacuum field comes from the mgrid file, whose grid extent and coil "
+            "geometry would have to be scaled as well. Regenerate the mgrid for the "
+            "scaled coils and run from that input instead."
+        )
+        raise ValueError(msg)
+
     scaled_input.phiedge *= b_scale * (r_scale**2)
 
     if scale_pressure:
         scaled_input.pres_scale *= b_scale**2
 
     scaled_input.curtor *= b_scale * r_scale
+
+    # the vacuum field scales with the coil currents that produce it
+    if scaled_input.lfreeb:
+        scaled_input.extcur = np.asarray(scaled_input.extcur, dtype=float) * b_scale
 
     scaled_input.rbc *= r_scale
     scaled_input.zbs *= r_scale

--- a/tests/test_rescale.py
+++ b/tests/test_rescale.py
@@ -1,11 +1,20 @@
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 import vmecpp
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TEST_DATA_DIR = REPO_ROOT / "src" / "vmecpp" / "cpp" / "vmecpp" / "test_data"
+
+
+@pytest.fixture(scope="module")
+def cth_like_free_boundary():
+    """A converged three-dimensional free-boundary equilibrium and its input."""
+    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cth_like_free_bdy.json")
+    vmec_input.mgrid_file = str((TEST_DATA_DIR / "mgrid_cth_like.nc").resolve())
+    return vmec_input, vmecpp.run(vmec_input, verbose=False)
 
 
 def test_equilibrium_rescale():
@@ -74,3 +83,39 @@ def test_equilibrium_rescale():
     np.testing.assert_allclose(
         oq_rescaled.wout.zmns, oq_full_run.wout.zmns, rtol=1e-9, atol=1e-10 * r_scale
     )
+
+
+def test_rescale_free_boundary_scales_the_coil_currents(cth_like_free_boundary):
+    """The vacuum field is produced by the coil currents, so B -> b_scale * B holds only
+    if extcur scales with it; otherwise the rescaled state is not in force balance
+    against the unchanged external field."""
+    vmec_input, oq_initial = cth_like_free_boundary
+    b_scale = 1.5
+
+    oq_rescaled = vmecpp.rescale(oq_initial, b_scale=b_scale, r_scale=1.0)
+
+    np.testing.assert_allclose(
+        oq_rescaled.input.extcur,
+        np.asarray(vmec_input.extcur, dtype=float) * b_scale,
+        rtol=1e-12,
+    )
+    np.testing.assert_allclose(
+        oq_rescaled.wout.bmnc,
+        np.asarray(oq_initial.wout.bmnc) * b_scale,
+        rtol=1e-9,
+        atol=1e-10 * b_scale,
+    )
+    # still an equilibrium: leaving extcur unscaled leaves fsqr at order 1 here
+    assert oq_rescaled.wout.fsqr < 1.0e-6
+    assert oq_rescaled.wout.fsqz < 1.0e-6
+
+
+def test_rescale_rejects_radial_scaling_of_a_free_boundary_equilibrium(
+    cth_like_free_boundary,
+):
+    """The mgrid fixes the grid extent and the coil geometry, so r_scale cannot be
+    applied to a free-boundary equilibrium."""
+    _, oq_initial = cth_like_free_boundary
+
+    with pytest.raises(ValueError, match="mgrid"):
+        vmecpp.rescale(oq_initial, b_scale=1.0, r_scale=2.0)

--- a/tests/test_rescale.py
+++ b/tests/test_rescale.py
@@ -11,10 +11,20 @@ TEST_DATA_DIR = REPO_ROOT / "src" / "vmecpp" / "cpp" / "vmecpp" / "test_data"
 
 @pytest.fixture(scope="module")
 def cth_like_free_boundary():
-    """A converged three-dimensional free-boundary equilibrium and its input."""
+    """A converged three-dimensional free-boundary equilibrium, its input and the coil
+    response table it was computed from (built from the coils file, so the test does not
+    depend on the git-lfs mgrid file)."""
+    makegrid_params = vmecpp.MakegridParameters.from_file(
+        TEST_DATA_DIR / "makegrid_parameters_cth_like.json"
+    )
+    makegrid_params.number_of_r_grid_points = 31
+    makegrid_params.number_of_phi_grid_points = 36
+    makegrid_params.number_of_z_grid_points = 20
+    response = vmecpp.MagneticFieldResponseTable.from_coils_file(
+        TEST_DATA_DIR / "coils.cth_like", makegrid_params
+    )
     vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cth_like_free_bdy.json")
-    vmec_input.mgrid_file = str((TEST_DATA_DIR / "mgrid_cth_like.nc").resolve())
-    return vmec_input, vmecpp.run(vmec_input, verbose=False)
+    return vmec_input, response, vmecpp.run(vmec_input, response, verbose=False)
 
 
 def test_equilibrium_rescale():
@@ -89,10 +99,12 @@ def test_rescale_free_boundary_scales_the_coil_currents(cth_like_free_boundary):
     """The vacuum field is produced by the coil currents, so B -> b_scale * B holds only
     if extcur scales with it; otherwise the rescaled state is not in force balance
     against the unchanged external field."""
-    vmec_input, oq_initial = cth_like_free_boundary
+    vmec_input, response, oq_initial = cth_like_free_boundary
     b_scale = 1.5
 
-    oq_rescaled = vmecpp.rescale(oq_initial, b_scale=b_scale, r_scale=1.0)
+    oq_rescaled = vmecpp.rescale(
+        oq_initial, b_scale=b_scale, r_scale=1.0, magnetic_field=response
+    )
 
     np.testing.assert_allclose(
         oq_rescaled.input.extcur,
@@ -115,7 +127,7 @@ def test_rescale_rejects_radial_scaling_of_a_free_boundary_equilibrium(
 ):
     """The mgrid fixes the grid extent and the coil geometry, so r_scale cannot be
     applied to a free-boundary equilibrium."""
-    _, oq_initial = cth_like_free_boundary
+    _, _, oq_initial = cth_like_free_boundary
 
     with pytest.raises(ValueError, match="mgrid"):
         vmecpp.rescale(oq_initial, b_scale=1.0, r_scale=2.0)


### PR DESCRIPTION
`rescale` scales the boundary, the axis, phiedge, curtor and pres_scale, but leaves `extcur` untouched. For a free-boundary run the vacuum field is set by the coil currents, so a state scaled to B -> b_scale * B sits against an unchanged external field and is no longer in force balance. `rescale` returns it after a single iteration against `ftol = 1.0`, so anything below that residual is reported as converged.

On `cth_like_free_bdy` (converged at fsqr = 9.3e-13):

| b_scale | fsqr returned | |
|---|---|---|
| 1.5 | 1.6e+00 | raises |
| 1.02 | 7.8e-03 | returned as converged |
| 1.5, extcur scaled | 4.5e-12 | |

`solovev_free_bdy` behaves the same way: 3.6e+00 at b_scale 1.5, 1.8e-02 returned silently at 1.02, and 2.7e-12 once extcur carries the factor.

`extcur` now scales with `b_scale`. Fixed-boundary results are unchanged, and the scaling was already exact there: on solovev, cth_like_fixed_bdy and cth_like_fixed_bdy_asym every scaling law holds to 1e-15 and the rescaled residual equals the base one.

`r_scale` is rejected for a free-boundary input. The mgrid file fixes both the grid extent and the coil geometry, and scaling the currents does not compensate: at r_scale = 1.02 the residual stays at 1.1e-02 either way, and larger factors move the boundary outside the vacuum grid, which `MGridProvider::interpolate` reports as clamped and not physically meaningful.

Both new tests fail on main and pass here. `pytest tests/` is 210 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG1y5xASoAYZtrdSLwTrPN
