### PR TITLE
Reject an external field without stellarator symmetry when lasym is false

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -91,6 +91,81 @@ absl::Status CheckInitialState(const vmecpp::HotRestartState& initial_state,
 
   return absl::OkStatus();
 }
+
+// Largest rms antisymmetric part of the external field, relative to the rms of
+// the field, that a run with lasym = false accepts.
+constexpr double kMaxExternalFieldAsymmetry = 1.0e-4;
+
+// The rms of the part of the external field on the initial boundary that is odd
+// under the stellarator symmetry (R, phi, Z) -> (R, -phi, -Z), relative to the
+// rms of the field. The boundary is sampled on the reduced poloidal grid of the
+// vacuum solver; its mirror image is the same surface, since the boundary is
+// stellarator symmetric.
+absl::StatusOr<double> StellaratorAsymmetryOfExternalField(
+    const vmecpp::VmecINDATA& indata, const vmecpp::Sizes& s,
+    const vmecpp::MGridProvider& mgrid) {
+  const int num_points = s.nThetaReduced * s.nZeta;
+  Eigen::VectorXd r(num_points);
+  Eigen::VectorXd z(num_points);
+  Eigen::VectorXd r_mirror(num_points);
+  Eigen::VectorXd z_mirror(num_points);
+  for (int l = 0; l < s.nThetaReduced; ++l) {
+    const double theta = 2.0 * M_PI * l / s.nThetaEven;
+    for (int k = 0; k < s.nZeta; ++k) {
+      const double zeta = 2.0 * M_PI * k / (s.nfp * s.nZeta);
+      double r_lk = 0.0;
+      double z_lk = 0.0;
+      for (int m = 0; m < indata.mpol; ++m) {
+        for (int n = -indata.ntor; n <= indata.ntor; ++n) {
+          const double arg = m * theta - n * s.nfp * zeta;
+          r_lk += indata.rbc(m, indata.ntor + n) * std::cos(arg);
+          z_lk += indata.zbs(m, indata.ntor + n) * std::sin(arg);
+        }
+      }
+      r[l * s.nZeta + k] = r_lk;
+      z[l * s.nZeta + k] = z_lk;
+      const int k_mirror = (s.nZeta - k) % s.nZeta;
+      r_mirror[l * s.nZeta + k_mirror] = r_lk;
+      z_mirror[l * s.nZeta + k_mirror] = -z_lk;
+    }
+  }
+
+  Eigen::VectorXd b_r(num_points);
+  Eigen::VectorXd b_p(num_points);
+  Eigen::VectorXd b_z(num_points);
+  Eigen::VectorXd b_r_mirror(num_points);
+  Eigen::VectorXd b_p_mirror(num_points);
+  Eigen::VectorXd b_z_mirror(num_points);
+  absl::Status status = mgrid.interpolate(0, num_points, s.nZeta, num_points, r,
+                                          z, b_r, b_p, b_z);
+  if (!status.ok()) {
+    return status;
+  }
+  status = mgrid.interpolate(0, num_points, s.nZeta, num_points, r_mirror,
+                             z_mirror, b_r_mirror, b_p_mirror, b_z_mirror);
+  if (!status.ok()) {
+    return status;
+  }
+
+  double field = 0.0;
+  double difference = 0.0;
+  for (int l = 0; l < s.nThetaReduced; ++l) {
+    for (int k = 0; k < s.nZeta; ++k) {
+      const int kl = l * s.nZeta + k;
+      const int kl_mirror = l * s.nZeta + (s.nZeta - k) % s.nZeta;
+      const double d_r = b_r_mirror[kl_mirror] + b_r[kl];
+      const double d_p = b_p_mirror[kl_mirror] - b_p[kl];
+      const double d_z = b_z_mirror[kl_mirror] - b_z[kl];
+      difference += d_r * d_r + d_p * d_p + d_z * d_z;
+      field += b_r[kl] * b_r[kl] + b_p[kl] * b_p[kl] + b_z[kl] * b_z[kl];
+    }
+  }
+  if (field == 0.0) {
+    return 0.0;
+  }
+  // the mirrored field minus the field is twice the antisymmetric part
+  return 0.5 * std::sqrt(difference / field);
+}
 }  // namespace
 
 absl::StatusOr<vmecpp::OutputQuantities> vmecpp::run(
@@ -249,6 +324,21 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
           "MGridProvider has %d field periods, but VmecINDATA has nfp = %d. "
           "Please ensure that the two are consistent.",
           mgrid_.nfp, indata_.nfp));
+    }
+    if (!indata_.lasym) {
+      // A boundary outside the vacuum grid is reported by the vacuum solver.
+      const absl::StatusOr<double> asymmetry =
+          StellaratorAsymmetryOfExternalField(indata_, s_, mgrid_);
+      if (asymmetry.ok() && *asymmetry > kMaxExternalFieldAsymmetry) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "The external magnetic field is not stellarator symmetric on the "
+            "initial boundary: its antisymmetric part is %.1e of the field, "
+            "above the limit of %.0e. With lasym = false the field is sampled "
+            "on half of the boundary and mirrored, which converges to the "
+            "equilibrium of a different field. Set lasym = true, or "
+            "symmetrize the field.",
+            *asymmetry, kMaxExternalFieldAsymmetry));
+      }
     }
   }
 

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_in_memory_mgrid_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_in_memory_mgrid_test.cc
@@ -118,6 +118,68 @@ TEST(TestVmec, InMemoryMgridWithMismatchedNfpIsRejected) {
               ::testing::HasSubstr("field periods"));
 }
 
+// A run with lasym = false samples the external field on half of the boundary
+// and mirrors it, so a field without stellarator symmetry is rejected before
+// the iteration; with lasym = true the same field runs. The cth coils raised
+// by 5 mm carry an antisymmetric part of about one percent on the boundary.
+TEST(TestVmec, ExternalFieldWithoutStellaratorSymmetryNeedsLasym) {
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile("vmecpp/test_data/cth_like_free_bdy.json");
+  ASSERT_TRUE(indata_json.ok());
+  absl::StatusOr<VmecINDATA> maybe_indata = VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(maybe_indata.ok());
+  const VmecINDATA& indata = maybe_indata.value();
+
+  auto maybe_magnetic_configuration =
+      magnetics::ImportMagneticConfigurationFromCoilsFile(
+          "vmecpp/test_data/coils.cth_like");
+  ASSERT_TRUE(maybe_magnetic_configuration.ok());
+  for (auto& circuit :
+       *maybe_magnetic_configuration->mutable_serial_circuits()) {
+    for (auto& coil : *circuit.mutable_coils()) {
+      for (auto& carrier : *coil.mutable_current_carriers()) {
+        if (!carrier.has_polygon_filament()) {
+          continue;
+        }
+        for (auto& vertex :
+             *carrier.mutable_polygon_filament()->mutable_vertices()) {
+          vertex.set_z(vertex.z() + 0.005);
+        }
+      }
+    }
+  }
+
+  auto maybe_makegrid_params = makegrid::ImportMakegridParametersFromFile(
+      "vmecpp/test_data/makegrid_parameters_cth_like.json");
+  ASSERT_TRUE(maybe_makegrid_params.ok());
+  makegrid::MakegridParameters makegrid_params = *maybe_makegrid_params;
+  makegrid_params.assume_stellarator_symmetry = false;
+  makegrid_params.number_of_r_grid_points = 51;
+  makegrid_params.number_of_z_grid_points = 51;
+
+  const auto maybe_response_table = makegrid::ComputeMagneticFieldResponseTable(
+      makegrid_params, *maybe_magnetic_configuration);
+  ASSERT_TRUE(maybe_response_table.ok()) << maybe_response_table.status();
+
+  const auto output = vmecpp::run(indata, *maybe_response_table);
+  ASSERT_FALSE(output.ok());
+  EXPECT_EQ(output.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(std::string(output.status().message()),
+              HasSubstr("not stellarator symmetric"));
+
+  const absl::StatusOr<std::string> asym_indata_json =
+      ReadFile("vmecpp/test_data/cth_like_free_bdy_asym.json");
+  ASSERT_TRUE(asym_indata_json.ok());
+  absl::StatusOr<VmecINDATA> maybe_asym_indata =
+      VmecINDATA::FromJson(*asym_indata_json);
+  ASSERT_TRUE(maybe_asym_indata.ok());
+  VmecINDATA asym_indata = maybe_asym_indata.value();
+  asym_indata.niter_array.setConstant(5);
+  asym_indata.return_outputs_even_if_not_converged = true;
+  const auto asym_output = vmecpp::run(asym_indata, *maybe_response_table);
+  ASSERT_TRUE(asym_output.ok()) << asym_output.status();
+}
+
 // The stellarator-symmetry operation maps toroidal plane k onto (kp - k) % kp
 // and Z onto -Z, negates B_R and leaves B_phi and B_Z unchanged; the
 // stellarator-symmetric mgrid_cth_like.nc satisfies that relation to 2e-15.

--- a/tests/test_free_boundary.py
+++ b/tests/test_free_boundary.py
@@ -85,6 +85,44 @@ def test_raise_invalid_nzeta():
         vmecpp.run(vmec_input, response, verbose=False)
 
 
+def test_external_field_without_stellarator_symmetry_needs_lasym(tmp_path):
+    """The cth coils raised by 5 mm give a field that lasym = false cannot use."""
+    raised_coils = tmp_path / "coils.cth_like_raised"
+    lines = []
+    in_filaments = False
+    for line in (TEST_DATA_DIR / "coils.cth_like").read_text().splitlines():
+        tokens = line.split()
+        if in_filaments and len(tokens) >= 4:
+            x, y, z, current = (float(t) for t in tokens[:4])
+            rest = " ".join(tokens[4:])
+            lines.append(f"{x:.12e} {y:.12e} {z + 0.005:.12e} {current:.12e} {rest}")
+        else:
+            lines.append(line)
+        in_filaments = in_filaments or line.strip().startswith("mirror")
+    raised_coils.write_text("\n".join(lines) + "\n")
+
+    makegrid_params = vmecpp.MakegridParameters.from_file(
+        TEST_DATA_DIR / "makegrid_parameters_cth_like.json"
+    )
+    makegrid_params.assume_stellarator_symmetry = False
+    makegrid_params.number_of_r_grid_points = 51
+    makegrid_params.number_of_z_grid_points = 51
+    response = vmecpp.MagneticFieldResponseTable.from_coils_file(
+        raised_coils, makegrid_params
+    )
+
+    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cth_like_free_bdy.json")
+    with pytest.raises(Exception, match="not stellarator symmetric"):
+        vmecpp.run(vmec_input, response, verbose=False)
+
+    asym_input = vmecpp.VmecInput.from_file(
+        TEST_DATA_DIR / "cth_like_free_bdy_asym.json"
+    )
+    asym_input.niter_array = np.array([5])
+    asym_input.return_outputs_even_if_not_converged = True
+    vmecpp.run(asym_input, response, verbose=False)
+
+
 def test_makegrid_parameters_conversion(makegrid_params):
     # Convert resolution parameters to C++ and back to Python
     cpp_params = makegrid_params._to_cpp_makegrid_parameters()


### PR DESCRIPTION
**Change** - a free-boundary run with `lasym = false` now rejects an external field that is not stellarator symmetric. `Vmec::run` samples the field on the initial boundary and on its mirror image and returns `kInvalidArgument` when the rms antisymmetric part exceeds 1e-4 of the field, naming the measured value; `lasym = true` is unaffected.

**Cause** - with `lasym = false` the vacuum solver samples the external field on the poloidal half range and the transforms extend it by stellarator symmetry, so a field with an antisymmetric part is replaced by a different field without any message, as in Fortran VMEC. The equilibrium then differs from the one the field produces: the cth coils raised by 0.2 mm, whose only physical effect is a rigid 0.2 mm shift of the plasma, move `rmax_surf` by 0.7 mm and the edge iota by 6e-4 relative to the `lasym = true` result; at 1 mm the boundary is off by 3.6 mm, at 5 mm by 26 mm and the edge iota by 2 percent. On an exact exterior Neumann problem (an interior current loop 6 cm off the axis) the symmetric path reports the enclosed current with a 14 percent error.

**Evidence** - the antisymmetric part on the cth boundary is 3.2e-4 of the field for the 0.2 mm shift, 1.6e-3 for 1 mm and 7.9e-3 for 5 mm, and the boundary error of the `lasym = false` run is about twice that fraction of `rmax_surf`; the shipped cth field measures 2e-14 and the Solovev free-boundary field 6e-8. At the limit of 1e-4 the coils are off by 0.06 mm and the unnoticed boundary error would be 0.2 mm. Every free-boundary case in the test suites passes the check.

**Tests** - `ExternalFieldWithoutStellaratorSymmetryNeedsLasym` in `vmec_in_memory_mgrid_test` (the raised coils rejected with `lasym = false`, accepted with `lasym = true`) and `test_external_field_without_stellarator_symmetry_needs_lasym` in `tests/test_free_boundary.py`.

**Scope** - the check runs once per `run`, costs two interpolations of the boundary, and only fires for `lasym = false` free-boundary runs whose field fails the symmetry by more than the limit; a boundary outside the vacuum grid is still reported by the vacuum solver.
