### PR TITLE
Describe b0 as the on-axis R B_phi over the axis major radius at phi = 0

### DIFF
--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -1953,7 +1953,8 @@ class Threed1GeometricAndMagneticQuantities(BaseModelWithNumpy):
     """Normalization factor used in the threed1 computation."""
 
     b0: float
-    """Magnetic field magnitude on the magnetic axis."""
+    """On-axis R B_phi (``rbtor0``) divided by the major radius of the magnetic axis at
+    phi = 0; the field strength on the axis only for a planar circular axis."""
 
     rmax_surf: float
     """Maximum major radius on the boundary."""


### PR DESCRIPTION
**Change** - the `b0` docstring of `Threed1GeometricAndMagneticQuantities`, the value `VmecWOut.b0` copies, says what the field holds: the on-axis R B_phi (`rbtor0`) divided by the major radius of the magnetic axis at phi = 0, which is the field strength on the axis only for a planar circular axis.

**Cause** - it read "Magnetic field magnitude on the magnetic axis". `b0` is `fpsi0 / r_00` in `output_quantities.cc`, with `fpsi0` the half-grid `bvco` extrapolated to the axis and `r_00` the axis R at the first grid point, as `eqfor.f` computes it; on a non-planar axis neither is the field there.

**Evidence** - pyQSC's `r2 section 5.4` quasi-helical configuration (`B0 = 1`, nfp 4, axis R from 0.847 to 1.190) solved at ns 201: `|B|` on the axis is 1.0000 within 6e-4 at every toroidal angle, `rbtor0` is 1.2009, which is `B0` times the axis length over 2 pi (1.2009), the axis R at phi = 0 is 1.1895, and `b0` is 1.0096.

**Tests** - none; no code path changes.

**Scope** - docstring only.
