### PR TITLE
Implement the sum_cossq current profiles

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -88,6 +89,36 @@ absl::Status CheckProfile(const std::string& type_key,
     }
   }
 
+  return absl::OkStatus();
+}
+
+// The sum_cossq_s and sum_cossq_sqrts current profiles take the number of
+// cos^2 humps from ac[0], which sets their spacing 1 / (ac[0] - 1), and
+// sum_cossq_s_free takes a half-width per hump from ac[3 i + 2]; a hump count
+// below two or a non-positive half-width cannot be evaluated.
+absl::Status CheckSumCossqCoefficients(const std::string& pcurr_type,
+                                       const Eigen::VectorXd& ac) {
+  const auto coefficient = [&ac](int i) { return i < ac.size() ? ac[i] : 0.0; };
+  if (pcurr_type == "sum_cossq_s" || pcurr_type == "sum_cossq_sqrts") {
+    const double num_humps = coefficient(0);
+    if (num_humps != std::floor(num_humps) || num_humps < 2.0 ||
+        num_humps > 20.0) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "input variable 'pcurr_type' is '%s', so 'ac[0]' must be the "
+          "number of cos^2 humps, an integer from 2 to 20, but is %g\n",
+          pcurr_type, num_humps));
+    }
+  } else if (pcurr_type == "sum_cossq_s_free") {
+    for (int i = 0; i < 7; ++i) {
+      if (coefficient(3 * i) != 0.0 && coefficient(3 * i + 2) <= 0.0) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "input variable 'pcurr_type' is 'sum_cossq_s_free', so 'ac[%d]' "
+            "must be the positive half-width of the hump with amplitude "
+            "'ac[%d]' = %g, but is %g\n",
+            3 * i + 2, 3 * i, coefficient(3 * i), coefficient(3 * i + 2)));
+      }
+    }
+  }
   return absl::OkStatus();
 }
 }  // namespace
@@ -1486,6 +1517,11 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
   if (absl::Status status = CheckProfile(
           "pcurr_type", vmec_indata.pcurr_type, ProfileType::CURRENT, "ac",
           vmec_indata.ac_aux_s, vmec_indata.ac_aux_f);
+      !status.ok()) {
+    return status;
+  }
+  if (absl::Status status =
+          CheckSumCossqCoefficients(vmec_indata.pcurr_type, vmec_indata.ac);
       !status.ok()) {
     return status;
   }

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata_test.cc
@@ -267,6 +267,38 @@ TEST(TestVmecINDATA, CheckSplineProfilesNeedKnots) {
   EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
 }
 
+// The sum_cossq current profiles read their hump layout from ac: a hump count
+// in ac[0] for the equidistant forms and a half-width per hump for the free
+// form.
+TEST(TestVmecINDATA, CheckSumCossqProfilesNeedAValidHumpLayout) {
+  VmecINDATA indata;
+  indata.ncurr = 1;
+  for (const std::string type : {"sum_cossq_s", "sum_cossq_sqrts"}) {
+    indata.pcurr_type = type;
+    for (double num_humps : {1.0, 2.5, 21.0}) {
+      indata.ac = Eigen::VectorXd::Constant(4, 1.0);
+      indata.ac[0] = num_humps;
+      EXPECT_EQ(IsConsistent(indata, /*enable_info_messages=*/false).code(),
+                absl::StatusCode::kInvalidArgument)
+          << type << " with ac[0] = " << num_humps;
+    }
+    indata.ac[0] = 3.0;
+    EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok())
+        << type;
+  }
+
+  indata.pcurr_type = "sum_cossq_s_free";
+  indata.ac = Eigen::VectorXd(3);
+  indata.ac << 1.0, 0.5, 0.0;
+  EXPECT_EQ(IsConsistent(indata, /*enable_info_messages=*/false).code(),
+            absl::StatusCode::kInvalidArgument);
+  indata.ac << 1.0, 0.5, 0.1;
+  EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+  // a hump of zero amplitude may have zero width
+  indata.ac << 0.0, 0.5, 0.0;
+  EXPECT_TRUE(IsConsistent(indata, /*enable_info_messages=*/false).ok());
+}
+
 TEST(TestVmecINDATA, ToJson) {
   const absl::StatusOr<std::string> indata_json =
       ReadFile("vmecpp/test_data/cth_like_free_bdy.json");

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.cc
@@ -505,8 +505,11 @@ double RadialProfiles::evalProfileFunction(const ProfileParameterization& param,
     case ProfileParameterization::NICE_QUADRATIC:
       return evalNiceQuadratic(coeffs, normX);
     case ProfileParameterization::SUM_COSSQ_S:
+      return evalSumCossqS(coeffs, normX);
     case ProfileParameterization::SUM_COSSQ_SQRTS:
+      return evalSumCossqSqrts(coeffs, normX);
     case ProfileParameterization::SUM_COSSQ_S_FREE:
+      return evalSumCossqSFree(coeffs, normX);
     default:
       std::cerr
           << absl::StrFormat(
@@ -1021,6 +1024,95 @@ double RadialProfiles::evalNiceQuadratic(const Eigen::VectorXd& coeffs,
   // Ported from Fortran VMEC piota 'nice_quadratic'.
   return Coef(coeffs, 0) * (1.0 - x) + Coef(coeffs, 1) * x +
          4.0 * Coef(coeffs, 2) * x * (1.0 - x);
+}
+
+namespace {
+// Integral from lower to upper of cos^2(pi (t - center) / (2 half_width)), the
+// enclosed current of one cos^2 hump of the sum_cossq profiles.
+double CosSqHumpIntegral(double center, double half_width, double lower,
+                         double upper) {
+  const auto primitive = [center, half_width](double t) {
+    return 0.5 * (t - center) + half_width / (2.0 * M_PI) *
+                                    std::sin(M_PI * (t - center) / half_width);
+  };
+  return primitive(upper) - primitive(lower);
+}
+}  // namespace
+
+// Enclosed current of coeffs[0] cos^2 humps in s of half-width
+// delta = 1 / (coeffs[0] - 1), centred on (i - 1) delta with amplitude
+// coeffs[i] for i = 1, ..., coeffs[0]; the two end humps are cut at s = 0 and
+// s = 1. Ported from Fortran VMEC pcurr 'sum_cossq_s'.
+double RadialProfiles::evalSumCossqS(const Eigen::VectorXd& coeffs, double x) {
+  const int num_humps = static_cast<int>(Coef(coeffs, 0));
+  if (num_humps < 2) {
+    return 0.0;
+  }
+  const double delta = 1.0 / (num_humps - 1);
+  double current = 0.0;
+  for (int i = 1; i <= num_humps; ++i) {
+    const double center = (i - 1) * delta;
+    const double lower = std::max(0.0, center - delta);
+    const double upper = std::min(x, std::min(center + delta, 1.0));
+    if (upper > lower) {
+      current +=
+          Coef(coeffs, i) * CosSqHumpIntegral(center, delta, lower, upper);
+    }
+  }
+  return current;
+}
+
+// The same humps placed in rho = sqrt(s), so the enclosed current is the
+// integral of hump times rho up to sqrt(s). Ported from Fortran VMEC pcurr
+// 'sum_cossq_sqrts'.
+double RadialProfiles::evalSumCossqSqrts(const Eigen::VectorXd& coeffs,
+                                         double x) {
+  const int num_humps = static_cast<int>(Coef(coeffs, 0));
+  if (num_humps < 2) {
+    return 0.0;
+  }
+  const double delta = 1.0 / (num_humps - 1);
+  const double rho = std::sqrt(std::max(x, 0.0));
+  double current = 0.0;
+  for (int i = 1; i <= num_humps; ++i) {
+    const double center = (i - 1) * delta;
+    const double lower = std::max(0.0, center - delta);
+    const double upper = std::min(rho, std::min(center + delta, 1.0));
+    if (upper <= lower) {
+      continue;
+    }
+    // antiderivative of t cos^2(pi (t - center) / (2 delta))
+    const auto primitive = [center, delta](double t) {
+      const double angle = M_PI * (t - center) / delta;
+      return 0.25 * t * t + delta * t / (2.0 * M_PI) * std::sin(angle) +
+             delta * delta / (2.0 * M_PI * M_PI) * std::cos(angle);
+    };
+    current += Coef(coeffs, i) * (primitive(upper) - primitive(lower));
+  }
+  return current;
+}
+
+// Up to seven cos^2 humps in s with their own amplitude coeffs[3 i], centre
+// coeffs[3 i + 1] and half-width coeffs[3 i + 2], each cut at s = 0 and
+// s = 1. Ported from Fortran VMEC pcurr 'sum_cossq_s_free'.
+double RadialProfiles::evalSumCossqSFree(const Eigen::VectorXd& coeffs,
+                                         double x) {
+  double current = 0.0;
+  for (int i = 0; i < 7; ++i) {
+    const double amplitude = Coef(coeffs, 3 * i);
+    const double center = Coef(coeffs, 3 * i + 1);
+    const double half_width = Coef(coeffs, 3 * i + 2);
+    if (amplitude == 0.0 || half_width <= 0.0) {
+      continue;
+    }
+    const double lower = std::max(0.0, center - half_width);
+    const double upper = std::min(x, std::min(center + half_width, 1.0));
+    if (upper > lower) {
+      current +=
+          amplitude * CosSqHumpIntegral(center, half_width, lower, upper);
+    }
+  }
+  return current;
 }
 
 void RadialProfiles::evalRadialProfiles(bool haveToFlipTheta,

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles.h
@@ -105,6 +105,9 @@ class RadialProfiles {
                                    const Eigen::VectorXd& splineValues,
                                    double x);
   double evalNiceQuadratic(const Eigen::VectorXd& coeffs, double x);
+  double evalSumCossqS(const Eigen::VectorXd& coeffs, double x);
+  double evalSumCossqSqrts(const Eigen::VectorXd& coeffs, double x);
+  double evalSumCossqSFree(const Eigen::VectorXd& coeffs, double x);
 
   // Accumulate contributions to volume-averaged spectral width <M>.
   void AccumulateVolumeAveragedSpectralWidth() const;

--- a/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/radial_profiles/radial_profiles_test.cc
@@ -11,7 +11,9 @@
 // two_power_gs, and the analytic endpoints/limits of the closed-form profiles.
 #include "vmecpp/vmec/radial_profiles/radial_profiles.h"
 
+#include <algorithm>
 #include <cmath>
+#include <functional>
 #include <initializer_list>
 #include <memory>
 
@@ -297,6 +299,109 @@ TEST_F(RadialProfilesTest, SumAtanTermsScaledByTwoOverPi) {
                  0.2 * std::atan(3.0 * std::pow(x, 2.0) / std::pow(0.6, 1.0)));
   EXPECT_NEAR(profiles_->evalSumAtan(d, x), expected, 1e-12);
   EXPECT_NEAR(profiles_->evalSumAtan(d, 1.0), 0.1 + 0.5 - 0.2, 1e-12);
+}
+
+// ---- sum_cossq -------------------------------------------------------------
+
+namespace {
+// Composite Simpson rule for the integral of f from 0 to x.
+double Integrate(const std::function<double(double)>& f, double x) {
+  constexpr int kPanels = 4000;
+  if (x <= 0.0) {
+    return 0.0;
+  }
+  const double h = x / kPanels;
+  double sum = f(0.0) + f(x);
+  for (int i = 1; i < kPanels; ++i) {
+    sum += (i % 2 == 1 ? 4.0 : 2.0) * f(i * h);
+  }
+  return sum * h / 3.0;
+}
+
+// Current density of sum_cossq_s: c[i] cos^2 humps of half-width
+// delta = 1 / (c[0] - 1) centred on (i - 1) delta, cut at 0 and 1. The humps
+// vanish at their edges, so closed intervals do not double count.
+double SumCossqDensity(const Eigen::VectorXd& c, double t) {
+  const int n = static_cast<int>(c[0]);
+  const double delta = 1.0 / (n - 1);
+  double density = 0.0;
+  for (int i = 1; i <= n; ++i) {
+    const double center = (i - 1) * delta;
+    if (t >= std::max(0.0, center - delta) &&
+        t <= std::min(center + delta, 1.0)) {
+      density +=
+          c[i] * std::pow(std::cos(M_PI * (t - center) / (2.0 * delta)), 2);
+    }
+  }
+  return density;
+}
+
+// Current density of sum_cossq_s_free: humps with amplitude c[3 i], centre
+// c[3 i + 1] and half-width c[3 i + 2], cut at 0 and 1.
+double SumCossqFreeDensity(const Eigen::VectorXd& c, double t) {
+  double density = 0.0;
+  for (int i = 0; 3 * i + 2 < c.size(); ++i) {
+    const double center = c[3 * i + 1];
+    const double half_width = c[3 * i + 2];
+    if (c[3 * i] != 0.0 && t >= std::max(0.0, center - half_width) &&
+        t <= std::min(center + half_width, 1.0)) {
+      density +=
+          c[3 * i] *
+          std::pow(std::cos(M_PI * (t - center) / (2.0 * half_width)), 2);
+    }
+  }
+  return density;
+}
+}  // namespace
+
+// The enclosed current of sum_cossq_s is the integral of its humps; the end
+// humps are cut in half by s = 0 and s = 1.
+TEST_F(RadialProfilesTest, SumCossqSIntegratesItsHumps) {
+  // five humps of half-width 1/4
+  const Eigen::VectorXd c = Vec({5.0, 1.0, 0.5, -0.3, 0.8, 0.2});
+  EXPECT_EQ(profiles_->evalSumCossqS(c, 0.0), 0.0);
+  for (double x : {0.1, 0.25, 0.3, 0.5, 0.62, 0.75, 0.9, 1.0}) {
+    EXPECT_NEAR(profiles_->evalSumCossqS(c, x),
+                Integrate([&c](double t) { return SumCossqDensity(c, t); }, x),
+                1e-9)
+        << "x = " << x;
+  }
+  // an interior hump encloses its amplitude times the half-width
+  EXPECT_NEAR(profiles_->evalSumCossqS(c, 1.0),
+              0.25 * (0.5 * 1.0 + 0.5 - 0.3 + 0.8 + 0.5 * 0.2), 1e-12);
+}
+
+// sum_cossq_sqrts places the humps in rho = sqrt(s) and integrates them with
+// the weight rho up to sqrt(s).
+TEST_F(RadialProfilesTest, SumCossqSqrtsIntegratesItsHumpsInRho) {
+  const Eigen::VectorXd c = Vec({5.0, 1.0, 0.5, -0.3, 0.8, 0.2});
+  EXPECT_EQ(profiles_->evalSumCossqSqrts(c, 0.0), 0.0);
+  for (double s : {0.01, 0.0625, 0.2, 0.25, 0.5, 0.64, 0.8, 1.0}) {
+    EXPECT_NEAR(
+        profiles_->evalSumCossqSqrts(c, s),
+        Integrate([&c](double rho) { return SumCossqDensity(c, rho) * rho; },
+                  std::sqrt(s)),
+        1e-9)
+        << "s = " << s;
+  }
+}
+
+// sum_cossq_s_free integrates humps of individual centre and half-width, cut
+// at s = 0 and s = 1, and skips entries with zero amplitude.
+TEST_F(RadialProfilesTest, SumCossqSFreeIntegratesItsHumps) {
+  const Eigen::VectorXd c =
+      Vec({1.0, 0.3, 0.2, -0.5, 0.7, 0.4, 0.8, 0.95, 0.15, 0.0, 0.5, 0.0});
+  EXPECT_EQ(profiles_->evalSumCossqSFree(c, 0.0), 0.0);
+  for (double x : {0.05, 0.1, 0.3, 0.5, 0.8, 0.9, 1.0}) {
+    EXPECT_NEAR(
+        profiles_->evalSumCossqSFree(c, x),
+        Integrate([&c](double t) { return SumCossqFreeDensity(c, t); }, x),
+        1e-9)
+        << "x = " << x;
+  }
+  // a hump inside (0, 1) encloses its amplitude times the half-width
+  const Eigen::VectorXd d = Vec({2.0, 0.5, 0.25});
+  EXPECT_NEAR(profiles_->evalSumCossqSFree(d, 1.0), 0.5, 1e-12);
 }
 
 // ---- rational --------------------------------------------------------------


### PR DESCRIPTION
**Change** - `pcurr_type = sum_cossq_s`, `sum_cossq_sqrts` and `sum_cossq_s_free` now evaluate the enclosed current of their cos^2 humps in closed form, as `pcurr` in Fortran VMEC does. `IsConsistent` requires `ac[0]` of the two equidistant forms to be an integer hump count from 2 to 20, and a positive half-width for every hump of the free form that carries an amplitude.

**Cause** - the three names sat in the parameterization table as allowed current profiles, but `evalProfileFunction` fell through to its default branch, which returns 0.0 after one line on stderr. With `ncurr = 1` the run continued with zero current everywhere and reported `ctor = 0`; `VmecInput` types `pcurr_type` as a plain string and `IsConsistent` only checks that the name is in the table, so nothing stopped it.

**Evidence** - `cth_like_fixed_bdy` with each of the three profiles, VMEC++ against PARVMEC 10.0 reading the same INDATA file at `ftol = 1e-11`: identical iteration counts (565, 513 and 620) and every wout field within 1e-6, `rmnc` within 1.2e-8, `iotaf` within 3e-8 and `jcurv` within 1e-13. On main the three inputs converge to one and the same currentless equilibrium in 744 iterations, `ctor` = 1e-11 A and an edge iota of 0.29 against the 43 kA and 0.83 to 0.89 they prescribe.

**Tests** - `SumCossqSIntegratesItsHumps`, `SumCossqSqrtsIntegratesItsHumpsInRho` and `SumCossqSFreeIntegratesItsHumps` in `radial_profiles_test` compare the closed forms with a quadrature of the hump densities and the end humps cut by s = 0 and s = 1; `CheckSumCossqProfilesNeedAValidHumpLayout` in `vmec_indata_test` covers the rejections.

**Scope** - the other parameterizations are untouched, and no reference file changes since educational_VMEC does not implement these profiles. At s = 0 exactly the enclosed current is 0, where the Fortran branch returns half the first hump; the solver evaluates the profile on the half grid and at s = 1 only.
