### PR TITLE
Carry signgs in the m = 1 polar constraint

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -410,6 +410,13 @@ class VmecInput(BaseModelWithNumpy):
     nvacskip: int = 1
     """Number of iterations between full vacuum calculations."""
 
+    signgs: int = -1
+    """Sign of the Jacobian of the (s, theta, zeta) coordinates: -1 for the left-handed
+    system of Fortran VMEC, +1 for a right-handed one.
+
+    The input boundary is flipped in theta to match it.
+    """
+
     free_boundary_method: typing.Annotated[
         FreeBoundaryMethod,
         pydantic.BeforeValidator(_validate_free_boundary_method),

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -218,6 +218,7 @@ VmecINDATA::VmecINDATA() {
   mgrid_file = "NONE";  // default from Fortran VMEC via indata2json
   // extcur is left empty
   nvacskip = 1;
+  signgs = -1;
   free_boundary_method = FreeBoundaryMethod::NESTOR;
 
   // tweaking parameters
@@ -342,6 +343,7 @@ absl::Status VmecINDATA::WriteTo(H5::H5File& file) const {
   WriteH5Dataset(lfreeb, "/indata/lfreeb", file);
   WriteH5Dataset(mgrid_file, "/indata/mgrid_file", file);
   WriteH5Dataset(nvacskip, "/indata/nvacskip", file);
+  WriteH5Dataset(signgs, "/indata/signgs", file);
 
   // special treatment for enums
   WriteH5Dataset(ToString(free_boundary_method), "/indata/free_boundary_method",
@@ -423,6 +425,9 @@ absl::Status VmecINDATA::LoadInto(VmecINDATA& m_indata, H5::H5File& from_file) {
   ReadH5Dataset(m_indata.lfreeb, "/indata/lfreeb", from_file);
   ReadH5Dataset(m_indata.mgrid_file, "/indata/mgrid_file", from_file);
   ReadH5Dataset(m_indata.nvacskip, "/indata/nvacskip", from_file);
+  if (from_file.nameExists("/indata/signgs")) {
+    ReadH5Dataset(m_indata.signgs, "/indata/signgs", from_file);
+  }
 
   // special treatment for enums
   std::string fbdy_method_str;
@@ -874,6 +879,14 @@ absl::StatusOr<VmecINDATA> VmecINDATA::FromJson(
     vmec_indata.nvacskip = maybe_nvacskip->value();
   }
 
+  auto maybe_signgs = JsonReadInt(j, "signgs");
+  if (!maybe_signgs.ok()) {
+    return maybe_signgs.status();
+  }
+  if (maybe_signgs->has_value()) {
+    vmec_indata.signgs = maybe_signgs->value();
+  }
+
   auto maybe_free_boundary_method = JsonReadString(j, "free_boundary_method");
   if (!maybe_free_boundary_method.ok()) {
     return maybe_free_boundary_method.status();
@@ -1245,6 +1258,7 @@ absl::StatusOr<std::string> VmecINDATA::ToJson() const {
   output["mgrid_file"] = mgrid_file;
   output["extcur"] = extcur;
   output["nvacskip"] = nvacskip;
+  output["signgs"] = signgs;
   output["free_boundary_method"] = ToString(free_boundary_method);
 
   // Tweaking Parameters
@@ -1339,6 +1353,12 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
     return absl::InvalidArgumentError(
         absl::StrFormat("input variable 'nzeta' needs to be >= 0, but is %d\n",
                         vmec_indata.nzeta));
+  }
+
+  if (vmec_indata.signgs != -1 && vmec_indata.signgs != 1) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "input variable 'signgs' needs to be -1 or +1, but is %d\n",
+        vmec_indata.signgs));
   }
 
   // the free-boundary case additionally requires nvacskip >= 1; see below

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
@@ -191,6 +191,11 @@ class VmecINDATA {
   // number of iterations between full vacuum calculations
   int nvacskip;
 
+  // sign of the Jacobian of the (s, theta, zeta) coordinates: -1 for the
+  // left-handed system of Fortran VMEC, +1 for a right-handed one; the input
+  // boundary is flipped in theta to match it
+  int signgs;
+
   // indicates which method to use
   // for the free-boundary force contribution
   FreeBoundaryMethod free_boundary_method;

--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/boundaries.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/boundaries.cc
@@ -124,8 +124,12 @@ void Boundaries::parseToInternalArrays(const VmecINDATA& id, bool verbose) {
     int m = 1;
     int n = 0;
 
-    delta = atan2((*id.rbs)(m, s_.ntor + n) - (*id.zbc)(m, s_.ntor + n),
-                  id.rbc(m, s_.ntor + n) + id.zbs(m, s_.ntor + n));
+    // The shift puts the boundary into the gauge rbs(m=1, n=0) = sigma *
+    // zbc(m=1, n=0), the frozen combination of ensureM1Constrained, with
+    // sigma = -sign_of_jacobian.
+    const double sigma = -sign_of_jacobian_;
+    delta = atan2((*id.rbs)(m, s_.ntor + n) - sigma * (*id.zbc)(m, s_.ntor + n),
+                  id.rbc(m, s_.ntor + n) + sigma * id.zbs(m, s_.ntor + n));
 
     if (verbose && delta != 0.0) {
       std::cout << "need to shift theta by delta = " << delta << "\n";

--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/boundaries.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/boundaries.cc
@@ -126,8 +126,24 @@ void Boundaries::parseToInternalArrays(const VmecINDATA& id, bool verbose) {
 
     // The shift puts the boundary into the gauge rbs(m=1, n=0) = sigma *
     // zbc(m=1, n=0), the frozen combination of ensureM1Constrained, with
-    // sigma = -sign_of_jacobian.
-    const double sigma = -sign_of_jacobian_;
+    // sigma = -sign_of_jacobian. flipTheta, applied afterwards when the input
+    // runs in the other poloidal direction, negates zbc relative to rbs, so
+    // the shift targets the opposite sign in that case. The poloidal direction
+    // is read from the signed area of the m = 1 ellipse, which the shift does
+    // not change (see checkSignOfJacobian).
+    double r_test = 0.0;
+    double z_test = 0.0;
+    double r_test_asym = 0.0;
+    double z_test_asym = 0.0;
+    for (int nn = -s_.ntor; nn <= s_.ntor; ++nn) {
+      r_test += id.rbc(m, s_.ntor + nn);
+      z_test += id.zbs(m, s_.ntor + nn);
+      r_test_asym += (*id.rbs)(m, s_.ntor + nn);
+      z_test_asym += (*id.zbc)(m, s_.ntor + nn);
+    }
+    const double handedness = r_test * z_test - r_test_asym * z_test_asym;
+    const bool will_flip_theta = (handedness * sign_of_jacobian_ > 0.0);
+    const double sigma = -sign_of_jacobian_ * (will_flip_theta ? -1.0 : 1.0);
     delta = atan2((*id.rbs)(m, s_.ntor + n) - sigma * (*id.zbc)(m, s_.ntor + n),
                   id.rbc(m, s_.ntor + n) + sigma * id.zbs(m, s_.ntor + n));
 

--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/boundaries.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/boundaries.cc
@@ -290,18 +290,21 @@ void Boundaries::flipTheta() {
  * origin.
  */
 void Boundaries::ensureM1Constrained(const double scaling_factor) {
+  // same map as FourierCoeffs::m1Constraint: the frozen combination is
+  // rss = sigma zcs with sigma = -sign_of_jacobian
+  const double sigma = -sign_of_jacobian_;
   for (int n = 0; n <= s_.ntor; ++n) {
     int m = 1;
     int idx_mn = m * (s_.ntor + 1) + n;
     if (s_.lthreed) {
       double backup_rss = rbss[idx_mn];
-      rbss[idx_mn] = (backup_rss + zbcs[idx_mn]) * scaling_factor;
-      zbcs[idx_mn] = (backup_rss - zbcs[idx_mn]) * scaling_factor;
+      rbss[idx_mn] = (backup_rss + sigma * zbcs[idx_mn]) * scaling_factor;
+      zbcs[idx_mn] = (sigma * backup_rss - zbcs[idx_mn]) * scaling_factor;
     }
     if (s_.lasym) {
       double backup_rsc = rbsc[idx_mn];
-      rbsc[idx_mn] = (backup_rsc + zbcc[idx_mn]) * scaling_factor;
-      zbcc[idx_mn] = (backup_rsc - zbcc[idx_mn]) * scaling_factor;
+      rbsc[idx_mn] = (backup_rsc + sigma * zbcc[idx_mn]) * scaling_factor;
+      zbcc[idx_mn] = (sigma * backup_rsc - zbcc[idx_mn]) * scaling_factor;
     }
   }  // n
 }

--- a/src/vmecpp/cpp/vmecpp/vmec/boundaries/guess_magnetic_axis.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/boundaries/guess_magnetic_axis.cc
@@ -112,8 +112,9 @@ RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
     }
   }
 
-  // undo m=1 constraint
+  // undo m=1 constraint; same map as FourierCoeffs::m1Constraint
   const double scalingFactor = 1.0;
+  const double sigma = -sign_of_jacobian;
   std::vector<std::vector<double> > rss_boundary;  // lthreed
   std::vector<std::vector<double> > zcs_boundary;  // lthreed
   std::vector<std::vector<double> > rsc_boundary;  // lasym
@@ -127,8 +128,10 @@ RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
       for (int n = 0; n <= s.ntor; ++n) {
         int idx_mn = m * (s.ntor + 1) + n;
         if (m == 1) {
-          rss_boundary[m][n] = (rbss[idx_mn] + zbcs[idx_mn]) * scalingFactor;
-          zcs_boundary[m][n] = (rbss[idx_mn] - zbcs[idx_mn]) * scalingFactor;
+          rss_boundary[m][n] =
+              (rbss[idx_mn] + sigma * zbcs[idx_mn]) * scalingFactor;
+          zcs_boundary[m][n] =
+              (sigma * rbss[idx_mn] - zbcs[idx_mn]) * scalingFactor;
         } else {
           rss_boundary[m][n] = rbss[idx_mn];
           zcs_boundary[m][n] = zbcs[idx_mn];
@@ -145,8 +148,10 @@ RecomputeAxisWorkspace RecomputeMagneticAxisToFixJacobianSign(
       for (int n = 0; n <= s.ntor; ++n) {
         int idx_mn = m * (s.ntor + 1) + n;
         if (m == 1) {
-          rsc_boundary[m][n] = (rbsc[idx_mn] + zbcc[idx_mn]) * scalingFactor;
-          zcc_boundary[m][n] = (rbsc[idx_mn] - zbcc[idx_mn]) * scalingFactor;
+          rsc_boundary[m][n] =
+              (rbsc[idx_mn] + sigma * zbcc[idx_mn]) * scalingFactor;
+          zcc_boundary[m][n] =
+              (sigma * rbsc[idx_mn] - zbcc[idx_mn]) * scalingFactor;
         } else {
           rsc_boundary[m][n] = rbsc[idx_mn];
           zcc_boundary[m][n] = zbcc[idx_mn];

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.cc
@@ -173,8 +173,9 @@ void FourierCoeffs::decomposeInto(FourierCoeffs& m_x,
 }
 
 /** (un)do m=1 constraint to couple R_ss,Z_cs as well as R_sc,Z_cc */
-void FourierCoeffs::m1Constraint(double scalingFactor,
+void FourierCoeffs::m1Constraint(double scalingFactor, int sign_of_jacobian,
                                  std::optional<int> jMax) {
+  const double sigma = -sign_of_jacobian;
   int nsMaxToUse = nsMax_;
   if (jMax.has_value()) {
     nsMaxToUse = std::min(jMax.value(), nsMaxToUse);
@@ -186,13 +187,13 @@ void FourierCoeffs::m1Constraint(double scalingFactor,
       int idx_fc = ((jF - nsMin_) * s_.mpol + m) * (s_.ntor + 1) + n;
       if (s_.lthreed) {
         double old_rss = rss[idx_fc];
-        rss[idx_fc] = (old_rss + zcs[idx_fc]) * scalingFactor;
-        zcs[idx_fc] = (old_rss - zcs[idx_fc]) * scalingFactor;
+        rss[idx_fc] = (old_rss + sigma * zcs[idx_fc]) * scalingFactor;
+        zcs[idx_fc] = (sigma * old_rss - zcs[idx_fc]) * scalingFactor;
       }
       if (s_.lasym) {
         double old_rsc = rsc[idx_fc];
-        rsc[idx_fc] = (old_rsc + zcc[idx_fc]) * scalingFactor;
-        zcc[idx_fc] = (old_rsc - zcc[idx_fc]) * scalingFactor;
+        rsc[idx_fc] = (old_rsc + sigma * zcc[idx_fc]) * scalingFactor;
+        zcc[idx_fc] = (sigma * old_rsc - zcc[idx_fc]) * scalingFactor;
       }
     }  // n
   }  // j

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_coefficients/fourier_coefficients.h
@@ -28,7 +28,10 @@ class FourierCoeffs {
   void setZero();
 
   void decomposeInto(FourierCoeffs& m_x, const Eigen::VectorXd& scalxc) const;
-  void m1Constraint(double scalingFactor,
+  // m = 1 polar constraint: rss <- f (rss + sigma zcs), zcs <- f (sigma rss -
+  // zcs), and rsc, zcc alike, with sigma = -sign_of_jacobian; self-inverse up
+  // to f.
+  void m1Constraint(double scalingFactor, int sign_of_jacobian,
                     std::optional<int> jMax = std::nullopt);
 
   // Zero R and Z coefficients with m >= mpolGeom or n > ntorGeom; lambda is

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.cc
@@ -189,7 +189,7 @@ void FourierGeometry::InitFromState(
     const RowMatrixXd& zmns, const RowMatrixXd& lmns_full,
     const RowMatrixXd& rmns, const RowMatrixXd& zmnc,
     const RowMatrixXd& lmnc_full, const RadialProfiles& p,
-    const VmecConstants& constants, const Boundaries* b) {
+    const VmecConstants& constants, int sign_of_jacobian, const Boundaries* b) {
   if (s_.lasym) {
     // The antisymmetric half must be present, or the restart would silently
     // begin from the stellarator-symmetric projection of the given state.
@@ -384,7 +384,7 @@ void FourierGeometry::InitFromState(
   // If performing a free-boundary hot-restart,
   // also the boundary geometry is initialized from the given initial state,
   // and hence the m=1 constraint also needs to be activated on the boundary.
-  this->m1Constraint(0.5, max_ns_to_set_rz_on_from_state);
+  this->m1Constraint(0.5, sign_of_jacobian, max_ns_to_set_rz_on_from_state);
 
   if (nsMin_ == 0) {
     // remove towards-axis-extrapolated m=0 coefficients of lambda (was done

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.h
@@ -41,7 +41,7 @@ class FourierGeometry : public FourierCoeffs {
                      const RowMatrixXd& lmns_full, const RowMatrixXd& rmns,
                      const RowMatrixXd& zmnc, const RowMatrixXd& lmnc_full,
                      const RadialProfiles& p, const VmecConstants& constants,
-                     const Boundaries* b = nullptr);
+                     int sign_of_jacobian, const Boundaries* b = nullptr);
 
   void extrapolateTowardsAxis();
 

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -481,7 +481,7 @@ absl::StatusOr<bool> IdealMhdModel::update(
   }
 
   // undo m=1 constraint
-  m_physical_x.m1Constraint(1.0);
+  m_physical_x.m1Constraint(1.0, signOfJacobian);
 
   m_physical_x.extrapolateTowardsAxis();
 
@@ -935,7 +935,7 @@ absl::StatusOr<bool> IdealMhdModel::update(
   // fsqz measure unchanged, and is its own inverse. With 1/2 the map would
   // instead halve the residuals on every application. Fortran residue.f90
   // constrain_m1 uses osqrt2 for the same reason.
-  m_decomposed_f.m1Constraint(1.0 / std::numbers::sqrt2);
+  m_decomposed_f.m1Constraint(1.0 / std::numbers::sqrt2, signOfJacobian);
 
   // v8.50: ADD iter2<2 so reset=<WOUT_FILE> works
   const bool fix_m1_gauge =
@@ -2543,7 +2543,7 @@ void IdealMhdModel::packGeometry(FourierGeometry& m_decomposed,
   // tangent it yields the exact geometry tangent (the chain is linear), so no
   // finite difference is needed.
   m_decomposed.decomposeInto(m_physical_scratch, m_p_.scalxc);
-  m_physical_scratch.m1Constraint(1.0);
+  m_physical_scratch.m1Constraint(1.0, signOfJacobian);
   m_physical_scratch.extrapolateTowardsAxis();
   geometryFromFourier(m_physical_scratch);
 
@@ -2691,7 +2691,7 @@ void IdealMhdModel::applyExactForceJacobian(const double* geomP,
   // tail of update()
   forcesToFourier(m_physical_f);
   m_physical_f.decomposeInto(m_decomposed_hv, m_p_.scalxc);
-  m_decomposed_hv.m1Constraint(1.0 / std::numbers::sqrt2);
+  m_decomposed_hv.m1Constraint(1.0 / std::numbers::sqrt2, signOfJacobian);
   if (fix_m1_gauge) {
     m_decomposed_hv.zeroZForceForM1();
   }
@@ -3072,7 +3072,7 @@ void IdealMhdModel::applyExactForceJacobianTranspose(
   if (fix_m1_gauge) {
     m_decomposed_in.zeroZForceForM1();
   }
-  m_decomposed_in.m1Constraint(1.0 / std::numbers::sqrt2);
+  m_decomposed_in.m1Constraint(1.0 / std::numbers::sqrt2, signOfJacobian);
   m_decomposed_in.decomposeInto(m_physical_f, m_p_.scalxc);
   if (s_.lthreed) {
     dft_ForcesToFourierTranspose_3d_symm(m_physical_f);
@@ -3161,7 +3161,7 @@ void IdealMhdModel::applyExactForceJacobianTranspose(
     dft_FourierToRealTranspose_2d_symm(m_physical_scratch);
   }
   m_physical_scratch.extrapolateTowardsAxisTranspose();
-  m_physical_scratch.m1Constraint(1.0);
+  m_physical_scratch.m1Constraint(1.0, signOfJacobian);
   m_physical_scratch.decomposeInto(m_decomposed_out, m_p_.scalxc);
 }
 

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -4831,6 +4831,8 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
   // MUST CONVERT m=1 MODES... FROM INTERNAL TO PHYSICAL FORM
   // Extrapolation of m=0 Lambda (cs) modes, which are not evolved at j=1, done
   // in CONVERT
+  // same map as FourierCoeffs::m1Constraint with scaling factor 1
+  const double sigma = -m_vmec_internal_results.sign_of_jacobian;
   if (s.lthreed) {
     for (int jF = 0; jF < fc.ns; ++jF) {
       for (int n = 0; n < s.ntor + 1; ++n) {
@@ -4839,9 +4841,9 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
 
         const double old_rss = m_vmec_internal_results.rmnss(idx_fc);
         m_vmec_internal_results.rmnss(idx_fc) =
-            (old_rss + m_vmec_internal_results.zmncs(idx_fc));
+            (old_rss + sigma * m_vmec_internal_results.zmncs(idx_fc));
         m_vmec_internal_results.zmncs(idx_fc) =
-            (old_rss - m_vmec_internal_results.zmncs(idx_fc));
+            (sigma * old_rss - m_vmec_internal_results.zmncs(idx_fc));
       }  // n
     }  // jF
   }
@@ -5452,9 +5454,9 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
 
         const double old_rsc = m_vmec_internal_results.rmnsc(idx_fc);
         m_vmec_internal_results.rmnsc(idx_fc) =
-            (old_rsc + m_vmec_internal_results.zmncc(idx_fc));
+            (old_rsc + sigma * m_vmec_internal_results.zmncc(idx_fc));
         m_vmec_internal_results.zmncc(idx_fc) =
-            (old_rsc - m_vmec_internal_results.zmncc(idx_fc));
+            (sigma * old_rsc - m_vmec_internal_results.zmncc(idx_fc));
       }  // n
     }  // jF
 

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -307,8 +307,8 @@ class VmecModel {
                                                        *vmec_->p_[0]);
   }
   void RecomputeAxis() const {
-    vmec_->b_.RecomputeMagneticAxisToFixJacobianSign(
-        vmec_->fc_.nsval, vmecpp::Vmec::kSignOfJacobian);
+    vmec_->b_.RecomputeMagneticAxisToFixJacobianSign(vmec_->fc_.nsval,
+                                                     vmec_->indata_.signgs);
   }
 
   // Recompute the magnetic axis to fix the Jacobian sign, then re-initialize
@@ -319,8 +319,8 @@ class VmecModel {
   // single continuous parallel region tolerates but a step-by-step driver does
   // not.
   void Reinitialize() {
-    vmec_->b_.RecomputeMagneticAxisToFixJacobianSign(
-        vmec_->fc_.nsval, vmecpp::Vmec::kSignOfJacobian);
+    vmec_->b_.RecomputeMagneticAxisToFixJacobianSign(vmec_->fc_.nsval,
+                                                     vmec_->indata_.signgs);
     double delt0 = vmec_->indata_.delt;
     // Vmec::run resets the accumulated constants before every
     // InitializeRadial (the rmsPhiP -> lamscale accumulation in
@@ -612,6 +612,7 @@ PYBIND11_MODULE(_vmecpp, m) {
       .def_readwrite("mgrid_file", &VmecINDATA::mgrid_file);
   DefEigenProperty(pyindata, "extcur", &VmecINDATA::extcur);
   pyindata.def_readwrite("nvacskip", &VmecINDATA::nvacskip)
+      .def_readwrite("signgs", &VmecINDATA::signgs)
       .def_readwrite("free_boundary_method", &VmecINDATA::free_boundary_method)
 
       // tweaking parameters

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -181,7 +181,7 @@ Vmec::Vmec(const VmecINDATA& indata, std::optional<int> max_threads,
     : indata_(indata),
       s_(indata_),
       t_(&s_),
-      b_(&s_, &t_, kSignOfJacobian),
+      b_(&s_, &t_, indata_.signgs),
       h_(&s_),
       fc_(indata_.lfreeb, indata_.delt,
           static_cast<int>(indata_.ns_array.size()), max_threads),
@@ -449,7 +449,7 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
   // compute output file quantities, but do not write them to output file yet
   // (for creating the output file, use WriteOutputFile())
   output_quantities_ = vmecpp::ComputeOutputQuantities(
-      kSignOfJacobian, indata_, s_, fc_, constants_, t_, h_, mgrid_.mgrid_mode,
+      indata_.signgs, indata_, s_, fc_, constants_, t_, h_, mgrid_.mgrid_mode,
       mgrid_.coil_group_names, r_, decomposed_x_, m_, p_, checkpoint,
       vacuum_pressure_state_, status_, iter2_);
 
@@ -642,7 +642,7 @@ bool Vmec::InitializeRadial(
       ls_[thread_id] = std::make_unique<ThreadLocalStorage>(&s_);
 
       p_[thread_id] = std::make_unique<RadialProfiles>(
-          r_[thread_id].get(), &h_, &indata_, &fc_, kSignOfJacobian, kPDamp);
+          r_[thread_id].get(), &h_, &indata_, &fc_, indata_.signgs, kPDamp);
 
       // update profile parameterizations based on p****_type strings
       p_[thread_id]->setupInputProfiles();
@@ -653,7 +653,7 @@ bool Vmec::InitializeRadial(
       m_[thread_id] = std::make_unique<IdealMhdModel>(
           &fc_, &s_, &t_, p_[thread_id].get(), &constants_,
           ls_[thread_id].get(), &h_, r_[thread_id].get(), &fb_vac_,
-          vac_num_threads_, kSignOfJacobian, indata_.nvacskip,
+          vac_num_threads_, indata_.signgs, indata_.nvacskip,
           &vacuum_pressure_state_);
       m_[thread_id]->setFromINDATA(indata_.ncurr, indata_.gamma, indata_.tcon0,
                                    indata_.lforbal);
@@ -727,7 +727,7 @@ bool Vmec::InitializeRadial(
               t_, initial_state->wout.rmnc, initial_state->wout.zmns,
               initial_state->wout.lmns_full, initial_state->wout.rmns,
               initial_state->wout.zmnc, initial_state->wout.lmnc_full,
-              *p_[thread_id], constants_);
+              *p_[thread_id], constants_, indata_.signgs);
         } else {
           // fixed-boundary hot restart: use inner flux surfaces from initial
           // state, and LCFS geometry from Boundaries (from INDATA)
@@ -735,7 +735,7 @@ bool Vmec::InitializeRadial(
               t_, initial_state->wout.rmnc, initial_state->wout.zmns,
               initial_state->wout.lmns_full, initial_state->wout.rmns,
               initial_state->wout.zmnc, initial_state->wout.lmnc_full,
-              *p_[thread_id], constants_, &b_);
+              *p_[thread_id], constants_, indata_.signgs, &b_);
         }
       }
     } else {
@@ -980,7 +980,7 @@ absl::StatusOr<Vmec::SolveEqLoopStatus> Vmec::SolveEquilibriumLoop(
           std::cout << " TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS\n";
         }
 
-        b_.RecomputeMagneticAxisToFixJacobianSign(fc_.nsval, kSignOfJacobian);
+        b_.RecomputeMagneticAxisToFixJacobianSign(fc_.nsval, indata_.signgs);
         fc_.ijacob = 1;
 
         // prepare parameters to functions that get called due to

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/fourier_geometry/fourier_geometry_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/fourier_geometry/fourier_geometry_test.cc
@@ -194,7 +194,7 @@ void CheckInitFromState(const VmecINDATA& indata, const WOutFileContents& wout,
 
   // THIS IS THE CALL UNDER TEST
   g.InitFromState(fb, wout.rmnc, wout.zmns, wout.lmns_full, wout.rmns,
-                  wout.zmnc, wout.lmnc_full, p, constants, &b);
+                  wout.zmnc, wout.lmnc_full, p, constants, signOfJacobian, &b);
 
   const int mnsize = s.mpol * (s.ntor + 1);
 

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/ideal_mhd_model/ideal_mhd_model_hot_restart_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec/ideal_mhd_model/ideal_mhd_model_hot_restart_test.cc
@@ -113,7 +113,7 @@ TEST_P(FourierGeometryToStartWithFromWOutTest,
         vmec.t_, output_quantities.wout.rmnc, output_quantities.wout.zmns,
         output_quantities.wout.lmns_full, output_quantities.wout.rmns,
         output_quantities.wout.zmnc, output_quantities.wout.lmnc_full,
-        *vmec.p_[thread_id], vmec.constants_, &(vmec.b_));
+        *vmec.p_[thread_id], vmec.constants_, vmec.indata_.signgs, &(vmec.b_));
 
     for (int jF = nsMinF1; jF < nsMaxF1; ++jF) {
       for (int m = 0; m < s.mpol; ++m) {

--- a/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec_hot_restart_test/vmec_hot_restart_test.cc
+++ b/src/vmecpp/cpp/vmecpp_large_cpp_tests/vmec_hot_restart_test/vmec_hot_restart_test.cc
@@ -135,7 +135,7 @@ TEST_P(GeometryInitializationTest, CheckGeometryInitialization) {
         vmec.t_, output_quantities.wout.rmnc, output_quantities.wout.zmns,
         output_quantities.wout.lmns_full, output_quantities.wout.rmns,
         output_quantities.wout.zmnc, output_quantities.wout.lmnc_full,
-        *vmec.p_[thread_id], vmec.constants_, &(vmec.b_));
+        *vmec.p_[thread_id], vmec.constants_, vmec.indata_.signgs, &(vmec.b_));
 
     for (int jF = nsMinF1; jF < nsMaxF1; ++jF) {
       for (int m = 0; m < s.mpol; ++m) {

--- a/tests/test_signgs.py
+++ b/tests/test_signgs.py
@@ -243,14 +243,17 @@ def test_hot_restart_from_a_right_handed_state():
     )
 
 
-def test_flipping_signgs_alone_relabels_theta():
+@pytest.mark.parametrize(
+    "case", ["cth_like_fixed_bdy", "cth_like_fixed_bdy_asym", "up_down_asym"]
+)
+def test_flipping_signgs_alone_relabels_theta(case: str):
     """With only signgs changed, the boundary is flipped in theta to match the.
 
     requested handedness, so the wout describes the same equilibrium in the poloidal
-    angle pi - theta: coefficient (m, n) becomes (-1)^m times coefficient (m, -n), the
-    rotational transform changes sign and the current does not.
+    angle pi - theta: coefficient (m, n) becomes (-1)^m times coefficient (m, -n), with
+    Z reversed, the rotational transform changes sign and the current does not.
     """
-    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cth_like_fixed_bdy.json")
+    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / f"{case}.json")
     wout = vmecpp.run(vmec_input, verbose=False).wout
     flipped_input = vmec_input.model_copy(deep=True)
     flipped_input.signgs = 1
@@ -273,12 +276,12 @@ def test_flipping_signgs_alone_relabels_theta():
         return parity[:, None] * np.asarray(coefficients)[relabelled, :]
 
     # R and lambda are relabelled as they stand; Z reverses with the poloidal
-    # direction on top of that
-    for name, sine, sign in (
-        ("rmnc", False, 1.0),
-        ("zmns", True, -1.0),
-        ("lmns", True, 1.0),
-    ):
+    # direction on top of that. The antisymmetric halves follow the same rule
+    # with the sine and cosine roles exchanged.
+    arrays = [("rmnc", False, 1.0), ("zmns", True, -1.0), ("lmns", True, 1.0)]
+    if vmec_input.lasym:
+        arrays += [("rmns", True, -1.0), ("zmnc", False, 1.0), ("lmnc", False, -1.0)]
+    for name, sine, sign in arrays:
         expected = np.asarray(getattr(wout, name))
         np.testing.assert_allclose(
             sign * relabel(getattr(flipped, name), sine),

--- a/tests/test_signgs.py
+++ b/tests/test_signgs.py
@@ -1,3 +1,6 @@
+"""Running an equilibrium in right-handed coordinates (signgs = +1) must give the same
+physics as running its mirror image in the left-handed ones (signgs = -1)."""
+
 from pathlib import Path
 
 import numpy as np
@@ -8,18 +11,174 @@ import vmecpp
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TEST_DATA_DIR = REPO_ROOT / "src" / "vmecpp" / "cpp" / "vmecpp" / "test_data"
 
+# Reflecting the equilibrium through the midplane (Z -> -Z) and describing it in the
+# right-handed coordinates leaves every scalar, every profile and the Fourier
+# coefficients of R, lambda, |B| and the field components unchanged, and negates the
+# ones of Z and of the Jacobian. The current reverses with the reflection while the
+# toroidal flux keeps its sign, so the current diagnostics change sign as well.
+IDENTICAL = [
+    "aspect",
+    "volume_p",
+    "wb",
+    "wp",
+    "betatotal",
+    "betapol",
+    "betator",
+    "betaxis",
+    "b0",
+    "rbtor",
+    "rbtor0",
+    "volavgB",
+    "Aminor_p",
+    "Rmajor_p",
+    "rmax_surf",
+    "rmin_surf",
+    "zmax_surf",
+    "iotaf",
+    "iotas",
+    "presf",
+    "pres",
+    "phipf",
+    "chipf",
+    "phi",
+    "bvco",
+    "buco",
+    "vp",
+    "specw",
+    "DMerc",
+    "DShear",
+    "DWell",
+    "DCurr",
+    "DGeod",
+    "raxis_cc",
+    "raxis_cs",
+    "rmnc",
+    "rmns",
+    "lmns",
+    "lmnc",
+    "lmns_full",
+    "lmnc_full",
+    "bmnc",
+    "bmns",
+    "bsupumnc",
+    "bsupumns",
+    "bsupvmnc",
+    "bsupvmns",
+    "bsubumnc",
+    "bsubumns",
+    "bsubvmnc",
+    "bsubvmns",
+    "bsubsmns",
+    "bsubsmnc",
+    "currumnc",
+    "currumns",
+    "currvmnc",
+    "currvmns",
+    "bdotb",
+    "bdotgradv",
+    "potvac",
+]
+NEGATED = [
+    "signgs",
+    "zmns",
+    "zmnc",
+    "zaxis_cs",
+    "zaxis_cc",
+    "gmnc",
+    "gmns",
+    "ctor",
+    "jcurv",
+    "jcuru",
+    "jdotb",
+]
+
 
 def _mirror_image(vmec_input: vmecpp.VmecInput) -> vmecpp.VmecInput:
-    """The equilibrium reflected through the midplane, described in the right-handed
-    (signgs = +1) coordinates: Z -> -Z negates the sine coefficients of the boundary and
-    of the axis, and the toroidal current, which is given in the laboratory sense,
-    reverses with the reflection while the toroidal flux keeps its sign."""
+    """The equilibrium reflected through the midplane, in right-handed coordinates."""
     mirrored = vmec_input.model_copy(deep=True)
     mirrored.zbs = -np.asarray(mirrored.zbs)
     mirrored.zaxis_s = -np.asarray(mirrored.zaxis_s)
+    if mirrored.lasym:
+        mirrored.zbc = -np.asarray(mirrored.zbc)
+        mirrored.zaxis_c = -np.asarray(mirrored.zaxis_c)
     mirrored.curtor = -mirrored.curtor
     mirrored.signgs = 1
     return mirrored
+
+
+def _mirror_table(
+    table: vmecpp.MagneticFieldResponseTable,
+) -> vmecpp.MagneticFieldResponseTable:
+    """The response table of the reflected coils carrying the reversed current: the
+    cylindrical field components at (R, phi, -Z) with B_Z negated."""
+    p = table.parameters
+    shape = (
+        -1,
+        p.number_of_phi_grid_points,
+        p.number_of_z_grid_points,
+        p.number_of_r_grid_points,
+    )
+
+    def reflect(component, sign):
+        flipped = sign * np.asarray(component).reshape(shape)[:, :, ::-1, :]
+        return np.ascontiguousarray(flipped).reshape(flipped.shape[0], -1)
+
+    parameters = p.model_copy(deep=True)
+    parameters.z_grid_minimum = -p.z_grid_maximum
+    parameters.z_grid_maximum = -p.z_grid_minimum
+    return vmecpp.MagneticFieldResponseTable(
+        parameters=parameters,
+        b_r=reflect(table.b_r, 1.0),
+        b_p=reflect(table.b_p, 1.0),
+        b_z=reflect(table.b_z, -1.0),
+    )
+
+
+def _cth_like_response_table(
+    raise_by: float = 0.0,
+) -> vmecpp.MagneticFieldResponseTable:
+    """The cth_like coils on the shipped makegrid parameters, optionally raised by
+    `raise_by` in Z, which makes the vacuum field up-down asymmetric."""
+    parameters = vmecpp.MakegridParameters.from_file(
+        TEST_DATA_DIR / "makegrid_parameters_cth_like.json"
+    )
+    evaluated_on = parameters.model_copy(deep=True)
+    # The field of the raised coils at Z is the field of the coils as given at
+    # Z - raise_by, so it is evaluated on the grid shifted the other way and then
+    # labelled with the unshifted grid. The shifted grid is not symmetric about the
+    # midplane, so the half-period shortcut does not apply to it.
+    evaluated_on.assume_stellarator_symmetry = False
+    evaluated_on.z_grid_minimum -= raise_by
+    evaluated_on.z_grid_maximum -= raise_by
+    table = vmecpp.MagneticFieldResponseTable.from_coils_file(
+        TEST_DATA_DIR / "coils.cth_like", evaluated_on
+    )
+    return vmecpp.MagneticFieldResponseTable(
+        parameters=parameters,
+        b_r=np.array(table.b_r),
+        b_p=np.array(table.b_p),
+        b_z=np.array(table.b_z),
+    )
+
+
+def _assert_mirror_image(wout: vmecpp.VmecWOut, mirrored: vmecpp.VmecWOut) -> None:
+    assert wout.signgs == -1
+    assert mirrored.signgs == 1
+    assert mirrored.niter == wout.niter
+    for sign, names in ((1.0, IDENTICAL), (-1.0, NEGATED)):
+        for name in names:
+            expected = getattr(wout, name)
+            actual = getattr(mirrored, name)
+            if expected is None or actual is None:
+                assert expected is None, name
+                assert actual is None, name
+                continue
+            expected = np.asarray(expected, dtype=float)
+            actual = np.asarray(actual, dtype=float)
+            scale = np.abs(expected).max() if expected.size else 0.0
+            np.testing.assert_allclose(
+                actual, sign * expected, rtol=0.0, atol=1e-7 * scale, err_msg=name
+            )
 
 
 def test_signgs_must_be_a_sign():
@@ -29,83 +188,105 @@ def test_signgs_must_be_a_sign():
         vmecpp.run(vmec_input, verbose=False)
 
 
-def test_right_handed_coordinates_give_the_mirror_image():
-    """Running the reflected boundary with signgs = +1 must reproduce the same physics
-    as the original with signgs = -1: every scalar and profile is identical, the Fourier
-    coefficients of R, lambda and |B| are identical, and the ones of Z, the Jacobian and
-    the current are negated."""
-    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cth_like_fixed_bdy.json")
+# solovev is axisymmetric, li383_low_res starts without an axis guess and recomputes it
+# after a bad initial Jacobian, and the two asymmetric cases pass through the poloidal
+# shift of the boundary and the asymmetric force paths.
+@pytest.mark.parametrize(
+    "case",
+    [
+        "cth_like_fixed_bdy",
+        "solovev",
+        "li383_low_res",
+        "cth_like_fixed_bdy_asym",
+        "up_down_asym",
+    ],
+)
+def test_right_handed_coordinates_give_the_mirror_image(case: str):
+    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / f"{case}.json")
     wout = vmecpp.run(vmec_input, verbose=False).wout
     mirrored = vmecpp.run(_mirror_image(vmec_input), verbose=False).wout
+    _assert_mirror_image(wout, mirrored)
 
-    assert wout.signgs == -1
-    assert mirrored.signgs == 1
-    assert mirrored.niter == wout.niter
 
-    identical = [
-        "aspect",
-        "volume_p",
-        "wb",
-        "wp",
-        "betatotal",
-        "betapol",
-        "betator",
-        "b0",
-        "rbtor",
-        "volavgB",
-        "Aminor_p",
-        "Rmajor_p",
-        "iotaf",
-        "iotas",
-        "presf",
-        "pres",
-        "phipf",
-        "bvco",
-        "buco",
-        "vp",
-        "DMerc",
-        "DShear",
-        "DWell",
-        "DCurr",
-        "DGeod",
-        "raxis_cc",
-        "rmnc",
-        "lmns",
-        "lmns_full",
-        "bmnc",
-        "bsupumnc",
-        "bsupvmnc",
-        "bsubumnc",
-        "bsubvmnc",
-        "bsubsmns",
-        "currumnc",
-        "currvmnc",
-        "bdotb",
-    ]
-    for name in identical:
+@pytest.mark.parametrize(
+    ("case", "raise_coils_by"),
+    [("cth_like_free_bdy", 0.0), ("cth_like_free_bdy_asym", 0.005)],
+)
+def test_right_handed_coordinates_give_the_mirror_image_free_boundary(
+    case: str, raise_coils_by: float
+):
+    """The vacuum field of the reflected coils is the reflected response table."""
+    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / f"{case}.json")
+    table = _cth_like_response_table(raise_coils_by)
+    wout = vmecpp.run(vmec_input, magnetic_field=table, verbose=False).wout
+    mirrored = vmecpp.run(
+        _mirror_image(vmec_input), magnetic_field=_mirror_table(table), verbose=False
+    ).wout
+    _assert_mirror_image(wout, mirrored)
+    if raise_coils_by != 0.0:
+        # the raised coils move the plasma off the midplane
+        assert abs(np.asarray(wout.zaxis_cc)[0]) > 1e-3
+
+
+def test_hot_restart_from_a_right_handed_state():
+    vmec_input = _mirror_image(
+        vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cth_like_fixed_bdy_asym.json")
+    )
+    output = vmecpp.run(vmec_input, verbose=False)
+    restarted = vmecpp.run(vmec_input, restart_from=output, verbose=False)
+    assert restarted.wout.niter <= 3
+    np.testing.assert_allclose(
+        restarted.wout.rmnc, output.wout.rmnc, rtol=0, atol=1e-12
+    )
+    np.testing.assert_allclose(
+        restarted.wout.zmns, output.wout.zmns, rtol=0, atol=1e-12
+    )
+
+
+def test_flipping_signgs_alone_relabels_theta():
+    """With only signgs changed, the boundary is flipped in theta to match the.
+
+    requested handedness, so the wout describes the same equilibrium in the poloidal
+    angle pi - theta: coefficient (m, n) becomes (-1)^m times coefficient (m, -n), the
+    rotational transform changes sign and the current does not.
+    """
+    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cth_like_fixed_bdy.json")
+    wout = vmecpp.run(vmec_input, verbose=False).wout
+    flipped_input = vmec_input.model_copy(deep=True)
+    flipped_input.signgs = 1
+    flipped = vmecpp.run(flipped_input, verbose=False).wout
+    assert flipped.niter == wout.niter
+
+    xm = np.asarray(wout.xm, dtype=int)
+    xn = np.asarray(wout.xn, dtype=int)
+    index = {(m, n): i for i, (m, n) in enumerate(zip(xm, xn, strict=True))}
+    relabelled = np.array(
+        [
+            index[(m, -n)] if m > 0 else index[(0, n)]
+            for m, n in zip(xm, xn, strict=True)
+        ]
+    )
+
+    def relabel(coefficients, sine: bool):
+        # the m = 0 rows fold n < 0 into n > 0, where a sine coefficient changes sign
+        parity = np.where(xm > 0, (-1.0) ** xm, -1.0 if sine else 1.0)
+        return parity[:, None] * np.asarray(coefficients)[relabelled, :]
+
+    # R and lambda are relabelled as they stand; Z reverses with the poloidal
+    # direction on top of that
+    for name, sine, sign in (
+        ("rmnc", False, 1.0),
+        ("zmns", True, -1.0),
+        ("lmns", True, 1.0),
+    ):
+        expected = np.asarray(getattr(wout, name))
         np.testing.assert_allclose(
-            np.asarray(getattr(mirrored, name), dtype=float),
-            np.asarray(getattr(wout, name), dtype=float),
-            rtol=1e-10,
-            atol=1e-13,
+            sign * relabel(getattr(flipped, name), sine),
+            expected,
+            rtol=0,
+            atol=1e-7 * np.abs(expected).max(),
             err_msg=name,
         )
-    negated = [
-        "zmns",
-        "zaxis_cs",
-        "gmnc",
-        "ctor",
-        "jcurv",
-        "jcuru",
-        "jdotb",
-        "chi",
-        "phips",
-    ]
-    for name in negated:
-        np.testing.assert_allclose(
-            np.asarray(getattr(mirrored, name), dtype=float),
-            -np.asarray(getattr(wout, name), dtype=float),
-            rtol=1e-10,
-            atol=1e-13,
-            err_msg=name,
-        )
+    np.testing.assert_allclose(flipped.iotaf, -np.asarray(wout.iotaf), rtol=1e-7)
+    for name in ("volume_p", "wb", "betatotal", "ctor"):
+        assert getattr(flipped, name) == pytest.approx(getattr(wout, name), rel=1e-7)

--- a/tests/test_signgs.py
+++ b/tests/test_signgs.py
@@ -1,0 +1,111 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import vmecpp
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEST_DATA_DIR = REPO_ROOT / "src" / "vmecpp" / "cpp" / "vmecpp" / "test_data"
+
+
+def _mirror_image(vmec_input: vmecpp.VmecInput) -> vmecpp.VmecInput:
+    """The equilibrium reflected through the midplane, described in the right-handed
+    (signgs = +1) coordinates: Z -> -Z negates the sine coefficients of the boundary and
+    of the axis, and the toroidal current, which is given in the laboratory sense,
+    reverses with the reflection while the toroidal flux keeps its sign."""
+    mirrored = vmec_input.model_copy(deep=True)
+    mirrored.zbs = -np.asarray(mirrored.zbs)
+    mirrored.zaxis_s = -np.asarray(mirrored.zaxis_s)
+    mirrored.curtor = -mirrored.curtor
+    mirrored.signgs = 1
+    return mirrored
+
+
+def test_signgs_must_be_a_sign():
+    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / "solovev.json")
+    vmec_input.signgs = 2
+    with pytest.raises((RuntimeError, AttributeError), match="signgs"):
+        vmecpp.run(vmec_input, verbose=False)
+
+
+def test_right_handed_coordinates_give_the_mirror_image():
+    """Running the reflected boundary with signgs = +1 must reproduce the same physics
+    as the original with signgs = -1: every scalar and profile is identical, the Fourier
+    coefficients of R, lambda and |B| are identical, and the ones of Z, the Jacobian and
+    the current are negated."""
+    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cth_like_fixed_bdy.json")
+    wout = vmecpp.run(vmec_input, verbose=False).wout
+    mirrored = vmecpp.run(_mirror_image(vmec_input), verbose=False).wout
+
+    assert wout.signgs == -1
+    assert mirrored.signgs == 1
+    assert mirrored.niter == wout.niter
+
+    identical = [
+        "aspect",
+        "volume_p",
+        "wb",
+        "wp",
+        "betatotal",
+        "betapol",
+        "betator",
+        "b0",
+        "rbtor",
+        "volavgB",
+        "Aminor_p",
+        "Rmajor_p",
+        "iotaf",
+        "iotas",
+        "presf",
+        "pres",
+        "phipf",
+        "bvco",
+        "buco",
+        "vp",
+        "DMerc",
+        "DShear",
+        "DWell",
+        "DCurr",
+        "DGeod",
+        "raxis_cc",
+        "rmnc",
+        "lmns",
+        "lmns_full",
+        "bmnc",
+        "bsupumnc",
+        "bsupvmnc",
+        "bsubumnc",
+        "bsubvmnc",
+        "bsubsmns",
+        "currumnc",
+        "currvmnc",
+        "bdotb",
+    ]
+    for name in identical:
+        np.testing.assert_allclose(
+            np.asarray(getattr(mirrored, name), dtype=float),
+            np.asarray(getattr(wout, name), dtype=float),
+            rtol=1e-10,
+            atol=1e-13,
+            err_msg=name,
+        )
+    negated = [
+        "zmns",
+        "zaxis_cs",
+        "gmnc",
+        "ctor",
+        "jcurv",
+        "jcuru",
+        "jdotb",
+        "chi",
+        "phips",
+    ]
+    for name in negated:
+        np.testing.assert_allclose(
+            np.asarray(getattr(mirrored, name), dtype=float),
+            -np.asarray(getattr(wout, name), dtype=float),
+            rtol=1e-10,
+            atol=1e-13,
+            err_msg=name,
+        )


### PR DESCRIPTION
**Change** - `signgs` becomes an input (`VmecInput.signgs`, default -1, JSON and HDF5 round trip), and every copy of the m = 1 polar constraint carries it: the coupling `rss <- rss + sigma zcs`, `zcs <- sigma rss - zcs` with `sigma = -signgs` in the coefficient map, the boundary, the hot-restart geometry, the force transpose, the wout recombination and the undo inside the axis guess, and the poloidal shift that puts an asymmetric boundary into the gauge `rbs(1,0) = sigma zbc(1,0)`.

**Cause** - the constraint was written for the left-handed system, where the frozen m = 1 combination is `rss = zcs`; in the right-handed one it is `rss = -zcs`. With `signgs = +1` the first update left the mirror image in every odd-m, n != 0 mode, an asymmetric boundary was shifted into the wrong gauge, and the axis guess decoded the boundary with the wrong sign and failed to start.

**Evidence** - each case run as is and as its reflection through the midplane in right-handed coordinates (`signgs = +1`, sine coefficients of the boundary and axis negated, `curtor` reversed, the response table reflected with `B_Z` negated) takes the same number of iterations and agrees to 1e-9 in every wout field, identically or with the sign of Z, the Jacobian and the current diagnostics reversed: `cth_like_fixed_bdy`, `solovev`, `li383_low_res` (axis recompute), `cth_like_fixed_bdy_asym`, `up_down_asym`, `cth_like_free_bdy`, and `cth_like_free_bdy_asym` on the cth coils raised by 5 mm, where the plasma settles 5.8 mm off the midplane. Flipping only `signgs` on an unchanged input reproduces the equilibrium under the theta -> pi - theta relabelling the code applies; a hot restart from a `signgs = +1` state converges in two iterations.

**Tests** - `tests/test_signgs.py`: the seven mirror comparisons, the relabelling with `signgs` alone, the hot restart, and the rejection of a `signgs` outside {-1, +1}.

**Scope** - `signgs = -1` is bit-identical to main. Fixes #827.
