### PR TITLE
Hand every force iteration to a callback and watch a solve converge

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,22 @@ vmec_output.wout.save("wout_w7x.nc")
 
 All other output files are accessible via members of the `vmec_output` object called `threed1_volumetrics`, `jxbout` and `mercier`.
 
+### Watching a solve
+
+`vmecpp.watch` runs the same solve as `vmecpp.run` and draws the flux surfaces and the
+force residuals of every iteration while it runs, in a window or into an animation file:
+
+```python
+import vmecpp
+
+vmec_input = vmecpp.VmecInput.from_file("examples/data/solovev.json")
+output = vmecpp.watch(vmec_input, save="solve.gif")
+```
+
+The per-iteration data behind it is available to any script through the
+`iteration_callback` argument of `vmecpp.run`, which receives an `IterationSnapshot` with
+the force residuals, the flow-control state and the geometry of every iteration.
+
 ### With SIMSOPT
 
 [SIMSOPT](https://simsopt.readthedocs.io) is a popular stellarator optimization framework.

--- a/examples/watch_solve.py
+++ b/examples/watch_solve.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+"""Watch VMEC++ converge: the flux surfaces at two toroidal angles above the force
+residuals of every iteration, drawn while the solve runs.
+
+Run it with a display to get a live window, or pass ``--save solve.gif`` to record
+the solve headlessly. The same per-iteration data is available to any script
+through the ``iteration_callback`` argument of ``vmecpp.run``.
+"""
+
+import argparse
+from pathlib import Path
+
+import vmecpp
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument(
+    "input",
+    nargs="?",
+    default=Path(__file__).parent / "data" / "solovev.json",
+    type=Path,
+    help="a VMEC++ JSON or INDATA file (default: examples/data/solovev.json)",
+)
+parser.add_argument(
+    "--save", type=Path, help="record the solve to a .gif or video file"
+)
+parser.add_argument("--every", type=int, default=5, help="draw every N iterations")
+parser.add_argument(
+    "--planes", type=int, default=2, help="toroidal cross-sections to show"
+)
+args = parser.parse_args()
+
+vmec_input = vmecpp.VmecInput.from_file(args.input)
+output = vmecpp.watch(vmec_input, planes=args.planes, every=args.every, save=args.save)
+print(
+    f"{output.wout.reason}: fsqr = {output.wout.fsqr:.2e} after {output.wout.niter} iterations"
+)

--- a/examples/watch_solve.py
+++ b/examples/watch_solve.py
@@ -12,6 +12,9 @@ through the ``iteration_callback`` argument of ``vmecpp.run``.
 import argparse
 from pathlib import Path
 
+import matplotlib as mpl
+from matplotlib.backends.registry import BackendFilter, backend_registry
+
 import vmecpp
 
 parser = argparse.ArgumentParser(description=__doc__)
@@ -23,7 +26,9 @@ parser.add_argument(
     help="a VMEC++ JSON or INDATA file (default: examples/data/solovev.json)",
 )
 parser.add_argument(
-    "--save", type=Path, help="record the solve to a .gif or video file"
+    "--save",
+    type=Path,
+    help="record the solve to a .gif or video file (the default without a display)",
 )
 parser.add_argument("--every", type=int, default=5, help="draw every N iterations")
 parser.add_argument(
@@ -31,8 +36,16 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
+interactive = {
+    name.lower() for name in backend_registry.list_builtin(BackendFilter.INTERACTIVE)
+}
+save = args.save
+if save is None and mpl.get_backend().lower() not in interactive:
+    save = Path("watch_solve.gif")
+    print(f"no display, recording the solve to {save}")
+
 vmec_input = vmecpp.VmecInput.from_file(args.input)
-output = vmecpp.watch(vmec_input, planes=args.planes, every=args.every, save=args.save)
+output = vmecpp.watch(vmec_input, planes=args.planes, every=args.every, save=save)
 print(
     f"{output.wout.reason}: fsqr = {output.wout.fsqr:.2e} after {output.wout.niter} iterations"
 )

--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -40,6 +40,7 @@ from vmecpp._pydantic_numpy import (
     own_model_fields,
 )
 from vmecpp._rescale import rescale
+from vmecpp._watch import watch
 from vmecpp.cpp import _vmecpp  # type: ignore # bindings to the C++ core
 
 logger = logging.getLogger(__name__)
@@ -862,6 +863,7 @@ class VmecWOut(BaseModelWithNumpy):
         return {
             0: "normal termination: converged, or returned without convergence because return_outputs_even_if_not_converged was set",
             1: "initially bad Jacobian",
+            2: "stopped by the iteration callback before convergence",
             3: "NCURR_NE_1_BLOAT_NE_1",
             4: "Jacobian reset 75 times, the geometry isn't well defined",
             5: "unrecoverable error: a physical inconsistency in the MHD model, such as a degenerate flux-surface geometry or a free-boundary current mismatch, with no retry strategy",
@@ -2411,6 +2413,21 @@ def _print_progress_tip_once() -> None:
         )
 
 
+IterationSnapshot = _vmecpp.IterationSnapshot
+"""The state of one force iteration, handed to the ``iteration_callback`` of
+:func:`run`.
+
+Its attributes are ``iteration`` (the counter of the current multigrid stage, as
+printed), ``multigrid_step`` (the index into ``ns_array``, -1 for the inserted
+ns = 3 stage), ``ns``, the invariant force residuals ``fsqr``, ``fsqz``, ``fsql``
+and the ``ftol`` they are tested against, the time step ``delt``,
+``restart_reason`` (1 no restart, 2 bad Jacobian, 3 bad progress, 4 huge initial
+forces), ``jacobian_resets``, ``vacuum_pressure_active``, ``mhd_energy`` and
+``geometry``, the R, Z and lambda coefficients of the state as a ``Geometry`` that
+``vmecpp.geometry.from_cpp`` reads.
+"""
+
+
 def run(
     input: VmecInput,
     magnetic_field: MagneticFieldResponseTable | None = None,
@@ -2418,6 +2435,7 @@ def run(
     max_threads: int | None = None,
     verbose: bool | int | OutputMode = OutputMode.PROGRESS,
     restart_from: VmecOutput | None = None,
+    iteration_callback: typing.Callable[[IterationSnapshot], bool | None] | None = None,
 ) -> VmecOutput:
     """Run VMEC++ using the provided input. This is the main entrypoint for both fixed-
     and free-boundary calculations.
@@ -2439,6 +2457,11 @@ def run(
             convergence when running VMEC++ on a configuration that is very similar to the `restart_from` equilibrium.
             If `input.mpol`/`input.ntor` is a sequence (see below), this is used to hot-restart
             only the first continuation step; later steps always hot-restart from the previous one.
+        iteration_callback: called once per force iteration with an :class:`IterationSnapshot`
+            of the state just reached, after every thread has finished the step. Returning
+            ``False`` stops the run, which then returns the outputs of that state with
+            ``wout.ier_flag`` reporting no convergence; returning ``None`` or ``True`` continues.
+            An exception raised inside the callback stops the run and propagates.
 
     If `input.mpol` and/or `input.ntor` is a sequence rather than a plain int, `run` performs
     continuation in Fourier resolution: each entry pairs with the corresponding `input.ns_array`
@@ -2463,6 +2486,7 @@ def run(
             max_threads=max_threads,
             verbose=verbose,
             restart_from=restart_from,
+            iteration_callback=iteration_callback,
         )
 
     cpp_indata = input._to_cpp_vmecindata()
@@ -2499,6 +2523,7 @@ def run(
             initial_state=initial_state,
             max_threads=max_threads,
             verbose=_verbose.value,
+            iteration_callback=iteration_callback,
         )
     else:
         # magnetic_response_table takes precedence anyway, but let's be explicit, to ensure
@@ -2510,6 +2535,7 @@ def run(
             initial_state=initial_state,
             max_threads=max_threads,
             verbose=_verbose.value,
+            iteration_callback=iteration_callback,
         )
 
     cpp_wout = cpp_output_quantities.wout
@@ -2729,4 +2755,6 @@ __all__ = [  # noqa: RUF022
     "solve_multigrid",
     "IterationResult",
     "IterationState",
+    "IterationSnapshot",
+    "watch",
 ]

--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -2413,7 +2413,7 @@ def _print_progress_tip_once() -> None:
         )
 
 
-IterationSnapshot = _vmecpp.IterationSnapshot
+IterationSnapshot: typing.TypeAlias = _vmecpp.IterationSnapshot
 """The state of one force iteration, handed to the ``iteration_callback`` of
 :func:`run`.
 

--- a/src/vmecpp/_continuation.py
+++ b/src/vmecpp/_continuation.py
@@ -31,7 +31,7 @@ import typing
 import numpy as np
 
 if typing.TYPE_CHECKING:
-    from vmecpp import OutputMode, VmecInput, VmecOutput
+    from vmecpp import IterationSnapshot, OutputMode, VmecInput, VmecOutput
     from vmecpp._free_boundary import MagneticFieldResponseTable
 
 # State-vector geometry arrays, shape [mn_mode, n_surfaces]. These are the only
@@ -301,6 +301,7 @@ def _run_fourier_continuation(
     max_threads: int | None,
     verbose: bool | int | OutputMode,
     restart_from: VmecOutput | None,
+    iteration_callback: typing.Callable[[IterationSnapshot], bool | None] | None = None,
 ) -> VmecOutput:
     """Solves an equilibrium by continuation in Fourier resolution.
 
@@ -363,6 +364,7 @@ def _run_fourier_continuation(
             max_threads=max_threads,
             verbose=verbose,
             restart_from=guess,
+            iteration_callback=iteration_callback,
         )
 
     assert output is not None  # n_steps >= 1, so the loop always assigns output

--- a/src/vmecpp/_watch.py
+++ b/src/vmecpp/_watch.py
@@ -1,0 +1,487 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+"""Live view of a VMEC++ solve.
+
+:func:`watch` runs an equilibrium exactly as :func:`vmecpp.run` does and draws the
+flux surfaces and the force residuals of every iteration while it runs, into a
+window, an animation file, or both.
+"""
+
+from __future__ import annotations
+
+import typing
+from collections.abc import Sequence
+from pathlib import Path
+
+import numpy as np
+
+if typing.TYPE_CHECKING:
+    from vmecpp import (
+        IterationSnapshot,
+        MagneticFieldResponseTable,
+        VmecInput,
+        VmecOutput,
+    )
+
+# RestartReason::NO_RESTART of the C++ solver.
+_NO_RESTART = 1
+
+_VIDEO_SUFFIXES = (".mp4", ".mov", ".webm", ".mkv", ".avi")
+
+
+def watch(
+    input: VmecInput,
+    magnetic_field: MagneticFieldResponseTable | None = None,
+    *,
+    planes: int | Sequence[float] = 2,
+    surfaces: int = 8,
+    every: int = 1,
+    save: str | Path | None = None,
+    fps: int = 20,
+    show: bool | None = None,
+    block: bool = True,
+    max_threads: int | None = None,
+    restart_from: VmecOutput | None = None,
+) -> VmecOutput:
+    """Run VMEC++ on ``input`` and watch the flux surfaces converge.
+
+    The solve is the one :func:`vmecpp.run` performs; the figure shows the flux
+    surfaces at a few toroidal angles above the force residuals of every
+    iteration, with the multigrid stages and the time-step restarts marked.
+
+    Args:
+        input: the configuration to solve, as for :func:`vmecpp.run`.
+        magnetic_field: an in-memory vacuum field for a free-boundary run, as for
+            :func:`vmecpp.run`.
+        planes: the toroidal angles of the cross-sections. An integer spreads that
+            many angles evenly over half a field period, from phi = 0 to the
+            half-period plane; a sequence gives the angles in radians.
+        surfaces: how many flux surfaces to draw, spaced evenly in sqrt(s); the
+            boundary is always one of them.
+        every: draw every this many iterations. Every iteration is recorded in
+            the residual trace regardless.
+        save: write the animation to this file, ``.gif`` through Pillow or a
+            video suffix through ffmpeg.
+        fps: frame rate of the saved animation.
+        show: open an interactive window. ``None`` opens one when the matplotlib
+            backend is interactive.
+        block: keep the window open after the solve until it is closed.
+        max_threads: as for :func:`vmecpp.run`.
+        restart_from: as for :func:`vmecpp.run`.
+
+    Returns:
+        the :class:`VmecOutput` of the solve. Closing the window stops the solve,
+        and the output then holds the state reached, with ``wout.ier_flag``
+        reporting that it did not converge.
+
+    Example::
+
+        import vmecpp
+
+        vmec_input = vmecpp.VmecInput.from_file("examples/data/solovev.json")
+        output = vmecpp.watch(vmec_input, save="solve.gif", every=5)
+    """
+    import matplotlib.pyplot as plt  # noqa: PLC0415
+
+    import vmecpp  # noqa: PLC0415
+
+    input = vmecpp.VmecInput.model_validate(input)
+    if every < 1:
+        msg = f"watch: every must be at least 1, got {every}"
+        raise ValueError(msg)
+    if surfaces < 1:
+        msg = f"watch: surfaces must be at least 1, got {surfaces}"
+        raise ValueError(msg)
+    if show is None:
+        show = _backend_is_interactive()
+    if not show and save is None:
+        msg = (
+            "watch: nothing to show; the matplotlib backend is not interactive, "
+            "so pass save='solve.gif' (or a video suffix) to record the solve"
+        )
+        raise ValueError(msg)
+
+    view = _SolveView(
+        nfp=int(input.nfp),
+        zetas=_plane_angles(planes, int(input.nfp)),
+        surfaces=surfaces,
+        every=every,
+        show=show,
+        save=save,
+        fps=fps,
+    )
+    try:
+        output = vmecpp.run(
+            input,
+            magnetic_field,
+            max_threads=max_threads,
+            verbose=False,
+            restart_from=restart_from,
+            iteration_callback=view.on_iteration,
+        )
+        view.finish()
+    finally:
+        view.close()
+    if show and block and plt.fignum_exists(view.fig.number):
+        plt.show()
+    return output
+
+
+def surface_curves(
+    geometry,
+    surface_indices: Sequence[int],
+    theta: np.ndarray,
+    zeta: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """R and Z of full-grid surfaces at the cylindrical angle ``zeta``.
+
+    ``geometry`` is a C++ ``Geometry`` as carried by :class:`vmecpp.IterationSnapshot`
+    or returned by ``make_geometry``. The result has one row per entry of
+    ``surface_indices`` and one column per ``theta``.
+    """
+    dimensions = geometry.dimensions
+    coefficients = _coefficient_arrays(geometry)
+    poloidal = np.arange(dimensions.mpol)
+    toroidal = np.arange(dimensions.ntor + 1) * dimensions.nfp
+    cos_m = np.cos(np.outer(theta, poloidal))
+    sin_m = np.sin(np.outer(theta, poloidal))
+    cos_n = np.cos(toroidal * zeta)
+    sin_n = np.sin(toroidal * zeta)
+    rows = np.asarray(surface_indices, dtype=int)
+
+    def series(cc, ss, sc, cs):
+        return (
+            np.einsum("jmn,tm,n->jt", cc[rows], cos_m, cos_n)
+            + np.einsum("jmn,tm,n->jt", ss[rows], sin_m, sin_n)
+            + np.einsum("jmn,tm,n->jt", sc[rows], sin_m, cos_n)
+            + np.einsum("jmn,tm,n->jt", cs[rows], cos_m, sin_n)
+        )
+
+    c = coefficients
+    return (
+        series(c["r_cc"], c["r_ss"], c["r_sc"], c["r_cs"]),
+        series(c["z_cc"], c["z_ss"], c["z_sc"], c["z_cs"]),
+    )
+
+
+def magnetic_axis(geometry, zeta: float) -> tuple[float, float]:
+    """R and Z of the magnetic axis at the cylindrical angle ``zeta``.
+
+    Only the m = 0 coefficients of the innermost surface describe the axis; the m >= 1
+    entries stored there are the axis extrapolation of the solver.
+    """
+    dimensions = geometry.dimensions
+    c = _coefficient_arrays(geometry)
+    toroidal = np.arange(dimensions.ntor + 1) * dimensions.nfp
+    cos_n = np.cos(toroidal * zeta)
+    sin_n = np.sin(toroidal * zeta)
+    r = c["r_cc"][0, 0] @ cos_n + c["r_cs"][0, 0] @ sin_n
+    z = c["z_cc"][0, 0] @ cos_n + c["z_cs"][0, 0] @ sin_n
+    return float(r), float(z)
+
+
+def surface_indices(ns: int, count: int) -> np.ndarray:
+    """Indices of ``count`` full-grid surfaces spaced evenly in sqrt(s), ending at the
+    boundary."""
+    rho = np.arange(1, count + 1) / count
+    return np.unique(np.rint((ns - 1) * rho**2).astype(int).clip(1, ns - 1))
+
+
+def _coefficient_arrays(geometry) -> dict[str, np.ndarray]:
+    dimensions = geometry.dimensions
+    shape = (dimensions.ns, dimensions.mpol, dimensions.ntor + 1)
+    coefficients = geometry.coefficients
+
+    def block(values):
+        array = np.asarray(values, dtype=float)
+        return array.reshape(shape) if array.size else np.zeros(shape)
+
+    names = ("r_cc", "r_ss", "r_sc", "r_cs", "z_sc", "z_cs", "z_cc", "z_ss")
+    return {name: block(getattr(coefficients, name)) for name in names}
+
+
+def _plane_angles(planes: int | Sequence[float], nfp: int) -> list[float]:
+    if isinstance(planes, int):
+        if planes < 1:
+            msg = f"watch: planes must be at least 1, got {planes}"
+            raise ValueError(msg)
+        return [float(z) for z in np.linspace(0.0, np.pi / nfp, planes)]
+    angles = [float(z) for z in planes]
+    if not angles:
+        msg = "watch: planes must name at least one toroidal angle"
+        raise ValueError(msg)
+    return angles
+
+
+def _plane_label(zeta: float, nfp: int) -> str:
+    periods = zeta * nfp / (2.0 * np.pi)
+    if periods == 0.0:
+        return "phi = 0"
+    return f"phi = {periods:g} of a field period"
+
+
+def _backend_is_interactive() -> bool:
+    import matplotlib as mpl  # noqa: PLC0415
+
+    backend = mpl.get_backend().lower()
+    try:
+        from matplotlib.backends import (  # noqa: PLC0415
+            BackendFilter,
+            backend_registry,
+        )
+
+        interactive = backend_registry.list_builtin(BackendFilter.INTERACTIVE)
+    except ImportError:
+        interactive = mpl.rcsetup.interactive_bk  # type: ignore[attr-defined]
+    return backend in {name.lower() for name in interactive}
+
+
+def _make_writer(save: str | Path, fps: int):
+    from matplotlib import animation  # noqa: PLC0415
+
+    suffix = Path(save).suffix.lower()
+    if suffix == ".gif":
+        return animation.PillowWriter(fps=fps)
+    if suffix in _VIDEO_SUFFIXES:
+        return animation.FFMpegWriter(fps=fps)
+    msg = (
+        f"watch: cannot write '{save}'; use a .gif or one of "
+        f"{', '.join(_VIDEO_SUFFIXES)}"
+    )
+    raise ValueError(msg)
+
+
+class _SolveView:
+    """The figure: flux surfaces at a few toroidal angles above the residual trace."""
+
+    def __init__(
+        self,
+        *,
+        nfp: int,
+        zetas: Sequence[float],
+        surfaces: int,
+        every: int,
+        show: bool,
+        save: str | Path | None,
+        fps: int,
+    ) -> None:
+        import matplotlib.pyplot as plt  # noqa: PLC0415
+
+        self._plt = plt
+        self.nfp = nfp
+        self.zetas = list(zetas)
+        self.surfaces = surfaces
+        self.every = every
+        self.show = show
+        self.theta = np.linspace(0.0, 2.0 * np.pi, 181)
+
+        self.count = 0
+        self.iterations: list[int] = []
+        self.residuals = {"fsqr": [], "fsqz": [], "fsql": []}
+        self.restarts: list[tuple[int, float]] = []
+        self.stage: int | None = None
+        self.ftol: float | None = None
+        self.last: IterationSnapshot | None = None
+        self.drawn_at = 0
+
+        width = 3.6 * len(self.zetas) + 1.2
+        self.fig = plt.figure(figsize=(max(width, 6.4), 7.2))
+        grid = self.fig.add_gridspec(
+            2,
+            len(self.zetas),
+            height_ratios=[3, 2],
+            hspace=0.35,
+            wspace=0.3,
+            left=0.09,
+            right=0.98,
+            top=0.9,
+            bottom=0.08,
+        )
+        self.surface_axes = [
+            self.fig.add_subplot(grid[0, k]) for k in range(len(self.zetas))
+        ]
+        self.residual_axes = self.fig.add_subplot(grid[1, :])
+
+        import matplotlib as mpl  # noqa: PLC0415
+
+        colors = mpl.colormaps["Blues"](np.linspace(0.35, 0.9, max(surfaces - 1, 1)))
+        self.limits: tuple[float, float, float, float] | None = None
+        self.vacuum_active = False
+        self.surface_lines = []
+        self.boundary_lines = []
+        self.axis_markers = []
+        for ax, zeta in zip(self.surface_axes, self.zetas, strict=True):
+            ax.set_aspect("equal")
+            ax.set_title(_plane_label(zeta, nfp))
+            ax.set_xlabel("R")
+            ax.set_ylabel("Z")
+            self.surface_lines.append(
+                [
+                    ax.plot([], [], color=colors[k], lw=0.9)[0]
+                    for k in range(surfaces - 1)
+                ]
+            )
+            self.boundary_lines.append(ax.plot([], [], color="black", lw=1.5)[0])
+            self.axis_markers.append(ax.plot([], [], "o", color="tab:red", ms=4)[0])
+
+        ax = self.residual_axes
+        ax.set_yscale("log")
+        ax.set_xlabel("iteration")
+        ax.set_ylabel("force residual")
+        self.residual_lines = {
+            name: ax.plot([], [], lw=1.0, label=name)[0]
+            for name in ("fsqr", "fsqz", "fsql")
+        }
+        self.ftol_line = ax.axhline(1.0, color="tab:red", ls="--", lw=0.8, label="ftol")
+        self.restart_marks = ax.plot(
+            [], [], "x", color="tab:red", ms=6, label="restart"
+        )[0]
+        ax.legend(loc="upper right", fontsize=8)
+
+        self.writer = None
+        if save is not None:
+            self.writer = _make_writer(save, fps)
+            self.writer.setup(self.fig, str(save), dpi=100)
+
+    def on_iteration(self, snapshot: IterationSnapshot) -> bool:
+        """Record the iteration, draw it when due, and stop the run if the window is
+        gone."""
+        self.count += 1
+        self.last = snapshot
+        self.iterations.append(self.count)
+        self.residuals["fsqr"].append(snapshot.fsqr)
+        self.residuals["fsqz"].append(snapshot.fsqz)
+        self.residuals["fsql"].append(snapshot.fsql)
+        if snapshot.restart_reason != _NO_RESTART:
+            self.restarts.append(
+                (self.count, snapshot.fsqr + snapshot.fsqz + snapshot.fsql)
+            )
+        if snapshot.multigrid_step != self.stage:
+            self.stage = snapshot.multigrid_step
+            self.residual_axes.axvline(self.count, color="gray", ls=":", lw=0.8)
+            self.residual_axes.text(
+                self.count,
+                1.0,
+                f" ns = {snapshot.ns}",
+                transform=self._stage_transform(),
+                fontsize=8,
+                va="top",
+                color="gray",
+            )
+        if snapshot.ftol != self.ftol:
+            self.ftol = snapshot.ftol
+            self.ftol_line.set_ydata([snapshot.ftol, snapshot.ftol])
+        if snapshot.vacuum_pressure_active and not self.vacuum_active:
+            self.vacuum_active = True
+            self.residual_axes.axvline(self.count, color="tab:purple", ls="-.", lw=0.8)
+            self.residual_axes.text(
+                self.count,
+                0.02,
+                " vacuum pressure on",
+                transform=self._stage_transform(),
+                fontsize=8,
+                va="bottom",
+                color="tab:purple",
+            )
+        if self.count % self.every == 0:
+            self.draw(snapshot)
+        return self.window_open()
+
+    def finish(self) -> None:
+        """Draw the state the solve ended on, marked converged when its residuals are
+        below ftol."""
+        if self.last is None:
+            return
+        converged = (
+            max(self.last.fsqr, self.last.fsqz, self.last.fsql) <= self.last.ftol
+        )
+        if self.drawn_at != self.count:
+            self.draw(self.last, converged=converged)
+        elif converged:
+            self._set_title(self.last, converged=True)
+            self._flush()
+
+    def close(self) -> None:
+        if self.writer is not None:
+            self.writer.finish()
+            self.writer = None
+
+    def window_open(self) -> bool:
+        return not self.show or self._plt.fignum_exists(self.fig.number)
+
+    def draw(self, snapshot: IterationSnapshot, *, converged: bool = False) -> None:
+        geometry = snapshot.geometry
+        rows = surface_indices(geometry.dimensions.ns, self.surfaces)
+        for k, zeta in enumerate(self.zetas):
+            r, z = surface_curves(geometry, rows, self.theta, zeta)
+            for line, ri, zi in zip(
+                self.surface_lines[k], r[:-1], z[:-1], strict=False
+            ):
+                line.set_data(ri, zi)
+            for line in self.surface_lines[k][len(rows) - 1 :]:
+                line.set_data([], [])
+            self.boundary_lines[k].set_data(r[-1], z[-1])
+            r_axis, z_axis = magnetic_axis(geometry, zeta)
+            self.axis_markers[k].set_data([r_axis], [z_axis])
+            self._widen_limits(r[-1], z[-1])
+        assert self.limits is not None
+        for ax in self.surface_axes:
+            ax.set_xlim(self.limits[0], self.limits[1])
+            ax.set_ylim(self.limits[2], self.limits[3])
+
+        for name, line in self.residual_lines.items():
+            line.set_data(self.iterations, self.residuals[name])
+        if self.restarts:
+            self.restart_marks.set_data(*zip(*self.restarts, strict=True))
+        ax = self.residual_axes
+        values = np.concatenate([self.residuals[name] for name in self.residuals])
+        values = values[np.isfinite(values) & (values > 0.0)]
+        low = min(values.min() if values.size else 1.0, self.ftol or 1.0)
+        high = values.max() if values.size else 1.0
+        ax.set_ylim(low * 0.3, high * 3.0)
+        ax.set_xlim(0, max(self.count, 10))
+        self._set_title(snapshot, converged=converged)
+        self._flush()
+        self.drawn_at = self.count
+
+    def _set_title(self, snapshot: IterationSnapshot, *, converged: bool) -> None:
+        fsq = snapshot.fsqr + snapshot.fsqz + snapshot.fsql
+        state = "converged" if converged else "iterating"
+        self.fig.suptitle(
+            f"{state}: iteration {snapshot.iteration}, ns = {snapshot.ns}, "
+            f"delt = {snapshot.delt:.3g}, fsq = {fsq:.2e}"
+        )
+
+    def _flush(self) -> None:
+        if self.window_open() and self.show:
+            self._plt.pause(1.0e-3)
+        if self.writer is not None:
+            self.writer.grab_frame()
+        elif not self.show:
+            self.fig.canvas.draw()
+
+    def _stage_transform(self):
+        from matplotlib import transforms  # noqa: PLC0415
+
+        ax = self.residual_axes
+        return transforms.blended_transform_factory(ax.transData, ax.transAxes)
+
+    def _widen_limits(self, r: np.ndarray, z: np.ndarray) -> None:
+        """Widen the shared cross-section limits to this boundary with a margin, never
+        shrinking them."""
+        margin = 0.05 * max(r.max() - r.min(), z.max() - z.min())
+        bounds = (
+            r.min() - margin,
+            r.max() + margin,
+            z.min() - margin,
+            z.max() + margin,
+        )
+        if self.limits is not None:
+            bounds = (
+                min(bounds[0], self.limits[0]),
+                max(bounds[1], self.limits[1]),
+                min(bounds[2], self.limits[2]),
+                max(bounds[3], self.limits[3]),
+            )
+        self.limits = bounds

--- a/src/vmecpp/_watch.py
+++ b/src/vmecpp/_watch.py
@@ -130,7 +130,7 @@ def watch(
 
 def surface_curves(
     geometry,
-    surface_indices: Sequence[int],
+    surface_indices: Sequence[int] | np.ndarray,
     theta: np.ndarray,
     zeta: float,
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -226,7 +226,7 @@ def _backend_is_interactive() -> bool:
 
     backend = mpl.get_backend().lower()
     try:
-        from matplotlib.backends import (  # noqa: PLC0415
+        from matplotlib.backends.registry import (  # noqa: PLC0415
             BackendFilter,
             backend_registry,
         )

--- a/src/vmecpp/cpp/vmecpp/common/util/util.cc
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.cc
@@ -20,6 +20,9 @@ std::string VmecStatusAsString(const VmecStatus vmec_status) {
   switch (vmec_status) {
     case VmecStatus::NORMAL_TERMINATION:
       return "NORMAL_TERMINATION";
+    case VmecStatus::MORE_ITERATIONS_NEEDED:
+      return "MORE_ITERATIONS_NEEDED: the iteration callback stopped the run "
+             "before convergence";
     case VmecStatus::BAD_JACOBIAN:
       return "BAD_JACOBIAN: the Jacobian of the flux-surface geometry "
              "changed sign, i.e. flux surfaces overlap. This can happen "

--- a/src/vmecpp/cpp/vmecpp/common/util/util.h
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.h
@@ -182,6 +182,9 @@ enum class VmecStatus : std::uint8_t {
   // no fatal error but convergence was not reached
   NORMAL_TERMINATION = 0,
   BAD_JACOBIAN = 1,
+  // the iteration callback stopped the run before convergence; more_iter_flag
+  // in VMEC 8.52
+  MORE_ITERATIONS_NEEDED = 2,
   JACOBIAN_75_TIMES_BAD = 4,
   // A physical inconsistency was detected deep in the MHD model (e.g. a
   // degenerate flux-surface geometry or a free-boundary current mismatch)

--- a/src/vmecpp/cpp/vmecpp/common/util/util.h
+++ b/src/vmecpp/cpp/vmecpp/common/util/util.h
@@ -184,7 +184,7 @@ enum class VmecStatus : std::uint8_t {
   BAD_JACOBIAN = 1,
   // the iteration callback stopped the run before convergence; more_iter_flag
   // in VMEC 8.52
-  MORE_ITERATIONS_NEEDED = 2,
+  MORE_ITERATIONS_NEEDED = 2,  // NOLINT(readability-identifier-naming)
   JACOBIAN_75_TIMES_BAD = 4,
   // A physical inconsistency was detected deep in the MHD model (e.g. a
   // degenerate flux-surface geometry or a free-boundary current mismatch)

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -1525,6 +1525,7 @@ vmecpp::OutputQuantities vmecpp::ComputeOutputQuantities(
 
   if (vmec_status == VmecStatus::NORMAL_TERMINATION ||
       vmec_status == VmecStatus::SUCCESSFUL_TERMINATION ||
+      vmec_status == VmecStatus::MORE_ITERATIONS_NEEDED ||
       indata.return_outputs_even_if_not_converged) {
     MeshBledingBSubZeta(
         s, fc,
@@ -1702,6 +1703,108 @@ vmecpp::OutputQuantities vmecpp::ComputeOutputQuantities(
   return output_quantities;
 }  // ComputeOutputQuantities
 
+namespace {
+
+// size the spectral state of results for num_full full-grid surfaces
+void AllocateStateVector(const vmecpp::Sizes& s, int num_full,
+                         vmecpp::VmecInternalResults& m_results) {
+  m_results.rmncc = vmecpp::RowMatrixXd::Zero(num_full, s.mnsize);
+  m_results.zmnsc = vmecpp::RowMatrixXd::Zero(num_full, s.mnsize);
+  m_results.lmnsc = vmecpp::RowMatrixXd::Zero(num_full, s.mnsize);
+  if (s.lthreed) {
+    m_results.rmnss = vmecpp::RowMatrixXd::Zero(num_full, s.mnsize);
+    m_results.zmncs = vmecpp::RowMatrixXd::Zero(num_full, s.mnsize);
+    m_results.lmncs = vmecpp::RowMatrixXd::Zero(num_full, s.mnsize);
+  }
+  if (s.lasym) {
+    m_results.rmnsc = vmecpp::RowMatrixXd::Zero(num_full, s.mnsize);
+    m_results.zmncc = vmecpp::RowMatrixXd::Zero(num_full, s.mnsize);
+    m_results.lmncc = vmecpp::RowMatrixXd::Zero(num_full, s.mnsize);
+    if (s.lthreed) {
+      m_results.rmncs = vmecpp::RowMatrixXd::Zero(num_full, s.mnsize);
+      m_results.zmnss = vmecpp::RowMatrixXd::Zero(num_full, s.mnsize);
+      m_results.lmnss = vmecpp::RowMatrixXd::Zero(num_full, s.mnsize);
+    }
+  }
+}
+
+// copy the spectral coefficients of full-grid surface jF from the thread that
+// holds it into the gathered results
+void GatherStateVectorOfSurface(const vmecpp::Sizes& s,
+                                const vmecpp::RadialPartitioning& r,
+                                const vmecpp::FourierGeometry& decomposed_x,
+                                int jF,
+                                vmecpp::VmecInternalResults& m_results) {
+  for (int n = 0; n < s.ntor + 1; ++n) {
+    for (int m = 0; m < s.mpol; ++m) {
+      const int source_index =
+          ((jF - r.nsMinF1) * s.mpol + m) * (s.ntor + 1) + n;
+      const int target_index = (jF * (s.ntor + 1) + n) * s.mpol + m;
+
+      m_results.rmncc(target_index) = decomposed_x.rmncc[source_index];
+      m_results.zmnsc(target_index) = decomposed_x.zmnsc[source_index];
+      m_results.lmnsc(target_index) = decomposed_x.lmnsc[source_index];
+      if (s.lthreed) {
+        m_results.rmnss(target_index) = decomposed_x.rmnss[source_index];
+        m_results.zmncs(target_index) = decomposed_x.zmncs[source_index];
+        m_results.lmncs(target_index) = decomposed_x.lmncs[source_index];
+      }
+      if (s.lasym) {
+        m_results.rmnsc(target_index) = decomposed_x.rmnsc[source_index];
+        m_results.zmncc(target_index) = decomposed_x.zmncc[source_index];
+        m_results.lmncc(target_index) = decomposed_x.lmncc[source_index];
+        if (s.lthreed) {
+          m_results.rmncs(target_index) = decomposed_x.rmncs[source_index];
+          m_results.zmnss(target_index) = decomposed_x.zmnss[source_index];
+          m_results.lmnss(target_index) = decomposed_x.lmnss[source_index];
+        }
+      }
+    }  // m
+  }  // n
+}
+
+}  // namespace
+
+vmecpp::VmecInternalResults vmecpp::GatherSpectralStateFromThreads(
+    const int sign_of_jacobian, const Sizes& s, const FlowControl& fc,
+    const VmecConstants& constants,
+    const std::vector<std::unique_ptr<RadialPartitioning>>& radial_partitioning,
+    const std::vector<std::unique_ptr<FourierGeometry>>& decomposed_x,
+    const std::vector<std::unique_ptr<RadialProfiles>>& radial_profiles) {
+  VmecInternalResults results;
+
+  results.sign_of_jacobian = sign_of_jacobian;
+  results.lamscale = constants.lamscale;
+  results.num_half = fc.ns - 1;
+  results.num_full = fc.ns;
+
+  results.phipF = VectorXd::Zero(results.num_full);
+  results.phipH = VectorXd::Zero(results.num_half);
+  results.iotaH = VectorXd::Zero(results.num_half);
+  AllocateStateVector(s, results.num_full, results);
+
+  const std::size_t num_threads = radial_partitioning.size();
+  for (std::size_t thread_id = 0; thread_id < num_threads; ++thread_id) {
+    const RadialPartitioning& r = *radial_partitioning[thread_id];
+    const RadialProfiles& p = *radial_profiles[thread_id];
+
+    for (int jH = r.nsMinH; jH < r.nsMaxH; ++jH) {
+      // half-grid points are overlapping --> only take unique ones !
+      if (jH < r.nsMaxH - 1 || jH == fc.ns - 2) {
+        results.phipH[jH] = p.phipH[jH - r.nsMinH];
+        results.iotaH[jH] = p.iotaH[jH - r.nsMinH];
+      }
+    }  // jH
+
+    for (int jF = r.nsMinF; jF < r.nsMaxFIncludingLcfs; ++jF) {
+      results.phipF[jF] = p.phipF[jF - r.nsMinF1];
+      GatherStateVectorOfSurface(s, r, *decomposed_x[thread_id], jF, results);
+    }  // jF
+  }  // thread_id
+
+  return results;
+}
+
 vmecpp::VmecInternalResults vmecpp::GatherDataFromThreads(
     const int sign_of_jacobian, const Sizes& s, const FlowControl& fc,
     const VmecConstants& constants,
@@ -1743,25 +1846,7 @@ vmecpp::VmecInternalResults vmecpp::GatherDataFromThreads(
   results.iotaH = VectorXd::Zero(results.num_half);
   results.currH = VectorXd::Zero(results.num_half);
 
-  // state vector
-  results.rmncc = RowMatrixXd::Zero(results.num_full, s.mnsize);
-  results.zmnsc = RowMatrixXd::Zero(results.num_full, s.mnsize);
-  results.lmnsc = RowMatrixXd::Zero(results.num_full, s.mnsize);
-  if (s.lthreed) {
-    results.rmnss = RowMatrixXd::Zero(results.num_full, s.mnsize);
-    results.zmncs = RowMatrixXd::Zero(results.num_full, s.mnsize);
-    results.lmncs = RowMatrixXd::Zero(results.num_full, s.mnsize);
-  }
-  if (s.lasym) {
-    results.rmnsc = RowMatrixXd::Zero(results.num_full, s.mnsize);
-    results.zmncc = RowMatrixXd::Zero(results.num_full, s.mnsize);
-    results.lmncc = RowMatrixXd::Zero(results.num_full, s.mnsize);
-    if (s.lthreed) {
-      results.rmncs = RowMatrixXd::Zero(results.num_full, s.mnsize);
-      results.zmnss = RowMatrixXd::Zero(results.num_full, s.mnsize);
-      results.lmnss = RowMatrixXd::Zero(results.num_full, s.mnsize);
-    }
-  }
+  AllocateStateVector(s, results.num_full, results);
 
   // from inv-DFTs
   results.r_e = RowMatrixXd::Zero(results.num_full, s.nZnT);
@@ -1874,46 +1959,7 @@ vmecpp::VmecInternalResults vmecpp::GatherDataFromThreads(
       results.iotaF[jF] = p.iotaF[jF - r.nsMinF1];
       results.spectral_width[jF] = p.spectral_width[jF - r.nsMinF1];
 
-      // state vector
-      for (int n = 0; n < s.ntor + 1; ++n) {
-        for (int m = 0; m < s.mpol; ++m) {
-          // FIXME(eguiraud) slow loop
-          const int source_index =
-              ((jF - nsMinF1) * s.mpol + m) * (s.ntor + 1) + n;
-          const int target_index = (jF * (s.ntor + 1) + n) * s.mpol + m;
-
-          results.rmncc(target_index) =
-              decomposed_x[thread_id]->rmncc[source_index];
-          results.zmnsc(target_index) =
-              decomposed_x[thread_id]->zmnsc[source_index];
-          results.lmnsc(target_index) =
-              decomposed_x[thread_id]->lmnsc[source_index];
-          if (s.lthreed) {
-            results.rmnss(target_index) =
-                decomposed_x[thread_id]->rmnss[source_index];
-            results.zmncs(target_index) =
-                decomposed_x[thread_id]->zmncs[source_index];
-            results.lmncs(target_index) =
-                decomposed_x[thread_id]->lmncs[source_index];
-          }
-          if (s.lasym) {
-            results.rmnsc(target_index) =
-                decomposed_x[thread_id]->rmnsc[source_index];
-            results.zmncc(target_index) =
-                decomposed_x[thread_id]->zmncc[source_index];
-            results.lmncc(target_index) =
-                decomposed_x[thread_id]->lmncc[source_index];
-            if (s.lthreed) {
-              results.rmncs(target_index) =
-                  decomposed_x[thread_id]->rmncs[source_index];
-              results.zmnss(target_index) =
-                  decomposed_x[thread_id]->zmnss[source_index];
-              results.lmnss(target_index) =
-                  decomposed_x[thread_id]->lmnss[source_index];
-            }
-          }
-        }  // m
-      }  // n
+      GatherStateVectorOfSurface(s, r, *decomposed_x[thread_id], jF, results);
 
       double unlamscale = 1.0;
       if (jF > 0) {

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.h
@@ -1442,6 +1442,16 @@ VmecInternalResults GatherDataFromThreads(
     const std::vector<std::unique_ptr<IdealMhdModel> >& models_from_threads,
     const std::vector<std::unique_ptr<RadialProfiles> >& radial_profiles);
 
+// gather the spectral state and the flux profiles MakeGeometry needs, without
+// the real-space fields; a view of the state during the iteration
+VmecInternalResults GatherSpectralStateFromThreads(
+    int sign_of_jacobian, const Sizes& s, const FlowControl& fc,
+    const VmecConstants& constants,
+    const std::vector<std::unique_ptr<RadialPartitioning> >&
+        radial_partitioning,
+    const std::vector<std::unique_ptr<FourierGeometry> >& decomposed_x,
+    const std::vector<std::unique_ptr<RadialProfiles> >& radial_profiles);
+
 // mesh blending for B_zeta back to half-grid
 void MeshBledingBSubZeta(const Sizes& s, const FlowControl& fc,
                          VmecInternalResults& m_vmec_internal_results);

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -74,6 +74,36 @@ T &GetValueOrThrow(absl::StatusOr<T> &s) {
   return s.value();
 }
 
+// Adapts a Python iteration callback to vmecpp::IterationCallback: the hook
+// acquires the GIL, treats a None return as "keep going", and stops the run
+// on an exception, which Rethrow raises once the run has returned.
+struct PythonIterationCallback {
+  py::object callable;
+  std::optional<py::error_already_set> error;
+
+  vmecpp::IterationCallback Hook() {
+    if (callable.is_none()) {
+      return nullptr;
+    }
+    return [this](const vmecpp::IterationSnapshot &snapshot) -> bool {
+      py::gil_scoped_acquire acquire;
+      try {
+        py::object keep_going = callable(snapshot);
+        return keep_going.is_none() || py::cast<bool>(keep_going);
+      } catch (py::error_already_set &e) {
+        error.emplace(std::move(e));
+        return false;
+      }
+    };
+  }
+
+  void Rethrow() {
+    if (error.has_value()) {
+      throw *error;
+    }
+  }
+};
+
 vmecpp::HotRestartState MakeHotRestartState(vmecpp::WOutFileContents wout,
                                             const vmecpp::VmecINDATA &indata) {
   return vmecpp::HotRestartState(std::move(wout), indata);
@@ -1375,6 +1405,26 @@ PYBIND11_MODULE(_vmecpp, m) {
       .def_readonly("coefficients", &vmecpp::Geometry::coefficients)
       .def("evaluate", &vmecpp::EvaluateGeometry, py::arg("s"),
            py::arg("theta"), py::arg("zeta"));
+  py::class_<vmecpp::IterationSnapshot>(m, "IterationSnapshot")
+      .def_readonly("iteration", &vmecpp::IterationSnapshot::iteration)
+      .def_readonly("multigrid_step",
+                    &vmecpp::IterationSnapshot::multigrid_step)
+      .def_readonly("ns", &vmecpp::IterationSnapshot::ns)
+      .def_readonly("fsqr", &vmecpp::IterationSnapshot::fsqr)
+      .def_readonly("fsqz", &vmecpp::IterationSnapshot::fsqz)
+      .def_readonly("fsql", &vmecpp::IterationSnapshot::fsql)
+      .def_readonly("ftol", &vmecpp::IterationSnapshot::ftol)
+      .def_readonly("delt", &vmecpp::IterationSnapshot::delt)
+      .def_property_readonly("restart_reason",
+                             [](const vmecpp::IterationSnapshot &snapshot) {
+                               return static_cast<int>(snapshot.restart_reason);
+                             })
+      .def_readonly("jacobian_resets",
+                    &vmecpp::IterationSnapshot::jacobian_resets)
+      .def_readonly("vacuum_pressure_active",
+                    &vmecpp::IterationSnapshot::vacuum_pressure_active)
+      .def_readonly("mhd_energy", &vmecpp::IterationSnapshot::mhd_energy)
+      .def_readonly("geometry", &vmecpp::IterationSnapshot::geometry);
   m.def("make_geometry", [](const vmecpp::OutputQuantities &output) {
     return vmecpp::MakeGeometry(output.indata, output.vmec_internal_results,
                                 vmecpp::GeometryCoefficientState::kPhysical);
@@ -1389,8 +1439,8 @@ PYBIND11_MODULE(_vmecpp, m) {
       "run",
       [](const VmecINDATA &indata,
          std::optional<vmecpp::HotRestartState> initial_state,
-         std::optional<int> max_threads,
-         vmecpp::OutputMode verbose) -> vmecpp::OutputQuantities {
+         std::optional<int> max_threads, vmecpp::OutputMode verbose,
+         py::object iteration_callback) -> vmecpp::OutputQuantities {
         bool was_interrupted = false;
         auto interrupt_check = [&was_interrupted]() -> bool {
           if (was_interrupted) {
@@ -1403,12 +1453,15 @@ PYBIND11_MODULE(_vmecpp, m) {
           }
           return false;
         };
+        PythonIterationCallback iteration_hook{iteration_callback,
+                                               std::nullopt};
         absl::StatusOr<vmecpp::OutputQuantities> ret;
         {
           py::gil_scoped_release release;
           ret = vmecpp::run(indata, std::move(initial_state), max_threads,
-                            verbose, interrupt_check);
+                            verbose, interrupt_check, iteration_hook.Hook());
         }
+        iteration_hook.Rethrow();
         if (was_interrupted) {
           throw py::error_already_set();
         }
@@ -1416,7 +1469,8 @@ PYBIND11_MODULE(_vmecpp, m) {
       },
       py::arg("indata"), py::arg("initial_state") = std::nullopt,
       py::arg("max_threads") = std::nullopt,
-      py::arg("verbose") = vmecpp::OutputMode::kProgress);
+      py::arg("verbose") = vmecpp::OutputMode::kProgress,
+      py::arg("iteration_callback") = py::none());
 
   py::class_<makegrid::MakegridParameters>(m, "MakegridParameters")
       .def(py::init<bool, bool, int, double, double, int, double, double, int,
@@ -1496,7 +1550,8 @@ PYBIND11_MODULE(_vmecpp, m) {
       [](const VmecINDATA &indata,
          const makegrid::MagneticFieldResponseTable &magnetic_response_table,
          std::optional<vmecpp::HotRestartState> initial_state,
-         std::optional<int> max_threads, vmecpp::OutputMode verbose) {
+         std::optional<int> max_threads, vmecpp::OutputMode verbose,
+         py::object iteration_callback) {
         bool was_interrupted = false;
         auto interrupt_check = [&was_interrupted]() -> bool {
           if (was_interrupted) return true;
@@ -1507,13 +1562,16 @@ PYBIND11_MODULE(_vmecpp, m) {
           }
           return false;
         };
+        PythonIterationCallback iteration_hook{iteration_callback,
+                                               std::nullopt};
         absl::StatusOr<vmecpp::OutputQuantities> ret;
         {
           py::gil_scoped_release release;
           ret = vmecpp::run(indata, magnetic_response_table,
                             std::move(initial_state), max_threads, verbose,
-                            interrupt_check);
+                            interrupt_check, iteration_hook.Hook());
         }
+        iteration_hook.Rethrow();
         if (was_interrupted) {
           throw py::error_already_set();
         }
@@ -1522,7 +1580,8 @@ PYBIND11_MODULE(_vmecpp, m) {
       py::arg("indata"), py::arg("magnetic_response_table"),
       py::arg("initial_state") = std::nullopt,
       py::arg("max_threads") = std::nullopt,
-      py::arg("verbose") = vmecpp::OutputMode::kProgress);
+      py::arg("verbose") = vmecpp::OutputMode::kProgress,
+      py::arg("iteration_callback") = py::none());
 
   // Single-resolution iteration model: exposes the forward model and the
   // time-step / restart primitives so the equilibrium iteration can be driven

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/BUILD.bazel
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/BUILD.bazel
@@ -24,6 +24,8 @@ cc_library(
         "//vmecpp/vmec/handover_storage",
         "//vmecpp/vmec/radial_partitioning",
         "//vmecpp/vmec/output_quantities",
+        "//vmecpp/vmec/geometry",
+        "//vmecpp/vmec/geometry:vmec_geometry",
         "//vmecpp/free_boundary/free_boundary_base",
         "//vmecpp/free_boundary/nestor",
         "//vmecpp/free_boundary/only_coils",
@@ -46,6 +48,8 @@ cc_test(
         "//vmecpp/test_data:solovev_free_bdy",
     ],
     deps = [
+        "//vmecpp/vmec/geometry",
+        "//vmecpp/vmec/geometry:vmec_geometry",
         "//vmecpp/vmec/output_quantities:test_helpers",
         "//vmecpp/vmec/vmec",
         "@googletest//:gtest_main",

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -32,6 +32,7 @@
 #include "vmecpp/common/vmec_indata/vmec_indata.h"
 #include "vmecpp/free_boundary/nestor/nestor.h"
 #include "vmecpp/free_boundary/only_coils/only_coils.h"
+#include "vmecpp/vmec/geometry/vmec_geometry.h"
 #include "vmecpp/vmec/output_quantities/output_quantities.h"
 #include "vmecpp/vmec/profile_parameterization_data/profile_parameterization_data.h"
 
@@ -96,9 +97,11 @@ absl::Status CheckInitialState(const vmecpp::HotRestartState& initial_state,
 absl::StatusOr<vmecpp::OutputQuantities> vmecpp::run(
     const VmecINDATA& indata, std::optional<HotRestartState> initial_state,
     std::optional<int> max_threads, OutputMode verbose,
-    InterruptCallback interrupt_callback) {
+    InterruptCallback interrupt_callback,
+    IterationCallback iteration_callback) {
   auto maybe_vmec = Vmec::FromIndata(indata, nullptr, max_threads, verbose,
-                                     std::move(interrupt_callback));
+                                     std::move(interrupt_callback),
+                                     std::move(iteration_callback));
   if (!maybe_vmec.ok()) {
     return maybe_vmec.status();
   }
@@ -120,10 +123,11 @@ absl::StatusOr<vmecpp::OutputQuantities> vmecpp::run(
     const makegrid::MagneticFieldResponseTable& magnetic_response_table,
     std::optional<HotRestartState> initial_state,
     std::optional<int> max_threads, OutputMode verbose,
-    InterruptCallback interrupt_callback) {
-  auto maybe_vmec =
-      Vmec::FromIndata(indata, &magnetic_response_table, max_threads, verbose,
-                       std::move(interrupt_callback));
+    InterruptCallback interrupt_callback,
+    IterationCallback iteration_callback) {
+  auto maybe_vmec = Vmec::FromIndata(
+      indata, &magnetic_response_table, max_threads, verbose,
+      std::move(interrupt_callback), std::move(iteration_callback));
   if (!maybe_vmec.ok()) {
     return maybe_vmec.status();
   }
@@ -146,7 +150,8 @@ absl::StatusOr<std::unique_ptr<Vmec>> Vmec::FromIndata(
     const VmecINDATA& indata,
     const makegrid::MagneticFieldResponseTable* magnetic_response_table,
     std::optional<int> max_threads, OutputMode verbose,
-    InterruptCallback interrupt_callback) {
+    InterruptCallback interrupt_callback,
+    IterationCallback iteration_callback) {
   // check the input before the constructor builds Sizes from it; the
   // informational messages are left to the check in run()
   absl::Status is_indata_consistent =
@@ -156,7 +161,8 @@ absl::StatusOr<std::unique_ptr<Vmec>> Vmec::FromIndata(
   }
 
   auto v = std::make_unique<Vmec>(indata, max_threads, verbose,
-                                  std::move(interrupt_callback));
+                                  std::move(interrupt_callback),
+                                  std::move(iteration_callback));
 
   // This part of Vmec initialization requires Status handling, and is therefore
   // in this factory method instead of the constructor.
@@ -177,7 +183,8 @@ absl::StatusOr<std::unique_ptr<Vmec>> Vmec::FromIndata(
 
 // initialize based on input file contents
 Vmec::Vmec(const VmecINDATA& indata, std::optional<int> max_threads,
-           OutputMode verbose, InterruptCallback interrupt_callback)
+           OutputMode verbose, InterruptCallback interrupt_callback,
+           IterationCallback iteration_callback)
     : indata_(indata),
       s_(indata_),
       t_(&s_),
@@ -188,6 +195,7 @@ Vmec::Vmec(const VmecINDATA& indata, std::optional<int> max_threads,
       verbose_(verbose != OutputMode::kSilent),
       logger_(std::cout, verbose),
       interrupt_callback_(std::move(interrupt_callback)),
+      iteration_callback_(std::move(iteration_callback)),
       vacuum_pressure_state_(VacuumPressureState::kOff),
       status_(VmecStatus::NORMAL_TERMINATION),
       iter2_(1),
@@ -265,6 +273,8 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
     }
   }
 
+  stopped_by_callback_ = false;
+
   // !!! THIS must be the ONLY place where this gets set to zero !!!
   num_eqsolve_retries_ = 0;
 
@@ -303,6 +313,7 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
 
     const int max_grids = std::min(fc_.multi_ns_grid, maximum_multi_grid_step);
     for (int igrid = -jacob_off_; igrid < max_grids; igrid++) {
+      multigrid_step_ = igrid;
       constants_.reset();
 
       // retrieve settings for (ns, ftol, niter) for current multi-grid
@@ -368,6 +379,10 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
         return reached_checkpoint;
       }
 
+      if (stopped_by_callback_) {
+        break;
+      }
+
       // break the multi-grid sequence if current number of flux surfaces did
       // not reach convergence
       if (status_ != VmecStatus::NORMAL_TERMINATION &&
@@ -399,7 +414,7 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
       // properly converged.
     }  // igrid
 
-    if (giving_up) {
+    if (giving_up || stopped_by_callback_) {
       break;
     }
 
@@ -415,7 +430,7 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
     // if ier_flag .eq. bad_jacobian_flag, repeat once again with ns=3 before
   }  // jacob_off
 
-  if (status_ != VmecStatus::SUCCESSFUL_TERMINATION &&
+  if (status_ != VmecStatus::SUCCESSFUL_TERMINATION && !stopped_by_callback_ &&
       !indata_.return_outputs_even_if_not_converged) {
     // By the time we get here, a bad-Jacobian-type status has already been
     // reported (with more specific diagnostics) from inside the multigrid
@@ -1212,6 +1227,19 @@ absl::StatusOr<Vmec::SolveEqLoopStatus> Vmec::SolveEquilibriumLoop(
       }
     }
 
+    if (iteration_callback_) {
+      // Every thread has finished this iteration's time step; the master
+      // thread hands the state to the callback while the others wait.
+#ifdef _OPENMP
+#pragma omp barrier
+#pragma omp master
+#endif  // _OPENMP
+      NotifyIterationCallback(iter2, restart_reason, m_liter_flag);
+#ifdef _OPENMP
+#pragma omp barrier
+#endif  // _OPENMP
+    }
+
 // protect read of vacuum_pressure_state_ in get_delbsq called by Printout above
 // from write below
 #ifdef _OPENMP
@@ -1439,6 +1467,40 @@ absl::StatusOr<bool> Vmec::Evolve(VmecCheckpoint checkpoint,
   PerformTimeStep(fac, b1, time_step, thread_id);
 
   return false;
+}
+
+void Vmec::NotifyIterationCallback(int iter2, RestartReason restart_reason,
+                                   bool& m_liter_flag) {
+  const IterationSnapshot snapshot{
+      .iteration = iter2,
+      .multigrid_step = multigrid_step_,
+      .ns = fc_.ns,
+      .fsqr = fc_.fsqr,
+      .fsqz = fc_.fsqz,
+      .fsql = fc_.fsql,
+      .ftol = fc_.ftolv,
+      .delt = fc_.delt0r,
+      .restart_reason = restart_reason,
+      .jacobian_resets = fc_.ijacob,
+      .vacuum_pressure_active =
+          vacuum_pressure_state_ >= VacuumPressureState::kInitialized,
+      .mhd_energy = h_.mhdEnergy * 4.0 * M_PI * M_PI,
+      .geometry = CurrentGeometry(),
+  };
+  if (!iteration_callback_(snapshot)) {
+    m_liter_flag = false;
+    status_ = VmecStatus::MORE_ITERATIONS_NEEDED;
+#ifdef _OPENMP
+#pragma omp atomic write
+#endif  // _OPENMP
+    stopped_by_callback_ = true;
+  }
+}
+
+Geometry Vmec::CurrentGeometry() const {
+  return MakeGeometry(indata_, GatherSpectralStateFromThreads(
+                                   kSignOfJacobian, s_, fc_, constants_, r_,
+                                   decomposed_x_, p_));
 }
 
 void Vmec::Printout(double delt0r, int thread_id, int iter2) {

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
@@ -23,6 +23,7 @@
 #include "vmecpp/vmec/fourier_forces/fourier_forces.h"
 #include "vmecpp/vmec/fourier_geometry/fourier_geometry.h"
 #include "vmecpp/vmec/fourier_velocity/fourier_velocity.h"
+#include "vmecpp/vmec/geometry/geometry.h"
 #include "vmecpp/vmec/handover_storage/handover_storage.h"
 #include "vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h"
 #include "vmecpp/vmec/iteration_logger/iteration_logger.h"
@@ -63,13 +64,46 @@ struct HotRestartState {
 // Called periodically from the iteration loop.
 using InterruptCallback = std::function<bool()>;
 
+// The state of the force iteration that just completed, handed to an
+// IterationCallback by the master thread while the other threads wait.
+struct IterationSnapshot {
+  // iteration counter of the current multigrid stage, as printed
+  int iteration;
+  // index into ns_array of the current stage; -1 for the inserted ns = 3 stage
+  int multigrid_step;
+  int ns;
+  // invariant force residuals of R, Z and lambda, the ones tested against ftol
+  double fsqr;
+  double fsqz;
+  double fsql;
+  double ftol;
+  // current time step
+  double delt;
+  // RestartReason of this iteration; NO_RESTART unless the state was reverted
+  // to the last backup
+  RestartReason restart_reason;
+  // Jacobian resets so far in this stage
+  int jacobian_resets;
+  // whether the vacuum pressure is part of the force balance yet
+  bool vacuum_pressure_active;
+  // MHD energy of the state
+  double mhd_energy;
+  // R, Z and lambda coefficients of the state, as MakeGeometry lays them out
+  Geometry geometry;
+};
+
+// Called once per force iteration; return false to stop the run, which then
+// returns the output quantities of the state reached.
+using IterationCallback = std::function<bool(const IterationSnapshot&)>;
+
 // This is the preferred way to run VMEC++.
 absl::StatusOr<OutputQuantities> run(
     const VmecINDATA& indata,
     std::optional<HotRestartState> initial_state = std::nullopt,
     std::optional<int> max_threads = std::nullopt,
     OutputMode verbose = OutputMode::kLegacy,
-    InterruptCallback interrupt_callback = nullptr);
+    InterruptCallback interrupt_callback = nullptr,
+    IterationCallback iteration_callback = nullptr);
 
 // This overload enables free-boundary runs with an in-memory mgrid file.
 // The mgrid_file entry in `indata` will be ignored.
@@ -81,7 +115,8 @@ absl::StatusOr<OutputQuantities> run(
     std::optional<HotRestartState> initial_state = std::nullopt,
     std::optional<int> max_threads = std::nullopt,
     OutputMode verbose = OutputMode::kLegacy,
-    InterruptCallback interrupt_callback = nullptr);
+    InterruptCallback interrupt_callback = nullptr,
+    IterationCallback iteration_callback = nullptr);
 
 class Vmec {
  public:
@@ -91,7 +126,8 @@ class Vmec {
   explicit Vmec(const VmecINDATA& indata,
                 std::optional<int> max_threads = std::nullopt,
                 OutputMode verbose = OutputMode::kLegacy,
-                InterruptCallback interrupt_callback = nullptr);
+                InterruptCallback interrupt_callback = nullptr,
+                IterationCallback iteration_callback = nullptr);
 
   // Vmec must not be moved or copied because members (t_, b_, h_) store
   // raw pointers to sibling members (s_, t_). Moving would leave those
@@ -117,7 +153,8 @@ class Vmec {
           nullptr,
       std::optional<int> max_threads = std::nullopt,
       OutputMode verbose = OutputMode::kLegacy,
-      InterruptCallback interrupt_callback = nullptr);
+      InterruptCallback interrupt_callback = nullptr,
+      IterationCallback iteration_callback = nullptr);
 
   absl::StatusOr<bool> run(
       const VmecCheckpoint& checkpoint = VmecCheckpoint::NONE,
@@ -246,6 +283,14 @@ class Vmec {
       int thread_id, int maximum_iterations, VmecCheckpoint checkpoint,
       bool& m_lreset_internal, bool& m_liter_flag);
 
+  // Hand the iteration that just completed to iteration_callback_. Runs on
+  // the master thread while the other threads wait at a barrier.
+  void NotifyIterationCallback(int iter2, RestartReason restart_reason,
+                               bool& m_liter_flag);
+
+  // The R, Z and lambda coefficients of the current state as a Geometry.
+  Geometry CurrentGeometry() const;
+
   // flag to enable or disable ALL screen output from VMEC++
   bool verbose_;
 
@@ -257,6 +302,15 @@ class Vmec {
 
   // set to true when the interrupt callback signals an interrupt
   bool interrupted_ = false;
+
+  // optional callback that receives every force iteration
+  IterationCallback iteration_callback_;
+
+  // set to true when the iteration callback asks to stop the run
+  bool stopped_by_callback_ = false;
+
+  // index into ns_array of the multigrid stage being solved
+  int multigrid_step_ = 0;
 
   // initialization state counter for Nestor. Called ivac in Fortran VMEC.
   VacuumPressureState vacuum_pressure_state_;

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec_test.cc
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 #include "vmecpp/vmec/vmec/vmec.h"
 
+#include <algorithm>
 #include <fstream>
 #include <functional>
 #include <memory>
@@ -15,6 +16,7 @@
 #include "vmecpp/common/flow_control/flow_control.h"
 #include "vmecpp/common/vmec_indata/vmec_indata.h"
 #include "vmecpp/vmec/fourier_geometry/fourier_geometry.h"
+#include "vmecpp/vmec/geometry/vmec_geometry.h"
 #include "vmecpp/vmec/handover_storage/handover_storage.h"
 #include "vmecpp/vmec/output_quantities/output_quantities.h"
 #include "vmecpp/vmec/output_quantities/test_helpers.h"
@@ -176,6 +178,79 @@ TEST(TestVmec, CheckInMemoryMgrid) {
   CompareWOut(output_with_inmemory_mgrid->wout, original_output->wout,
               /*tolerance=*/1e-7);
 }  // CheckInMemoryMgrid
+
+// The iteration callback receives every force iteration of the multigrid run:
+// the residuals the solver records, in order, plus the converged iteration
+// that closes each stage, whose geometry is the one the outputs are built
+// from. Returning false stops the run with the state reached.
+TEST(TestVmec, IterationCallbackSeesEveryIterationAndCanStop) {
+  const std::string filename = "vmecpp/test_data/solovev.json";
+  absl::StatusOr<std::string> indata_json = ReadFile(filename);
+  ASSERT_TRUE(indata_json.ok());
+  absl::StatusOr<VmecINDATA> indata = VmecINDATA::FromJson(*indata_json);
+  ASSERT_TRUE(indata.ok());
+
+  std::vector<vmecpp::IterationSnapshot> snapshots;
+  const auto output = vmecpp::run(
+      *indata, std::nullopt, std::nullopt, vmecpp::OutputMode::kSilent, nullptr,
+      [&snapshots](const vmecpp::IterationSnapshot& snapshot) {
+        snapshots.push_back(snapshot);
+        return true;
+      });
+  ASSERT_TRUE(output.ok());
+  const vmecpp::WOutFileContents& wout = output->wout;
+
+  const int num_stages = static_cast<int>(indata->ns_array.size());
+  int recorded = 0;
+  int stage_ends = 0;
+  for (std::size_t i = 0; i < snapshots.size(); ++i) {
+    const vmecpp::IterationSnapshot& snapshot = snapshots[i];
+    const bool last_of_stage =
+        i + 1 == snapshots.size() ||
+        snapshots[i + 1].multigrid_step != snapshot.multigrid_step;
+    if (last_of_stage) {
+      ++stage_ends;
+      EXPECT_EQ(snapshot.ns, indata->ns_array[snapshot.multigrid_step]);
+      EXPECT_LE(std::max({snapshot.fsqr, snapshot.fsqz, snapshot.fsql}),
+                snapshot.ftol);
+      continue;
+    }
+    if (snapshot.restart_reason != vmecpp::RestartReason::NO_RESTART) {
+      continue;
+    }
+    ASSERT_LT(recorded, wout.force_residual_r.size());
+    EXPECT_EQ(snapshot.fsqr, wout.force_residual_r[recorded]);
+    EXPECT_EQ(snapshot.fsqz, wout.force_residual_z[recorded]);
+    EXPECT_EQ(snapshot.fsql, wout.force_residual_lambda[recorded]);
+    ++recorded;
+  }
+  EXPECT_EQ(stage_ends, num_stages);
+  EXPECT_EQ(recorded, static_cast<int>(wout.fsqt.size()));
+
+  const vmecpp::Geometry final_geometry =
+      vmecpp::MakeGeometry(output->indata, output->vmec_internal_results,
+                           vmecpp::GeometryCoefficientState::kPhysical);
+  EXPECT_EQ(snapshots.back().geometry.coefficients.r_cc,
+            final_geometry.coefficients.r_cc);
+  EXPECT_EQ(snapshots.back().geometry.coefficients.z_sc,
+            final_geometry.coefficients.z_sc);
+  EXPECT_EQ(snapshots.back().geometry.coefficients.lambda_sc,
+            final_geometry.coefficients.lambda_sc);
+
+  int seen = 0;
+  const auto stopped = vmecpp::run(
+      *indata, std::nullopt, std::nullopt, vmecpp::OutputMode::kSilent, nullptr,
+      [&seen](const vmecpp::IterationSnapshot& snapshot) {
+        ++seen;
+        return snapshot.iteration < 20;
+      });
+  ASSERT_TRUE(stopped.ok());
+  EXPECT_EQ(seen, 20);
+  EXPECT_EQ(stopped->wout.ns, indata->ns_array[0]);
+  EXPECT_EQ(stopped->wout.ier_flag,
+            vmecpp::VmecStatusCode(vmecpp::VmecStatus::MORE_ITERATIONS_NEEDED));
+  EXPECT_EQ(stopped->wout.fsqt.size(), 20);
+}
 
 // A stellarator-symmetric, axisymmetric equilibrium (solovev) must converge to
 // the same result whether run with lasym=false or with lasym=true and zero

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+"""The per-iteration callback of ``run`` and the live view built on it."""
+
+from pathlib import Path
+
+import jax
+import matplotlib as mpl
+import numpy as np
+import pytest
+from PIL import Image
+
+import vmecpp
+from vmecpp import _watch
+from vmecpp import geometry as vmec_geometry
+from vmecpp.cpp import _vmecpp  # type: ignore
+
+mpl.use("Agg")
+jax.config.update("jax_enable_x64", True)
+
+REPO_ROOT = Path(__file__).parent.parent
+TEST_DATA_DIR = REPO_ROOT / "src" / "vmecpp" / "cpp" / "vmecpp" / "test_data"
+SOLOVEV = REPO_ROOT / "examples" / "data" / "solovev.json"
+
+# RestartReason::NO_RESTART of the C++ solver.
+NO_RESTART = 1
+
+
+def _collect(vmec_input):
+    snapshots = []
+    output = vmecpp.run(vmec_input, verbose=False, iteration_callback=snapshots.append)
+    return snapshots, output
+
+
+@pytest.mark.parametrize(
+    "case",
+    [SOLOVEV, TEST_DATA_DIR / "cth_like_fixed_bdy.json"],
+    ids=["solovev", "cth_like_fixed_bdy"],
+)
+def test_callback_sees_every_iteration_of_the_residual_history(case):
+    """One snapshot per force iteration: the residual history of the wout, in
+    order and bit for bit, plus the converged iteration that closes each multigrid
+    stage, which the solver does not record."""
+    vmec_input = vmecpp.VmecInput.from_file(case)
+    snapshots, output = _collect(vmec_input)
+    wout = output.wout
+
+    stage_ends = {}
+    for index, snapshot in enumerate(snapshots):
+        stage_ends[snapshot.multigrid_step] = index
+    assert sorted(stage_ends) == list(range(len(vmec_input.ns_array)))
+    for stage, index in stage_ends.items():
+        assert snapshots[index].ns == vmec_input.ns_array[stage]
+        assert snapshots[index].ftol == vmec_input.ftol_array[stage]
+
+    recorded = [
+        s
+        for index, s in enumerate(snapshots)
+        if s.restart_reason == NO_RESTART and index not in stage_ends.values()
+    ]
+    assert len(recorded) == wout.fsqt.size
+    np.testing.assert_array_equal(
+        [s.fsqr for s in recorded], np.asarray(wout.force_residual_r)
+    )
+    np.testing.assert_array_equal(
+        [s.fsqz for s in recorded], np.asarray(wout.force_residual_z)
+    )
+    np.testing.assert_array_equal(
+        [s.fsql for s in recorded], np.asarray(wout.force_residual_lambda)
+    )
+
+    last = snapshots[-1]
+    assert last.fsqr == wout.fsqr
+    assert last.fsqz == wout.fsqz
+    assert last.fsql == wout.fsql
+    assert max(last.fsqr, last.fsqz, last.fsql) <= last.ftol
+
+
+@pytest.mark.parametrize(
+    "case",
+    [SOLOVEV, TEST_DATA_DIR / "cth_like_fixed_bdy_asym.json"],
+    ids=["solovev", "cth_like_fixed_bdy_asym"],
+)
+def test_last_snapshot_carries_the_converged_geometry(case):
+    vmec_input = vmecpp.VmecInput.from_file(case)
+    snapshots, _ = _collect(vmec_input)
+    cpp_output = _vmecpp.run(
+        vmec_input._to_cpp_vmecindata(), verbose=_vmecpp.OutputMode.SILENT
+    )
+    live = vmec_geometry.from_cpp(snapshots[-1].geometry)
+    final = vmec_geometry.make(cpp_output)
+    for name in (
+        "r_cc",
+        "r_ss",
+        "r_sc",
+        "r_cs",
+        "z_sc",
+        "z_cs",
+        "z_cc",
+        "z_ss",
+        "lambda_sc",
+        "lambda_cs",
+        "lambda_cc",
+        "lambda_ss",
+        "toroidal_flux",
+        "poloidal_flux",
+    ):
+        np.testing.assert_allclose(
+            np.asarray(getattr(live, name)),
+            np.asarray(getattr(final, name)),
+            rtol=0.0,
+            atol=1.0e-13,
+            err_msg=name,
+        )
+
+
+def test_returning_false_stops_the_run_with_the_state_reached():
+    vmec_input = vmecpp.VmecInput.from_file(SOLOVEV)
+    seen = []
+
+    def stop_at_twenty(snapshot):
+        seen.append(snapshot.iteration)
+        return snapshot.iteration < 20
+
+    output = vmecpp.run(vmec_input, verbose=False, iteration_callback=stop_at_twenty)
+    assert seen == list(range(1, 21))
+    assert output.wout.ns == vmec_input.ns_array[0]
+    assert output.wout.ier_flag == 2
+    assert "stopped by the iteration callback" in output.wout.reason
+    assert output.wout.fsqt.size == 20
+
+
+def test_exception_in_the_callback_propagates():
+    vmec_input = vmecpp.VmecInput.from_file(SOLOVEV)
+
+    def fail_at_five(snapshot):
+        if snapshot.iteration == 5:
+            msg = "stop here"
+            raise KeyError(msg)
+
+    with pytest.raises(KeyError, match="stop here"):
+        vmecpp.run(vmec_input, verbose=False, iteration_callback=fail_at_five)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        TEST_DATA_DIR / "cth_like_fixed_bdy.json",
+        TEST_DATA_DIR / "cth_like_fixed_bdy_asym.json",
+    ],
+    ids=["symmetric", "asymmetric"],
+)
+def test_surface_curves_match_the_geometry_evaluator(case):
+    """The cross-sections drawn by watch agree with vmecpp.geometry on every surface."""
+    vmec_input = vmecpp.VmecInput.from_file(case)
+    cpp_output = _vmecpp.run(
+        vmec_input._to_cpp_vmecindata(), verbose=_vmecpp.OutputMode.SILENT
+    )
+    geometry = _vmecpp.make_geometry(cpp_output)
+    jax_geometry = vmec_geometry.from_cpp(geometry)
+    ns = geometry.dimensions.ns
+    rows = _watch.surface_indices(ns, 6)
+    assert rows[-1] == ns - 1
+    theta = np.linspace(0.0, 2.0 * np.pi, 7)
+    for zeta in (0.0, 0.37, np.pi / vmec_input.nfp):
+        r, z = _watch.surface_curves(geometry, rows, theta, zeta)
+        for i, j in enumerate(rows):
+            for k, t in enumerate(theta):
+                jet = np.asarray(
+                    vmec_geometry.evaluate(
+                        jax_geometry, np.array([j / (ns - 1), t, zeta])
+                    )
+                )
+                assert abs(r[i, k] - jet[0, 0]) < 1.0e-12
+                assert abs(z[i, k] - jet[1, 0]) < 1.0e-12
+        r_axis, z_axis = _watch.magnetic_axis(geometry, zeta)
+        axis = np.asarray(
+            vmec_geometry.evaluate(jax_geometry, np.array([0.0, 0.0, zeta]))
+        )
+        assert abs(r_axis - axis[0, 0]) < 1.0e-12
+        assert abs(z_axis - axis[1, 0]) < 1.0e-12
+
+
+def test_watch_records_the_solve(tmp_path):
+    vmec_input = vmecpp.VmecInput.from_file(SOLOVEV)
+    path = tmp_path / "solve.gif"
+    output = vmecpp.watch(vmec_input, save=path, every=25, show=False)
+    reference = vmecpp.run(vmec_input, verbose=False)
+
+    assert output.wout.ier_flag == 0
+    np.testing.assert_array_equal(output.wout.rmnc, reference.wout.rmnc)
+    np.testing.assert_array_equal(output.wout.fsqt, reference.wout.fsqt)
+
+    iterations = output.wout.fsqt.size + len(vmec_input.ns_array)
+    frames = iterations // 25 + (1 if iterations % 25 else 0)
+    with Image.open(path) as image:
+        assert image.n_frames == frames
+
+
+def test_watch_without_a_window_or_a_file_is_refused():
+    vmec_input = vmecpp.VmecInput.from_file(SOLOVEV)
+    with pytest.raises(ValueError, match="nothing to show"):
+        vmecpp.watch(vmec_input, show=False)
+
+
+def test_closing_the_window_stops_the_solve(monkeypatch):
+    vmec_input = vmecpp.VmecInput.from_file(SOLOVEV)
+    drawn = []
+
+    def window_open(_view):
+        return len(drawn) < 3
+
+    original = _watch._SolveView.draw
+
+    def draw(self, snapshot, **kwargs):
+        drawn.append(snapshot.iteration)
+        original(self, snapshot, **kwargs)
+
+    monkeypatch.setattr(_watch._SolveView, "window_open", window_open)
+    monkeypatch.setattr(_watch._SolveView, "draw", draw)
+    monkeypatch.setattr(
+        _watch._SolveView, "_flush", lambda self: self.fig.canvas.draw()
+    )
+    monkeypatch.setattr(_watch, "_backend_is_interactive", lambda: True)
+    output = vmecpp.watch(vmec_input, every=5, block=False)
+    assert output.wout.ier_flag == 2
+    assert output.wout.fsqt.size == 15

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -6,6 +6,7 @@
 from pathlib import Path
 
 import jax
+import jax.numpy as jnp
 import matplotlib as mpl
 import numpy as np
 import pytest
@@ -169,14 +170,14 @@ def test_surface_curves_match_the_geometry_evaluator(case):
             for k, t in enumerate(theta):
                 jet = np.asarray(
                     vmec_geometry.evaluate(
-                        jax_geometry, np.array([j / (ns - 1), t, zeta])
+                        jax_geometry, jnp.array([j / (ns - 1), t, zeta])
                     )
                 )
                 assert abs(r[i, k] - jet[0, 0]) < 1.0e-12
                 assert abs(z[i, k] - jet[1, 0]) < 1.0e-12
         r_axis, z_axis = _watch.magnetic_axis(geometry, zeta)
         axis = np.asarray(
-            vmec_geometry.evaluate(jax_geometry, np.array([0.0, 0.0, zeta]))
+            vmec_geometry.evaluate(jax_geometry, jnp.array([0.0, 0.0, zeta]))
         )
         assert abs(r_axis - axis[0, 0]) < 1.0e-12
         assert abs(z_axis - axis[1, 0]) < 1.0e-12
@@ -195,7 +196,7 @@ def test_watch_records_the_solve(tmp_path):
     iterations = output.wout.fsqt.size + len(vmec_input.ns_array)
     frames = iterations // 25 + (1 if iterations % 25 else 0)
     with Image.open(path) as image:
-        assert image.n_frames == frames
+        assert getattr(image, "n_frames") == frames  # noqa: B009
 
 
 def test_watch_without_a_window_or_a_file_is_refused():


### PR DESCRIPTION
**Change** - `vmecpp.run` takes an `iteration_callback`, called once per force iteration from the master thread with an `IterationSnapshot`: the iteration counter and multigrid stage, `ns`, the three invariant residuals and the stage's `ftol`, the time step, the restart reason, the Jacobian-reset count, whether the vacuum pressure is in the force balance, the MHD energy, and the R, Z and lambda coefficients of the state as a `Geometry`. Returning `False` stops the run, which returns the state reached with `ier_flag = 2`, VMEC 8.52's `more_iter_flag`, added as `VmecStatus::MORE_ITERATIONS_NEEDED`. `vmecpp.watch(input)` sits on it: the same solve as `run`, drawn while it runs as the flux surfaces at a few toroidal angles above the residual trace, with the multigrid stages and the restarts marked, into a window, a `.gif` or video file, or both; closing the window stops the solve. On the C++ side `run`, `Vmec::FromIndata` and the constructor take an `IterationCallback` beside the interrupt callback, `GatherSpectralStateFromThreads` collects the spectral state and the flux profiles without the real-space fields and shares its per-surface copy with the full gather, and `MakeGeometry` turns that into the snapshot's geometry.

**Cause** - the loop offered no view of an iteration: the residual history after the fact and the printout every `nstep`. The geometry of an iteration was reachable only through the Python-owned single-thread loop, which does not run free-boundary cases.

**Evidence** - `examples/data/solovev.json` (every 10th iteration), the free-boundary `cth_like_free_bdy` (every 4th) and `examples/data/w7x.json` (every 20th), recorded with `vmecpp.watch`:

![solovev](https://raw.githubusercontent.com/CharlesCNorton/vmecpp/watch-assets/solovev.gif)

![cth free boundary](https://raw.githubusercontent.com/CharlesCNorton/vmecpp/watch-assets/cth_like_free_bdy.gif)

![W7-X](https://raw.githubusercontent.com/CharlesCNorton/vmecpp/watch-assets/w7x.gif)

The snapshot is a copy of the spectral state and one Python call, about a millisecond per iteration: `cth_like_fixed_bdy` takes 0.57 s without and 0.67 s with a callback that stores every snapshot, `cth_like_fixed_bdy_asym` 1.34 s and 1.39 s. A drawn frame costs 60 ms.

**Tests** - `IterationCallbackSeesEveryIterationAndCanStop` in `vmec_test`: one snapshot per entry of the residual history with bit-identical residuals, one converged snapshot per multigrid stage whose geometry equals the output's, and a stop at iteration 20 that returns `ns_array[0]` with `ier_flag` 2. `tests/test_watch.py`: the same through Python on solovev and the symmetric and asymmetric cth cases, an exception raised in the callback propagating, the drawn cross-sections against `vmecpp.geometry.evaluate` on every surface to 1e-12, the frame count of a recorded animation, the stop when the window closes, and the refusal to run with neither a window nor a file. `bazel test --config=opt //vmecpp/...` and `pytest` pass.

**Scope** - without a callback nothing changes: no barrier is added to the loop and the outputs are the ones the existing tests compare. `matplotlib` is imported inside `watch`, so it stays an optional dependency; the README gains a paragraph and `examples/watch_solve.py` records or shows a solve from the command line.
