### PR TITLE
Reject a current profile that encloses no net current at the boundary

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/BUILD.bazel
@@ -7,6 +7,7 @@ cc_library(
     hdrs = ["radial_profiles.h"],
     visibility = ["//visibility:public"],
     deps = [
+        "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/strings:str_format",
         "@abseil-cpp//absl/log:log",
         "//vmecpp/common/vmec_indata:vmec_indata",

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
@@ -463,6 +463,29 @@ double RadialProfiles::evalCurrProfile(double x) {
   return p;
 }
 
+absl::Status RadialProfiles::CheckCurrentProfileEnclosesEdgeCurrent() {
+  if (id_.ncurr != 1) {
+    return absl::OkStatus();
+  }
+  const double edge_current = std::abs(evalCurrProfile(1.0));
+  double largest_current = edge_current;
+  static constexpr int kSamples = 100;
+  for (int i = 1; i < kSamples; ++i) {
+    largest_current =
+        std::max(largest_current,
+                 std::abs(evalCurrProfile(static_cast<double>(i) / kSamples)));
+  }
+  if (largest_current > 0.0 && edge_current <= 1.0e-10 * largest_current) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "the current profile '%s' encloses no net current at the boundary "
+        "(I(1) = %.3e against max |I| = %.3e), so it cannot be scaled to "
+        "curtor; give a profile with I(1) != 0 or prescribe iota with ncurr = "
+        "0",
+        id_.pcurr_type, edge_current, largest_current));
+  }
+  return absl::OkStatus();
+}
+
 double RadialProfiles::evalProfileFunction(const ProfileParameterization& param,
                                            const Eigen::VectorXd& coeffs,
                                            const Eigen::VectorXd& splineKnots,

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.h
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <string>
 
+#include "absl/status/status.h"
 #include "vmecpp/common/flow_control/flow_control.h"
 #include "vmecpp/common/util/util.h"
 #include "vmecpp/common/vmec_indata/vmec_indata.h"
@@ -48,6 +49,11 @@ class RadialProfiles {
   double evalMassProfile(double x);
   double evalIotaProfile(double x);
   double evalCurrProfile(double x);
+
+  // With ncurr = 1 the enclosed current profile is a shape scaled to curtor by
+  // its value at the boundary, so a profile that encloses no net current there
+  // while carrying current inside cannot be imposed.
+  absl::Status CheckCurrentProfileEnclosesEdgeCurrent();
 
   // Evaluate the radial profile function specified by the given
   // parameterization, which can be either an analytical function (in which case

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -356,8 +356,13 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
       // initialize ns-dependent arrays
       // and (if previous solution is available) interpolate to current ns
       // value
-      if (InitializeRadial(checkpoint, iterations_before_checkpointing,
-                           fc_.nsval, fc_.ns_old, fc_.delt0r, initial_state)) {
+      const absl::StatusOr<bool> initialized =
+          InitializeRadial(checkpoint, iterations_before_checkpointing,
+                           fc_.nsval, fc_.ns_old, fc_.delt0r, initial_state);
+      if (!initialized.ok()) {
+        return initialized.status();
+      }
+      if (*initialized) {
         return true;
       }
 
@@ -535,7 +540,7 @@ void Vmec::SetupVacuumSolvers() {
 }  // SetupVacuumSolvers
 
 // initialize_radial quantities, return true if a checkpoint was reached
-bool Vmec::InitializeRadial(
+absl::StatusOr<bool> Vmec::InitializeRadial(
     VmecCheckpoint checkpoint, int iterations_before_checkpointing, int nsval,
     int ns_old, double& m_delt0,
     const std::optional<HotRestartState>& initial_state,
@@ -658,6 +663,12 @@ bool Vmec::InitializeRadial(
       m_[thread_id]->setFromINDATA(indata_.ncurr, indata_.gamma, indata_.tcon0,
                                    indata_.lforbal);
     }  // thread_id
+
+    absl::Status current_profile_status =
+        p_[0]->CheckCurrentProfileEnclosesEdgeCurrent();
+    if (!current_profile_status.ok()) {
+      return current_profile_status;
+    }
 
     if (checkpoint == VmecCheckpoint::SPECTRAL_CONSTRAINT &&
         iterations_before_checkpointing <= 1) {

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
@@ -133,7 +133,7 @@ class Vmec {
   // multigrid steps.
   void SetupVacuumSolvers();
 
-  bool InitializeRadial(
+  absl::StatusOr<bool> InitializeRadial(
       VmecCheckpoint checkpoint, int maximum_iterations, int nsval, int ns_old,
       double& m_delt0,
       const std::optional<HotRestartState>& initial_state = std::nullopt,

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
@@ -110,6 +110,27 @@ TEST(TestVmec, CheckNoErrorOnNonConvergenceIfDesired) {
   CHECK(status.ok());
 }  // CheckNoErrorOnNonConvergenceIfDesired
 
+// With ncurr = 1 the current profile is scaled to curtor by its value at the
+// boundary, so a profile that encloses no net current there cannot be imposed
+// and used to run silently with zero current.
+TEST(TestVmec, RejectsACurrentProfileWithoutEdgeCurrent) {
+  const std::string filename = "vmecpp/test_data/cth_like_fixed_bdy.json";
+  const absl::StatusOr<std::string> indata_json = ReadFile(filename);
+  ASSERT_TRUE(indata_json.ok());
+  absl::StatusOr<VmecINDATA> maybe_indata = VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(maybe_indata.ok());
+  VmecINDATA indata = *maybe_indata;
+  // I'(s) = 1 - 2 s integrates to zero at the boundary
+  indata.pcurr_type = "power_series";
+  indata.ac = Eigen::VectorXd(2);
+  indata.ac << 1.0, -2.0;
+  const auto output = vmecpp::run(indata);
+  ASSERT_FALSE(output.ok());
+  EXPECT_EQ(output.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(std::string(output.status().message()),
+              ::testing::HasSubstr("encloses no net current"));
+}
+
 TEST(TestVmec, CheckFromIndataReturnsErrorForInvalidMgridPath) {
   // Verify that FromIndata returns an error status (rather than throwing)
   // when a free-boundary run specifies a non-existent mgrid file.


### PR DESCRIPTION
**Change** - with `ncurr = 1` the enclosed current profile is a shape that `curtor` scales by its value at the boundary. A profile that carries current inside but encloses none at `s = 1`, such as `power_series` with `ac = [1, -2]`, is now rejected with `kInvalidArgument` naming the profile, `I(1)` and `max |I|`.

**Cause** - `RadialProfiles::evalRadialProfiles` sets the scale to zero when `I(1)` vanishes, as `profil1d` does in Fortran VMEC behind a comment that asks what the branch is for, so such an input ran with zero current everywhere and reported `ctor = 0` without any message, for any `curtor`.

**Evidence** - `cth_like_fixed_bdy` with `pcurr_type = power_series`, `ac = [1, -2]` and `curtor = 1e4` converged in 151 iterations to the currentless equilibrium of `curtor = 0` (identical `iotaf`, `jcurv` below 3e-10).

**Tests** - `RejectsACurrentProfileWithoutEdgeCurrent` in `vmec_test`. The check evaluates the profile once per multigrid step in `InitializeRadial`, which now returns `absl::StatusOr<bool>`.

**Scope** - a profile that is zero everywhere still runs (no current), and every shipped input has `I(1) != 0`.
