### PR TITLE
Size the parallel regions with num_threads clauses instead of the process thread count

### DIFF
--- a/src/vmecpp/cpp/vmecpp/common/flow_control/flow_control.cc
+++ b/src/vmecpp/cpp/vmecpp/common/flow_control/flow_control.cc
@@ -37,14 +37,6 @@ int get_max_threads(std::optional<int> max_threads) {
   CHECK_GT(max_threads.value(), 0)
       << "The number of threads must be >=1. "
          "To automatically use all available threads, pass std::nullopt";
-#ifdef _OPENMP
-  // Size the thread pool immediately so spin-waiting threads are not created
-  // for cores that will never be used. Without this, omp_get_max_threads()
-  // returns the hardware count and the runtime may spawn that many threads
-  // before vmec_adjust_num_threads narrows the count at the first multigrid
-  // step.
-  omp_set_num_threads(max_threads.value());
-#endif  // _OPENMP
   return max_threads.value();
 }
 

--- a/src/vmecpp/cpp/vmecpp/common/util/util.cc
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.cc
@@ -329,10 +329,8 @@ int vmec_adjust_num_threads(const int max_threads,
   int num_threads = std::min(max_threads, num_surfaces_to_distribute / 2);
 
 #ifdef _OPENMP
-  // This must be done _before_ the '#pragma omp parallel' is entered.
-  omp_set_num_threads(num_threads);
-
-  // Explicitly turn off dynamic threads.
+  // The parallel regions request their team size with a num_threads clause;
+  // without dynamic adjustment the runtime grants exactly that many threads.
   omp_set_dynamic(0);
 #endif
 
@@ -344,9 +342,7 @@ int vmec_adjust_vacuum_num_threads(const int max_threads, const int n_znt) {
   // (see TangentialPartitioning). There is no minimum-points-per-thread
   // constraint like the radial solve's shared half-grid point, so we can use up
   // to nZnT threads. In practice nZnT >> max_threads, so this returns
-  // max_threads. Deliberately does NOT call omp_set_num_threads: the vacuum
-  // solve runs in a nested parallel region with an explicit num_threads()
-  // clause.
+  // max_threads.
   return std::min(max_threads, n_znt);
 }
 

--- a/src/vmecpp/cpp/vmecpp/common/util/util.h
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.h
@@ -274,8 +274,9 @@ void TridiagonalSolveOpenMP(
 // ----------------------
 // VMEC-specific
 
-// Compute the maximum allowed number of threads for a VMEC++ run with given
-// radial resolution and adjust the number of OpenMP threads accordingly.
+// Compute the number of threads for the radial solve at the given radial
+// resolution. The count is passed to the parallel region as a num_threads
+// clause; the process-wide OpenMP thread count is left alone.
 int vmec_adjust_num_threads(int max_threads, int num_surfaces_to_distribute);
 
 // Compute the number of threads to use for the free-boundary (NESTOR) vacuum
@@ -283,8 +284,7 @@ int vmec_adjust_num_threads(int max_threads, int num_surfaces_to_distribute);
 // (nZnT points), so - unlike the radial solve, which is capped at ns/2 - it can
 // use as many threads as there are tangential grid points. This count is
 // deliberately decoupled from the radial thread count so the vacuum solve can
-// use the full thread budget even at coarse multigrid steps (small ns).
-// Unlike vmec_adjust_num_threads, this does NOT call omp_set_num_threads: the
+// use the full thread budget even at coarse multigrid steps (small ns). The
 // vacuum solve runs in a nested parallel region with an explicit num_threads()
 // clause.
 int vmec_adjust_vacuum_num_threads(int max_threads, int n_znt);

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -4958,7 +4958,7 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
   // COMPUTE |B| = SQRT(|B|**2) and store in bsq, bsqa
   std::vector<double> magnetic_pressure((fc.ns - 1) * s.nZnT, 0.0);
 #ifdef _OPENMP
-#pragma omp parallel for
+#pragma omp parallel for num_threads(fc.max_threads())
 #endif
   for (int jH = 0; jH < fc.ns - 1; ++jH) {
     for (int kl = 0; kl < s.nZnT; ++kl) {
@@ -5027,7 +5027,7 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
   const int partial_sum_size = (s.mnyq + 1) * s.nZeta;
 
 #ifdef _OPENMP
-#pragma omp parallel
+#pragma omp parallel num_threads(fc.max_threads())
   {
 #endif
     std::vector<double> Fc_gsqrt(partial_sum_size), Fs_gsqrt(partial_sum_size),
@@ -5338,7 +5338,7 @@ vmecpp::WOutFileContents vmecpp::ComputeWOutFileContents(
   // Use the same two-phase separable DFT as the half-grid loop above,
   // parallelised over full-grid surfaces jF.
 #ifdef _OPENMP
-#pragma omp parallel
+#pragma omp parallel num_threads(fc.max_threads())
   {
 #endif
     std::vector<double> Fc_bsubs_full(partial_sum_size),

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -806,7 +806,7 @@ absl::StatusOr<bool> Vmec::SolveEquilibrium(
 
 // NOTE: *THIS* is the main parallel region for the equilibrium solver
 #ifdef _OPENMP
-#pragma omp parallel
+#pragma omp parallel num_threads(num_threads_)
 #endif  // _OPENMP
   {
 #ifdef _OPENMP

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_in_memory_mgrid_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_in_memory_mgrid_test.cc
@@ -118,6 +118,39 @@ TEST(TestVmec, InMemoryMgridWithMismatchedNfpIsRejected) {
               ::testing::HasSubstr("field periods"));
 }
 
+// Two runs of one input in one process take the same thread teams, so their
+// reductions group identically and the states agree bit for bit. Seven
+// surfaces admit three radial threads; the vacuum team takes the full budget.
+TEST(TestVmec, ConsecutiveRunsAreBitIdentical) {
+  const absl::StatusOr<std::string> indata_json =
+      ReadFile("vmecpp/test_data/cth_like_free_bdy.json");
+  ASSERT_TRUE(indata_json.ok());
+  absl::StatusOr<VmecINDATA> maybe_indata = VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(maybe_indata.ok());
+  VmecINDATA indata = *maybe_indata;
+  indata.ns_array.setConstant(7);
+  indata.niter_array.setConstant(60);
+  indata.return_outputs_even_if_not_converged = true;
+
+  const auto maybe_magnetic_configuration =
+      magnetics::ImportMagneticConfigurationFromCoilsFile(
+          "vmecpp/test_data/coils.cth_like");
+  ASSERT_TRUE(maybe_magnetic_configuration.ok());
+  const auto maybe_makegrid_params = makegrid::ImportMakegridParametersFromFile(
+      "vmecpp/test_data/makegrid_parameters_cth_like.json");
+  ASSERT_TRUE(maybe_makegrid_params.ok());
+  const auto maybe_response_table = makegrid::ComputeMagneticFieldResponseTable(
+      *maybe_makegrid_params, *maybe_magnetic_configuration);
+  ASSERT_TRUE(maybe_response_table.ok());
+
+  const auto first = vmecpp::run(indata, *maybe_response_table);
+  ASSERT_TRUE(first.ok()) << first.status();
+  const auto second = vmecpp::run(indata, *maybe_response_table);
+  ASSERT_TRUE(second.ok()) << second.status();
+  CompareWOut(second->wout, first->wout, /*tolerance=*/0.0,
+              /*check_equal_niter=*/true);
+}
+
 // The stellarator-symmetry operation maps toroidal plane k onto (kp - k) % kp
 // and Z onto -Z, negates B_R and leaves B_phi and B_Z unchanged; the
 // stellarator-symmetric mgrid_cth_like.nc satisfies that relation to 2e-15.

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_in_memory_mgrid_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_in_memory_mgrid_test.cc
@@ -8,6 +8,10 @@
 #include <string>
 #include <vector>
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif  // _OPENMP
+
 #include "absl/log/check.h"
 #include "absl/strings/str_format.h"
 #include "gmock/gmock.h"  // ElementsAreArray
@@ -118,10 +122,15 @@ TEST(TestVmec, InMemoryMgridWithMismatchedNfpIsRejected) {
               ::testing::HasSubstr("field periods"));
 }
 
-// Two runs of one input in one process take the same thread teams, so their
-// reductions group identically and the states agree bit for bit. Seven
-// surfaces admit three radial threads; the vacuum team takes the full budget.
-TEST(TestVmec, ConsecutiveRunsAreBitIdentical) {
+// The vacuum solve sizes a nested parallel region of its own, on a thread
+// count decoupled from the radial one. Like the radial solve it has to request
+// that team with a num_threads clause: narrowing the process-wide count
+// instead would outlive the run. Seven surfaces admit three radial threads,
+// fewer than most machines have, while the vacuum team takes the full budget.
+TEST(TestVmec, FreeBoundaryRunLeavesTheProcessThreadCountUnchanged) {
+#ifndef _OPENMP
+  GTEST_SKIP() << "a process-wide thread count exists only in an OpenMP build";
+#else
   const absl::StatusOr<std::string> indata_json =
       ReadFile("vmecpp/test_data/cth_like_free_bdy.json");
   ASSERT_TRUE(indata_json.ok());
@@ -143,12 +152,12 @@ TEST(TestVmec, ConsecutiveRunsAreBitIdentical) {
       *maybe_makegrid_params, *maybe_magnetic_configuration);
   ASSERT_TRUE(maybe_response_table.ok());
 
-  const auto first = vmecpp::run(indata, *maybe_response_table);
-  ASSERT_TRUE(first.ok()) << first.status();
-  const auto second = vmecpp::run(indata, *maybe_response_table);
-  ASSERT_TRUE(second.ok()) << second.status();
-  CompareWOut(second->wout, first->wout, /*tolerance=*/0.0,
-              /*check_equal_niter=*/true);
+  const int process_thread_count = omp_get_max_threads();
+
+  const auto output = vmecpp::run(indata, *maybe_response_table);
+  ASSERT_TRUE(output.ok()) << output.status();
+  EXPECT_EQ(omp_get_max_threads(), process_thread_count);
+#endif  // _OPENMP
 }
 
 // The stellarator-symmetry operation maps toroidal plane k onto (kp - k) % kp

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
@@ -89,6 +89,9 @@ TEST(TestVmec, CheckErrorOnNonConvergence) {
 // not cap the thread budget that a later run, or another OpenMP user in the
 // process, reads from the runtime.
 TEST(TestVmec, RunLeavesTheProcessThreadCountUnchanged) {
+#ifndef _OPENMP
+  GTEST_SKIP() << "a process-wide thread count exists only in an OpenMP build";
+#else
   const std::string filename = "vmecpp/test_data/solovev.json";
   absl::StatusOr<std::string> indata_json = ReadFile(filename);
   ASSERT_TRUE(indata_json.ok());
@@ -107,6 +110,7 @@ TEST(TestVmec, RunLeavesTheProcessThreadCountUnchanged) {
 
   ASSERT_TRUE(vmecpp::run(indata, std::nullopt, /*max_threads=*/1).ok());
   EXPECT_EQ(omp_get_max_threads(), process_thread_count);
+#endif  // _OPENMP
 }  // RunLeavesTheProcessThreadCountUnchanged
 
 TEST(TestVmec, CheckNoErrorOnNonConvergenceIfDesired) {

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
@@ -85,6 +85,30 @@ TEST(TestVmec, CheckErrorOnNonConvergence) {
       absl::StrContains(status.status().message(), "VMEC++ did not converge"));
 }  // CheckErrorOnNonConvergence
 
+// The thread count a run uses is a property of that run: a coarse run must
+// not cap the thread budget that a later run, or another OpenMP user in the
+// process, reads from the runtime.
+TEST(TestVmec, RunLeavesTheProcessThreadCountUnchanged) {
+  const std::string filename = "vmecpp/test_data/solovev.json";
+  absl::StatusOr<std::string> indata_json = ReadFile(filename);
+  ASSERT_TRUE(indata_json.ok());
+  absl::StatusOr<VmecINDATA> maybe_indata = VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(maybe_indata.ok());
+  VmecINDATA indata = *maybe_indata;
+  // five surfaces admit two radial threads, fewer than most machines have
+  indata.ns_array.setConstant(5);
+  indata.niter_array.setConstant(3);
+  indata.return_outputs_even_if_not_converged = true;
+
+  const int process_thread_count = omp_get_max_threads();
+
+  ASSERT_TRUE(vmecpp::run(indata).ok());
+  EXPECT_EQ(omp_get_max_threads(), process_thread_count);
+
+  ASSERT_TRUE(vmecpp::run(indata, std::nullopt, /*max_threads=*/1).ok());
+  EXPECT_EQ(omp_get_max_threads(), process_thread_count);
+}  // RunLeavesTheProcessThreadCountUnchanged
+
 TEST(TestVmec, CheckNoErrorOnNonConvergenceIfDesired) {
   // make sure VMEC++ returns the outputs without an error
   // if explicitly instructed to do so

--- a/tests/test_free_boundary.py
+++ b/tests/test_free_boundary.py
@@ -85,25 +85,6 @@ def test_raise_invalid_nzeta():
         vmecpp.run(vmec_input, response, verbose=False)
 
 
-def test_consecutive_runs_are_identical():
-    """A run does not change the thread budget the next run in the process sees."""
-    makegrid_params = vmecpp.MakegridParameters.from_file(
-        TEST_DATA_DIR / "makegrid_parameters_cth_like.json"
-    )
-    response = vmecpp.MagneticFieldResponseTable.from_coils_file(
-        TEST_DATA_DIR / "coils.cth_like", makegrid_params
-    )
-    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cth_like_free_bdy.json")
-    vmec_input.ns_array = np.array([7])
-    vmec_input.niter_array = np.array([60])
-    vmec_input.return_outputs_even_if_not_converged = True
-    first = vmecpp.run(vmec_input, response, verbose=False)
-    second = vmecpp.run(vmec_input, response, verbose=False)
-    np.testing.assert_array_equal(second.wout.rmnc, first.wout.rmnc)
-    np.testing.assert_array_equal(second.wout.lmns, first.wout.lmns)
-    assert second.wout.wb == first.wout.wb
-
-
 def test_makegrid_parameters_conversion(makegrid_params):
     # Convert resolution parameters to C++ and back to Python
     cpp_params = makegrid_params._to_cpp_makegrid_parameters()

--- a/tests/test_free_boundary.py
+++ b/tests/test_free_boundary.py
@@ -85,6 +85,25 @@ def test_raise_invalid_nzeta():
         vmecpp.run(vmec_input, response, verbose=False)
 
 
+def test_consecutive_runs_are_identical():
+    """A run does not change the thread budget the next run in the process sees."""
+    makegrid_params = vmecpp.MakegridParameters.from_file(
+        TEST_DATA_DIR / "makegrid_parameters_cth_like.json"
+    )
+    response = vmecpp.MagneticFieldResponseTable.from_coils_file(
+        TEST_DATA_DIR / "coils.cth_like", makegrid_params
+    )
+    vmec_input = vmecpp.VmecInput.from_file(TEST_DATA_DIR / "cth_like_free_bdy.json")
+    vmec_input.ns_array = np.array([7])
+    vmec_input.niter_array = np.array([60])
+    vmec_input.return_outputs_even_if_not_converged = True
+    first = vmecpp.run(vmec_input, response, verbose=False)
+    second = vmecpp.run(vmec_input, response, verbose=False)
+    np.testing.assert_array_equal(second.wout.rmnc, first.wout.rmnc)
+    np.testing.assert_array_equal(second.wout.lmns, first.wout.lmns)
+    assert second.wout.wb == first.wout.wb
+
+
 def test_makegrid_parameters_conversion(makegrid_params):
     # Convert resolution parameters to C++ and back to Python
     cpp_params = makegrid_params._to_cpp_makegrid_parameters()


### PR DESCRIPTION
**Change** - every parallel region of a run states its team size with a `num_threads` clause, and nothing in a run calls `omp_set_num_threads` any more: the main region takes `vmec_adjust_num_threads`'s count, the vacuum region already took its own, and the output stage takes the run's `max_threads`. The thread budget a run reads from the runtime is therefore the process's, whatever ran before. The macOS wheel tests clear `OpenMP_ROOT` in their environment.

**Cause** - `vmec_adjust_num_threads` set the process-wide OpenMP thread count to `min(max_threads, ns / 2)` at every multigrid step, and an explicit `max_threads` did the same in `FlowControl`. The next run in the same process, and any other OpenMP user in it, then read that count as the maximum: after one cth run at `ns = 15` on a 20-thread machine, `omp_get_max_threads()` returns 7, a following `ns = 99` run solves on 7 radial threads instead of 20, every following free-boundary run solves its vacuum on 7 threads instead of 20, and a response table built afterwards is computed on 7. The smaller vacuum team also regroups the thread-ordered reductions of the vacuum solve, so the first free-boundary run of a process and all later ones disagreed at round-off: 1.4e-14 in `rmnc` at 20 threads, 9e-14 at 12, 1.6e-13 at 8, identical only when the radial and vacuum teams coincide.

With the process thread count left alone, the macOS CPython 3.14 wheel test runs on three threads, and it segfaulted in libomp. simsopt has no 3.14 wheel and builds from source in the test environment, where `OpenMP_ROOT` made it link Homebrew's libomp, a second copy next to the one bundled in the vmecpp wheel. The test imports simsopt first, so dyld binds the bundled copy's weak `__kmp_suspend_64` to the Homebrew copy, whose runtime is never initialized, and a vmecpp worker that goes to sleep faults there. On main the first `simsopt_compat.Vmec` run (`max_threads=1`) leaves the whole test process on one thread, so no worker exists.

**Evidence** - with the change `omp_get_max_threads()` is the same before and after a run, with and without an explicit `max_threads`, and consecutive runs of one input agree bit for bit. The cth cases take the same wall time either way on the 20-thread laptop used here. On macos-14 with CPython 3.14, a three-thread run with simsopt imported first segfaults on [main](https://github.com/CharlesCNorton/vmecpp/actions/runs/35506082563) and [here](https://github.com/CharlesCNorton/vmecpp/actions/runs/35506082587), and passes with vmecpp imported first or on one thread; with `OpenMP_ROOT` cleared simsoptpp links no OpenMP and the wheel tests [pass](https://github.com/CharlesCNorton/vmecpp/actions/runs/35506082744).

**Tests** - `RunLeavesTheProcessThreadCountUnchanged` in `vmec_test`, `ConsecutiveRunsAreBitIdentical` in `vmec_in_memory_mgrid_test` and `test_consecutive_runs_are_identical` in `tests/test_free_boundary.py`, all failing before the change on a machine with more threads than the coarse run uses.

**Scope** - the team sizes of the solve are unchanged; `omp_set_dynamic(0)` stays so the requested teams are granted in full. The output stage now runs on the run's `max_threads` rather than the last radial count. The `pyproject.toml` line affects only the macOS wheel-test environment.
