### PR TITLE
Take the vacuum magnetic pressure alone as the total pressure outside the free boundary

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -839,16 +839,6 @@ absl::StatusOr<bool> IdealMhdModel::update(
       }
 
       if (r_.nsMaxF1 == m_fc_.ns) {
-        // MUST NOT BREAK TRI-DIAGONAL RADIAL COUPLING: OFFENDS PRECONDITIONER!
-        // double edgePressure = 1.5 * p.presH[r.nsMaxH-1 - r.nsMinH] - 0.5 *
-        // p.presH[r.nsMinH - r.nsMinH];
-        double edgePressure =
-            m_p_.evalMassProfile((m_fc_.ns - 1.5) / (m_fc_.ns - 1.0));
-        if (edgePressure != 0.0) {
-          edgePressure = m_p_.evalMassProfile(1.0) / edgePressure *
-                         m_p_.presH[r_.nsMaxH - 1 - r_.nsMinH];
-        }
-
         for (int kl = 0; kl < s_.nZnT; ++kl) {
           // extrapolate total pressure (from inside) to LCFS; this is
           // bsqsav(:,3) in Fortran VMEC
@@ -856,15 +846,16 @@ absl::StatusOr<bool> IdealMhdModel::update(
               1.5 * totalPressure[(r_.nsMaxH - 1 - r_.nsMinH) * s_.nZnT + kl] -
               0.5 * totalPressure[(r_.nsMaxH - 2 - r_.nsMinH) * s_.nZnT + kl];
 
-          // net pressure from outside on LCFS
+          // total pressure from outside on LCFS: the vacuum carries no kinetic
+          // pressure, so the boundary settles where B_vac^2/2 = p + B^2/2
           // FIXME(eguiraud) slow loop over Nestor output
           // NOTE: here is the interface between the fast-toroidal setup in
           // Nestor and fast-poloidal setup in VMEC
           const int k = kl / s_.nThetaEff;
           const int l = kl % s_.nThetaEff;
           const int idx_lk = l * s_.nZeta + k;
-          double outsideEdgePressure =
-              m_h_.vacuum_magnetic_pressure[idx_lk] + edgePressure;
+          const double outsideEdgePressure =
+              m_h_.vacuum_magnetic_pressure[idx_lk];
 
           // term to enter MHD forces
           int idx_kl = (r_.nsMaxF1 - 1 - r_.nsMinF1) * s_.nZnT + kl;

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_in_memory_mgrid_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_in_memory_mgrid_test.cc
@@ -356,3 +356,69 @@ TEST(TestVmec, SolovevFreeBoundaryAxisymmetric) {
               /*tolerance=*/1e-7, /*check_equal_niter=*/true,
               /*current_density_tolerance=*/2e-7);
 }
+
+// A finite edge pressure is balanced by a jump of the magnetic pressure across
+// the plasma boundary: B_vac^2/2 = p_edge + B_in^2/2 at the converged state.
+TEST(TestVmec, EdgePressureIsBalancedByTheMagneticPressureJump) {
+  const std::string filename = "vmecpp/test_data/cth_like_free_bdy.json";
+  const absl::StatusOr<std::string> indata_json = ReadFile(filename);
+  ASSERT_TRUE(indata_json.ok());
+  absl::StatusOr<VmecINDATA> maybe_indata = VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(maybe_indata.ok());
+  VmecINDATA& indata = maybe_indata.value();
+
+  // p = 2000 (1 - s / 2) Pa, so 1 kPa at the boundary, 0.7% of B^2 / 2 mu0
+  indata.pmass_type = "power_series";
+  indata.am = Eigen::VectorXd(2);
+  indata.am << 1.0, -0.5;
+  indata.pres_scale = 2000.0;
+  const double mu0_edge_pressure = vmecpp::MU_0 * 1000.0;
+
+  const auto maybe_magnetic_configuration =
+      magnetics::ImportMagneticConfigurationFromCoilsFile(
+          "vmecpp/test_data/coils.cth_like");
+  ASSERT_TRUE(maybe_magnetic_configuration.ok());
+  auto maybe_makegrid_params = makegrid::ImportMakegridParametersFromFile(
+      "vmecpp/test_data/makegrid_parameters_cth_like.json");
+  ASSERT_TRUE(maybe_makegrid_params.ok());
+  makegrid::MakegridParameters makegrid_params = *maybe_makegrid_params;
+  // The plasma expands beyond the shipped box once the edge pressure is
+  // balanced by the field, so widen the grid.
+  makegrid_params.r_grid_minimum = 0.35;
+  makegrid_params.r_grid_maximum = 1.25;
+  makegrid_params.number_of_r_grid_points = 61;
+  makegrid_params.z_grid_minimum = -0.4;
+  makegrid_params.z_grid_maximum = 0.4;
+  makegrid_params.number_of_z_grid_points = 61;
+  const auto maybe_response_table = makegrid::ComputeMagneticFieldResponseTable(
+      makegrid_params, *maybe_magnetic_configuration);
+  ASSERT_TRUE(maybe_response_table.ok());
+
+  const auto output = vmecpp::run(indata, *maybe_response_table);
+  ASSERT_TRUE(output.ok()) << output.status();
+
+  const vmecpp::Threed1FreeBoundary& fb = output->threed1_free_boundary;
+  double magnetic_pressure_jump = 0.0;
+  double total_pressure_jump = 0.0;
+  for (int k = 0; k < fb.brv.rows(); ++k) {
+    for (int l = 0; l < fb.brv.cols(); ++l) {
+      const double vacuum =
+          0.5 * (fb.brv(k, l) * fb.brv(k, l) + fb.bphiv(k, l) * fb.bphiv(k, l) +
+                 fb.bzv(k, l) * fb.bzv(k, l));
+      const double plasma = 0.5 * (fb.bredge(k, l) * fb.bredge(k, l) +
+                                   fb.bpedge(k, l) * fb.bpedge(k, l) +
+                                   fb.bzedge(k, l) * fb.bzedge(k, l));
+      magnetic_pressure_jump += vacuum - plasma;
+      total_pressure_jump += fb.bsqvacf(k, l) - fb.bsqmhdf(k, l);
+    }
+  }
+  const double num_points = static_cast<double>(fb.brv.size());
+  magnetic_pressure_jump /= num_points;
+  total_pressure_jump /= num_points;
+
+  // the field carries the kinetic pressure jump, and the total pressure is
+  // continuous; the remainder is the O(delta s) slope of the profile
+  EXPECT_NEAR(magnetic_pressure_jump, mu0_edge_pressure,
+              0.05 * mu0_edge_pressure);
+  EXPECT_LT(std::abs(total_pressure_jump), 0.02 * mu0_edge_pressure);
+}


### PR DESCRIPTION
**Change** - the free-boundary force takes the vacuum magnetic pressure alone as the total pressure outside the plasma, so the boundary settles where `B_vac^2/2 = p_edge + B^2/2`, the jump condition DESC's `BoundaryError` imposes with a sheet current. VMEC 8.52 adds the plasma edge pressure to the vacuum side (`presf_ns` in `funct3d`), which makes `|B|` continuous across the boundary instead and leaves the kinetic pressure jump unbalanced; PARVMEC and educational_VMEC carry the same lines, and the "RPRES" alternative the comment refers to does not exist in any of them.

**Cause** - with a finite edge pressure the converged state had `|B_vac|^2/2 - |B|^2/2 = 0` and a total-pressure step of exactly `mu0 p_edge` across the boundary, measured from the `freeb_data` arrays: on `cth_like_free_bdy` with `p = 2000 (1 - s/2)` Pa, the step is 1.2505e-3 T^2 against `mu0 p_edge` = 1.2566e-3 T^2, with `|B|` continuous to 5e-5. The edge pressure therefore drops out entirely: a flat profile `p = 1000` Pa gives the same free-boundary equilibrium as `p = 0` (every `rmnc` within 2e-6, `b0` and iota unchanged) while reporting `betatotal` = 0.75 %, although a uniform pressure needs a diamagnetic surface current and its hoop force has to be balanced.

**Evidence** - with the change the total pressure is continuous to 4e-6 T^2, the same residual as the zero-edge-pressure control, and the magnetic pressure jumps by 1.2466e-3 T^2. The equilibrium moves: `rmax_surf` 1.0174 -> 1.0534, volume +4.8 %, edge iota +4 %, 13 mm rms over the boundary; the flat 1 kPa profile now moves the boundary by 31 mm at `rmax_surf` and lowers `b0` by 1.4 %. Convergence takes 548 iterations against 488; at 5 kPa (3.5 % of the magnetic pressure) the corrected balance converges monotonically but needs about 4000 iterations against 717.

**Tests** - `EdgePressureIsBalancedByTheMagneticPressureJump` in `vmec_in_memory_mgrid_test` solves the 1 kPa case on a widened in-memory response table and requires the magnetic pressure jump to equal `mu0 p_edge` within 5 % and the total pressure to be continuous within 2 %; on main the jump is zero.

**Scope** - every shipped case has `p(1) = 0`, so the reference comparisons and the fixed-boundary path are unchanged bit for bit. The threed1 `delbsq` column now reports the physical total-pressure mismatch.
