### PR TITLE
Differentiate the constraint force multiplier in the exact force Jacobian

### DIFF
--- a/src/vmecpp/autodiff.py
+++ b/src/vmecpp/autodiff.py
@@ -271,62 +271,56 @@ def _implicit_boundary_vjp(model, geometry_bar: np.ndarray) -> np.ndarray:
     state_bar = np.asarray(model.geometry_state_vjp(coefficient_bar), dtype=np.float64)
     state = np.asarray(model.get_state(), dtype=np.float64)
     interior, boundary = _interior_and_boundary(model)
-    try:
-        model.set_state(np.ascontiguousarray(state))
-        model.set_freeze_constraint_multiplier(True)
-        model.evaluate(2, 2, True)
-        state_size = state.size
-        # Deflate the structural null space; without this the transposed
-        # interior system is singular and inconsistent in 3D.
-        interior = _structural_nullfree_interior(model, interior)
+    model.set_state(np.ascontiguousarray(state))
+    model.evaluate(2, 2, True)
+    state_size = state.size
+    # Deflate the structural null space; without this the transposed
+    # interior system is singular and inconsistent in 3D.
+    interior = _structural_nullfree_interior(model, interior)
 
-        def transpose(value: np.ndarray) -> np.ndarray:
-            return np.asarray(
-                model.exact_hessian_vector_product_transpose(
-                    np.ascontiguousarray(value)
-                ),
-                dtype=np.float64,
-            )
-
-        def matvec(value: np.ndarray) -> np.ndarray:
-            embedded = np.zeros(state_size)
-            embedded[interior] = value
-            return transpose(embedded)[interior]
-
-        def precondition(value: np.ndarray) -> np.ndarray:
-            embedded = np.zeros(state_size)
-            embedded[interior] = value
-            return np.asarray(
-                model.apply_preconditioner(np.ascontiguousarray(embedded)),
-                dtype=np.float64,
-            )[interior]
-
-        operator_factory: Any = LinearOperator
-        operator = operator_factory(
-            (interior.size, interior.size), matvec=matvec, dtype=np.float64
+    def transpose(value: np.ndarray) -> np.ndarray:
+        return np.asarray(
+            model.exact_hessian_vector_product_transpose(np.ascontiguousarray(value)),
+            dtype=np.float64,
         )
-        preconditioner = operator_factory(
-            (interior.size, interior.size), matvec=precondition, dtype=np.float64
-        )
-        adjoint, info = gmres(
-            operator,
-            state_bar[interior],
-            M=preconditioner,
-            rtol=1.0e-8,
-            restart=200,
-            maxiter=400,
-        )
-        if info != 0:
-            error_message = f"VMEC++ implicit adjoint solve failed with info={info}"
-            raise RuntimeError(error_message)
+
+    def matvec(value: np.ndarray) -> np.ndarray:
         embedded = np.zeros(state_size)
-        embedded[interior] = adjoint
-        internal_boundary_bar = state_bar[boundary] - transpose(embedded)[boundary]
-        full_state_bar = np.zeros(state_size)
-        full_state_bar[boundary] = internal_boundary_bar
-        return _boundary_from_state_vjp(model, full_state_bar)
-    finally:
-        model.set_freeze_constraint_multiplier(False)
+        embedded[interior] = value
+        return transpose(embedded)[interior]
+
+    def precondition(value: np.ndarray) -> np.ndarray:
+        embedded = np.zeros(state_size)
+        embedded[interior] = value
+        return np.asarray(
+            model.apply_preconditioner(np.ascontiguousarray(embedded)),
+            dtype=np.float64,
+        )[interior]
+
+    operator_factory: Any = LinearOperator
+    operator = operator_factory(
+        (interior.size, interior.size), matvec=matvec, dtype=np.float64
+    )
+    preconditioner = operator_factory(
+        (interior.size, interior.size), matvec=precondition, dtype=np.float64
+    )
+    adjoint, info = gmres(
+        operator,
+        state_bar[interior],
+        M=preconditioner,
+        rtol=1.0e-8,
+        restart=200,
+        maxiter=400,
+    )
+    if info != 0:
+        error_message = f"VMEC++ implicit adjoint solve failed with info={info}"
+        raise RuntimeError(error_message)
+    embedded = np.zeros(state_size)
+    embedded[interior] = adjoint
+    internal_boundary_bar = state_bar[boundary] - transpose(embedded)[boundary]
+    full_state_bar = np.zeros(state_size)
+    full_state_bar[boundary] = internal_boundary_bar
+    return _boundary_from_state_vjp(model, full_state_bar)
 
 
 @dataclass(frozen=True)

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -2419,24 +2419,21 @@ void IdealMhdModel::computePreconditioningMatrix(
  * Compute constraint force multiplier profile.
  * Note that this needs to have the radial preconditioner updated.
  */
-absl::Status IdealMhdModel::constraintForceMultiplier() {
-  // Freeze: reuse the existing tcon so the raw force is a function of the state
-  // alone, matching the exact HVP (which freezes tcon). Requires a prior
-  // unfrozen evaluation to have populated tcon.
-  if (freeze_constraint_multiplier_) {
-    return absl::OkStatus();
-  }
-  // tcon
-
+double IdealMhdModel::constraintMultiplierScale() const {
   // TODO(jons): some parabola in ns,
   // but why these specific values of the parameters ?
-  double tcon_multiplier =
+  const double tcon_multiplier =
       tcon0 * (1.0 + m_fc_.ns * (1.0 / 60.0 + m_fc_.ns / (200.0 * 120.0)));
 
   // Fortran bcovar.f90: tcon_mul / (4 * r0scale**2)**2, undoing the scaling of
   // ard and azd (2*r0scale**2) and of cos**2 in alias (4*r0scale**2). r0scale
   // is 1 here, so the divisor is 16.
-  tcon_multiplier /= (4.0 * 4.0);
+  return tcon_multiplier / (4.0 * 4.0);
+}
+
+absl::Status IdealMhdModel::constraintForceMultiplier() {
+  // tcon
+  const double tcon_multiplier = constraintMultiplierScale();
 
   // compute constraint force multiplier profile on forces full-grid except axis
   int jMin = 0;
@@ -2625,7 +2622,8 @@ LocalForceComposition IdealMhdModel::makeLocalForceComposition(
   comp.rCon0 = rCon0.data();
   comp.zCon0 = zCon0.data();
   comp.faccon = faccon.data();
-  comp.tcon = tcon.data();
+  comp.ns = m_fc_.ns;
+  comp.tcon_multiplier = constraintMultiplierScale();
   comp.sinmui = t_.sinmui.data();
   comp.cosmui = t_.cosmui.data();
   comp.cosnv = t_.cosnv.data();
@@ -2644,10 +2642,7 @@ void IdealMhdModel::applyExactForceJacobian(const double* geomP,
   LocalForceComposition comp = makeLocalForceComposition(geom_stride);
   const int nForce = comp.force_stride;
 
-  const int nH = (r_.nsMaxH - r_.nsMinH) * s_.nZnT;
-  // work holds the half-grid and per-point scratch plus the constraint scratch.
-  const int nWork = 15 * nH + 30 * s_.nZnT + 4 * nForce + 4 * (s_.ntor + 1) +
-                    s_.nZnT + s_.nThetaReduced;
+  const int nWork = LocalForceWorkSize(comp);
   std::vector<double> work(nWork, 0.0);
   std::vector<double> dwork(nWork, 0.0);
   std::vector<double> force(20 * nForce, 0.0);
@@ -2706,9 +2701,7 @@ void IdealMhdModel::exactForceDensityTangent(const double* geomP,
                                              double* dforce_out) {
   LocalForceComposition comp = makeLocalForceComposition(geom_stride);
   const int nForce = comp.force_stride;
-  const int nH = (r_.nsMaxH - r_.nsMinH) * s_.nZnT;
-  const int nWork = 15 * nH + 30 * s_.nZnT + 4 * nForce + 4 * (s_.ntor + 1) +
-                    s_.nZnT + s_.nThetaReduced;
+  const int nWork = LocalForceWorkSize(comp);
   std::vector<double> work(nWork, 0.0);
   std::vector<double> dwork(nWork, 0.0);
   std::vector<double> force(20 * nForce, 0.0);
@@ -2722,9 +2715,7 @@ void IdealMhdModel::exactForceDensityCotangent(const double* geomP,
                                                double* geom_bar_out) {
   LocalForceComposition comp = makeLocalForceComposition(geom_stride);
   const int nForce = comp.force_stride;
-  const int nH = (r_.nsMaxH - r_.nsMinH) * s_.nZnT;
-  const int nWork = 15 * nH + 30 * s_.nZnT + 4 * nForce + 4 * (s_.ntor + 1) +
-                    s_.nZnT + s_.nThetaReduced;
+  const int nWork = LocalForceWorkSize(comp);
   std::vector<double> work(nWork, 0.0);
   std::vector<double> work_bar(nWork, 0.0);
   std::vector<double> force(20 * nForce, 0.0);
@@ -3169,54 +3160,9 @@ void IdealMhdModel::applyExactForceJacobianTranspose(
 // current state, to isolate composition bugs from the transform/tangent path.
 double IdealMhdModel::composedForceResidual(const double* geomP,
                                             int geom_stride) {
-  LocalForceComposition comp;
-  comp.nZnT = s_.nZnT;
-  comp.geom_stride = geom_stride;
-  const int nForce = (r_.nsMaxFIncludingLcfs - r_.nsMinF) * s_.nZnT;
-  comp.force_stride = nForce;
-  comp.nsMinF = r_.nsMinF;
-  comp.nsMinF1 = r_.nsMinF1;
-  comp.nsMinH = r_.nsMinH;
-  comp.nsMaxH = r_.nsMaxH;
-  comp.jMaxRZ = std::min(r_.nsMaxF, m_fc_.ns - 1);
-  comp.nsMaxFIncludingLcfs = r_.nsMaxFIncludingLcfs;
-  comp.sqrtSF = m_p_.sqrtSF.data();
-  comp.sqrtSH = m_p_.sqrtSH.data();
-  comp.chipH = m_p_.chipH.data();
-  comp.presH = m_p_.presH.data();
-  comp.radialBlending = m_p_.radialBlending.data();
-  comp.deltaS = m_fc_.deltaS;
-  comp.dSHalfDsInterp = dSHalfDsInterp;
-  comp.lamscale = constants_.lamscale;
-  comp.lthreed = s_.lthreed;
-  comp.with_constraint = true;
-  comp.lasym = s_.lasym;
-  comp.nsMaxF = r_.nsMaxF;
-  comp.nZeta = s_.nZeta;
-  comp.nThetaEff = s_.nThetaEff;
-  comp.ncurr = ncurr;
-  comp.currH = m_p_.currH.data();
-  comp.wInt = s_.wInt.data();
-  comp.nThetaEven = s_.nThetaEven;
-  comp.nThetaReduced = s_.nThetaReduced;
-  comp.mpol = s_.mpol;
-  comp.ntor = s_.ntor;
-  comp.nnyq2 = s_.nnyq2;
-  comp.rCon0 = rCon0.data();
-  comp.zCon0 = zCon0.data();
-  comp.faccon = faccon.data();
-  comp.tcon = tcon.data();
-  comp.sinmui = t_.sinmui.data();
-  comp.cosmui = t_.cosmui.data();
-  comp.cosnv = t_.cosnv.data();
-  comp.sinnv = t_.sinnv.data();
-  comp.sinmu = t_.sinmu.data();
-  comp.cosmu = t_.cosmu.data();
-
-  const int nH = (r_.nsMaxH - r_.nsMinH) * s_.nZnT;
-  const int nWork = 15 * nH + 30 * s_.nZnT + 4 * nForce + 4 * (s_.ntor + 1) +
-                    s_.nZnT + s_.nThetaReduced;
-  std::vector<double> work(nWork, 0.0);
+  LocalForceComposition comp = makeLocalForceComposition(geom_stride);
+  const int nForce = comp.force_stride;
+  std::vector<double> work(LocalForceWorkSize(comp), 0.0);
   std::vector<double> force(20 * nForce, 0.0);
   ComputeLocalForceDensity(geomP, work.data(), force.data(), &comp);
 

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
@@ -169,6 +169,9 @@ class IdealMhdModel {
   // Current working hypothesis: This is used to make the constraint force "look
   // similar" to the MHD forces for improved numerical stability.
   absl::Status constraintForceMultiplier();
+  // The ns-dependent scale of the constraint force multiplier, shared with the
+  // local force composition that recomputes tcon from the geometry.
+  double constraintMultiplierScale() const;
 
   // Computes the effective constraint force that actually enters the iterative
   // scheme.
@@ -193,9 +196,10 @@ class IdealMhdModel {
   // condensation constraint force) by one Enzyme forward pass, then apply the
   // linear forward transform and preconditioner decomposition to obtain the
   // decomposed force tangent in m_decomposed_hv. The constraint multiplier tcon
-  // is held frozen; freeze it in the raw force too
-  // (freeze_constraint_multiplier_) for an exactly consistent Jacobian. Used by
-  // the exact internal Newton-Krylov Hessian-vector product. This low-level
+  // is recomputed from the geometry inside the composition, as the raw force
+  // recomputes it from the state, so the product is the derivative of the
+  // force the iteration drives to zero. Used by the exact internal
+  // Newton-Krylov Hessian-vector product. This low-level
   // kernel does not differentiate the state-dependent LFORBAL replacement;
   // public callers must reject lforbal=true.
   void applyExactForceJacobian(const double* geomP, const double* dgeom,
@@ -222,11 +226,6 @@ class IdealMhdModel {
   // spectral-transform wrapping.
   void exactForceDensityTangent(const double* geomP, const double* dgeom,
                                 int geom_stride, double* dforce_out);
-
-  // Freeze/unfreeze the constraint-force multiplier tcon (see the member).
-  void setFreezeConstraintMultiplier(bool freeze) {
-    freeze_constraint_multiplier_ = freeze;
-  }
 
   // Reverse-mode force-density cotangent: J_g^T applied to the force-density
   // cotangent force_bar (20 blocks of (nsMaxFIncludingLcfs-nsMinF)*nZnT),
@@ -613,14 +612,6 @@ class IdealMhdModel {
   // 0 -- no spectral condensation constraint force
   // 1 (default) -- full spectral condensation constraint force
   double tcon0;
-
-  // When true, constraintForceMultiplier reuses the existing tcon instead of
-  // recomputing it from the geometry. The exact Hessian-vector product freezes
-  // tcon (it depends on the preconditioner diagonal, not just the geometry), so
-  // freezing it in the raw force too keeps the force and its exact HVP a
-  // consistent function of the state -- the residual a Newton solver drives and
-  // the Jacobian it linearizes with then match.
-  bool freeze_constraint_multiplier_ = false;
 
   // [mnsize] minimum flux surface index for which to apply radial
   // preconditioner for R and Z

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/local_force_composition.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/local_force_composition.h
@@ -5,6 +5,9 @@
 #ifndef VMECPP_VMEC_IDEAL_MHD_MODEL_LOCAL_FORCE_COMPOSITION_H_
 #define VMECPP_VMEC_IDEAL_MHD_MODEL_LOCAL_FORCE_COMPOSITION_H_
 
+#include <algorithm>
+#include <cmath>
+
 #include "vmecpp/vmec/ideal_mhd_model/bco_kernel.h"
 #include "vmecpp/vmec/ideal_mhd_model/bcontra_kernel.h"
 #include "vmecpp/vmec/ideal_mhd_model/constraint_force_kernel.h"
@@ -23,7 +26,7 @@ namespace vmecpp {
 // exact Hessian-vector product. Covers the MHD force and the hybrid lambda
 // force; when with_constraint is set it also computes the spectral-condensation
 // constraint force (effective force, Fourier bandpass, assembly into the R/Z
-// force), holding the multiplier tcon frozen.
+// force) with its multiplier tcon recomputed from the geometry.
 //
 // Geometry layout (each block GeomStride doubles, index (jF-nsMinF1)*nZnT):
 //   r1_e r1_o z1_e z1_o ru_e ru_o zu_e zu_o rv_e rv_o zv_e zv_o lu_e lu_o lv_e
@@ -60,18 +63,20 @@ struct LocalForceComposition {
   // Spectral-condensation constraint force. Enabled only when with_constraint
   // is set; then geometry blocks 16-19 hold rCon, zCon, ruFull, zuFull and
   // force blocks 16-19 receive frcon_e/o, fzcon_e/o. The bandpass uses the
-  // Fourier basis arrays and the tcon/faccon profiles. rCon0/zCon0 are
-  // recomputed in place from the live geometry (so they are differentiated);
-  // tcon is held frozen (see freeze_constraint_multiplier_).
+  // Fourier basis arrays and the faccon profile. rCon0/zCon0 and the
+  // multiplier tcon are recomputed in place from the live geometry, so both
+  // are differentiated; tcon needs ns and the ns-dependent scale
+  // tcon_multiplier of constraintForceMultiplier.
   bool with_constraint = false;
   bool lasym = false;
+  int ns = 0;
   int nsMaxF = 0;  // constraint RZ range upper bound
   int nZeta = 0, nThetaEven = 0, nThetaReduced = 0, mpol = 0, ntor = 0,
       nnyq2 = 0;
+  double tcon_multiplier = 0.0;
   const double* rCon0 = nullptr;
   const double* zCon0 = nullptr;
   const double* faccon = nullptr;
-  const double* tcon = nullptr;
   const double* sinmui = nullptr;
   const double* cosmui = nullptr;
   const double* cosnv = nullptr;
@@ -80,8 +85,21 @@ struct LocalForceComposition {
   const double* cosmu = nullptr;
 };
 
-// work must hold 15*nHalf + 30*nZnT plus the constraint scratch described
-// below, where nHalf=(nsMaxH-nsMinH)*nZnT.
+// Doubles of work that ComputeLocalForceDensity slices for composition c: the
+// half-grid fields and per-point scratch, plus the constraint scratch when
+// with_constraint is set.
+inline int LocalForceWorkSize(const LocalForceComposition& c) {
+  const int nHalf = c.nsMaxH - c.nsMinH;
+  int n = 15 * nHalf * c.nZnT + 30 * c.nZnT;
+  if (c.with_constraint) {
+    const int nFull = c.nsMaxFIncludingLcfs - c.nsMinF;
+    n += 4 * nFull * c.nZnT + 4 * (c.ntor + 1) + c.nZnT + c.nThetaReduced +
+         nFull + 2 * nHalf;
+  }
+  return n;
+}
+
+// work must hold LocalForceWorkSize(*c) doubles.
 inline void ComputeLocalForceDensity(const double* geom, double* work,
                                      double* force,
                                      const LocalForceComposition* c) {
@@ -304,7 +322,60 @@ inline void ComputeLocalForceDensity(const double* geom, double* work,
     // exact HVP consistent with re-evaluating rzConIntoVolume each step.
     double* rCon0 = s;
     s += (c->nsMaxFIncludingLcfs - c->nsMinF) * nZnT;
-    double* zCon0 = s;  // last slice of the work buffer
+    double* zCon0 = s;
+    s += (c->nsMaxFIncludingLcfs - c->nsMinF) * nZnT;
+    // Constraint multiplier tcon from the geometry, as
+    // constraintForceMultiplier forms it: the even-parity radial preconditioner
+    // diagonals ard, azd of computePreconditioningMatrix, summed from both
+    // half-grid neighbours of each full-grid surface, over the surface averages
+    // of ruFull^2 and zuFull^2.
+    double* tcon = s;
+    s += c->nsMaxFIncludingLcfs - c->nsMinF;
+    double* ard_h = s;
+    s += c->nsMaxH - c->nsMinH;
+    double* azd_h = s;  // last slice of the work buffer
+    for (int jH = c->nsMinH; jH < c->nsMaxH; ++jH) {
+      double ar = 0.0;
+      double az = 0.0;
+      for (int kl = 0; kl < nZnT; ++kl) {
+        const int ih = (jH - c->nsMinH) * nZnT + kl;
+        // pFactor * r12 * totalPressure / tau * wInt, times (xu12 / deltaS)^2
+        const double pTau =
+            -4.0 * r12[ih] * tp[ih] / tau[ih] * c->wInt[kl % c->nThetaEff];
+        const double zu = zu12[ih] / c->deltaS;
+        const double ru = ru12[ih] / c->deltaS;
+        ar += pTau * zu * zu;
+        az += pTau * ru * ru;
+      }
+      ard_h[jH - c->nsMinH] = ar;
+      azd_h[jH - c->nsMinH] = az;
+    }
+    for (int i = 0; i < c->nsMaxFIncludingLcfs - c->nsMinF; ++i) {
+      tcon[i] = 0.0;
+    }
+    const double tcon_scale =
+        c->tcon_multiplier * 32.0 * c->deltaS * 32.0 * c->deltaS;
+    for (int jF = (c->nsMinF > 0 ? c->nsMinF : 1); jF < c->nsMaxF; ++jF) {
+      double arNorm = 0.0;
+      double azNorm = 0.0;
+      for (int kl = 0; kl < nZnT; ++kl) {
+        const int idx = (jF - c->nsMinF) * nZnT + kl;
+        const double w = c->wInt[kl % c->nThetaEff];
+        arNorm += ruFull[idx] * ruFull[idx] * w;
+        azNorm += zuFull[idx] * zuFull[idx] * w;
+      }
+      const double ard = ard_h[jF - 1 - c->nsMinH] +
+                         (jF < c->ns - 1 ? ard_h[jF - c->nsMinH] : 0.0);
+      const double azd = azd_h[jF - 1 - c->nsMinH] +
+                         (jF < c->ns - 1 ? azd_h[jF - c->nsMinH] : 0.0);
+      tcon[jF - c->nsMinF] =
+          std::min(std::fabs(ard / arNorm), std::fabs(azd / azNorm)) *
+          tcon_scale;
+    }
+    if (c->nsMaxFIncludingLcfs == c->ns) {
+      // The boundary surface carries half the weight of an interior one.
+      tcon[c->ns - 1 - c->nsMinF] = 0.5 * tcon[c->ns - 2 - c->nsMinF];
+    }
     const int lcfs = (c->nsMaxFIncludingLcfs - 1 - c->nsMinF) * nZnT;
     for (int jF = (c->nsMinF > 1 ? c->nsMinF : 1); jF < c->nsMaxFIncludingLcfs;
          ++jF) {
@@ -319,7 +390,7 @@ inline void ComputeLocalForceDensity(const double* geom, double* work,
                                     nZnT, c->nsMinF, c->nsMaxFIncludingLcfs,
                                     gConEff);
     ComputeDeAliasConstraintForce(
-        gConEff, c->faccon, c->tcon, c->sinmui, c->cosmui, c->cosnv, c->sinnv,
+        gConEff, c->faccon, tcon, c->sinmui, c->cosmui, c->cosnv, c->sinnv,
         c->sinmu, c->cosmu, c->nsMinF, c->nsMaxF, c->nZeta, c->nThetaEff,
         c->nThetaReduced, c->nThetaEven, c->mpol, c->ntor, c->nnyq2, c->lasym,
         gsc, gcs, gcc, gss, gConAsym, refl, gCon);

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -281,12 +281,6 @@ class VmecModel {
   void reset_force_eval_count() const {
     vmec_->m_[0]->resetForceEvaluationCount();
   }
-  // Freeze/unfreeze the constraint-force multiplier tcon. Freezing makes the
-  // raw force a function of the state alone, consistent with the exact HVP.
-  void SetFreezeConstraintMultiplier(bool freeze) const {
-    vmec_->m_[0]->setFreezeConstraintMultiplier(freeze);
-  }
-
   // The Garabedian-style time step (PerformTimeStep): for each Fourier
   // coefficient, v = velocity_scale*(conjugation*v + dt*force); x += dt*v.
   void PerformTimeStep(double velocity_scale, double conjugation_parameter,
@@ -578,11 +572,9 @@ class VmecModel {
   // condensation constraint force (effective force, Fourier bandpass and
   // assembly). The geometry tangent T v is obtained exactly from the linearity
   // of geometryFromFourier: T v = geom(x+v) - geom(x), so no finite-difference
-  // step enters. The constraint multiplier tcon is held frozen (it depends on
-  // the preconditioner diagonal, not just the geometry); for an exactly
-  // consistent Jacobian, freeze it in the raw force too via
-  // set_freeze_constraint_multiplier(True). The model state is restored to x on
-  // return.
+  // step enters. The constraint multiplier tcon is recomputed from the geometry
+  // inside the composition, as the raw force recomputes it from the state. The
+  // model state is restored to x on return.
   Eigen::VectorXd ExactHessianVectorProduct(const Eigen::VectorXd &v) {
     RequireLforbalDisabledForExactDerivatives();
     vmecpp::IdealMhdModel &model = *vmec_->m_[0];
@@ -1567,8 +1559,6 @@ PYBIND11_MODULE(_vmecpp, m) {
       .def("exact_hessian_vector_product_transpose",
            &VmecModel::ExactHessianVectorProductTranspose, py::arg("w"))
 #endif  // VMECPP_ENABLE_ENZYME
-      .def("set_freeze_constraint_multiplier",
-           &VmecModel::SetFreezeConstraintMultiplier, py::arg("freeze"))
       .def_property_readonly("force_eval_count", &VmecModel::force_eval_count)
       .def("reset_force_eval_count", &VmecModel::reset_force_eval_count)
       .def_property_readonly("fsqr", &VmecModel::fsqr)

--- a/tests/test_autodiff.py
+++ b/tests/test_autodiff.py
@@ -160,66 +160,62 @@ def _tangent_through_the_solve(indata, boundary, seed_state):
     state = np.asarray(model.get_state(), dtype=np.float64)
     interior, edge = autodiff._interior_and_boundary(model)
     model.set_state(np.ascontiguousarray(state))
-    model.set_freeze_constraint_multiplier(True)
-    try:
-        model.evaluate(2, 2, True)
-        keep = autodiff._structural_nullfree_interior(model, interior)
-        size = state.size
+    model.evaluate(2, 2, True)
+    keep = autodiff._structural_nullfree_interior(model, interior)
+    size = state.size
 
-        def forward(value):
-            return np.asarray(
-                model.exact_hessian_vector_product(np.ascontiguousarray(value)),
-                dtype=np.float64,
-            )
-
-        def restricted(value):
-            embedded = np.zeros(size)
-            embedded[keep] = value
-            return forward(embedded)[keep]
-
-        def precondition(value):
-            embedded = np.zeros(size)
-            embedded[keep] = value
-            return np.asarray(
-                model.apply_preconditioner(np.ascontiguousarray(embedded)),
-                dtype=np.float64,
-            )[keep]
-
-        factory: Any = LinearOperator
-        operator = factory((keep.size, keep.size), matvec=restricted, dtype=np.float64)
-        preconditioner = factory(
-            (keep.size, keep.size), matvec=precondition, dtype=np.float64
+    def forward(value):
+        return np.asarray(
+            model.exact_hessian_vector_product(np.ascontiguousarray(value)),
+            dtype=np.float64,
         )
-        seeded = np.zeros(size)
-        seeded[edge] = seed_state[edge]
-        tangent, info = gmres(
-            operator,
-            -forward(seeded)[keep],
-            M=preconditioner,
-            rtol=1.0e-12,
-            restart=200,
-            maxiter=400,
+
+    def restricted(value):
+        embedded = np.zeros(size)
+        embedded[keep] = value
+        return forward(embedded)[keep]
+
+    def precondition(value):
+        embedded = np.zeros(size)
+        embedded[keep] = value
+        return np.asarray(
+            model.apply_preconditioner(np.ascontiguousarray(embedded)),
+            dtype=np.float64,
+        )[keep]
+
+    factory: Any = LinearOperator
+    operator = factory((keep.size, keep.size), matvec=restricted, dtype=np.float64)
+    preconditioner = factory(
+        (keep.size, keep.size), matvec=precondition, dtype=np.float64
+    )
+    seeded = np.zeros(size)
+    seeded[edge] = seed_state[edge]
+    tangent, info = gmres(
+        operator,
+        -forward(seeded)[keep],
+        M=preconditioner,
+        rtol=1.0e-12,
+        restart=200,
+        maxiter=400,
+    )
+    assert info == 0
+    state_tangent = np.zeros(size)
+    state_tangent[keep] = tangent
+    state_tangent[edge] = seed_state[edge]
+
+    step = 1.0e-6  # MakeGeometry is linear in the state, so this is exact
+
+    def flat(value):
+        model.set_state(np.ascontiguousarray(value))
+        return autodiff._cpp_geometry_flat(
+            model.get_geometry(), model.ns, model.mpol, model.ntor
         )
-        assert info == 0
-        state_tangent = np.zeros(size)
-        state_tangent[keep] = tangent
-        state_tangent[edge] = seed_state[edge]
 
-        step = 1.0e-6  # MakeGeometry is linear in the state, so this is exact
-
-        def flat(value):
-            model.set_state(np.ascontiguousarray(value))
-            return autodiff._cpp_geometry_flat(
-                model.get_geometry(), model.ns, model.mpol, model.ntor
-            )
-
-        result = (
-            flat(state + step * state_tangent) - flat(state - step * state_tangent)
-        ) / (2.0 * step)
-        model.set_state(np.ascontiguousarray(state))
-        return result
-    finally:
-        model.set_freeze_constraint_multiplier(False)
+    result = (
+        flat(state + step * state_tangent) - flat(state - step * state_tangent)
+    ) / (2.0 * step)
+    model.set_state(np.ascontiguousarray(state))
+    return result
 
 
 def _parser_state_tangent(indata, boundary, direction):
@@ -281,3 +277,43 @@ def test_quasisymmetry_gradient_through_a_three_dimensional_solve() -> None:
     assert float(value) > 0.0  # a 3D equilibrium is not quasi-axisymmetric
     assert np.all(np.isfinite(gradient))
     assert np.abs(gradient).max() > 0.0
+
+
+def test_exact_hessian_vector_product_is_the_derivative_of_the_force() -> None:
+    """The exact product against a central difference of the raw force, which recomputes
+    the spectral-condensation multiplier from the state on every evaluation.
+
+    A boundary-only direction moves the multiplier the most.
+    """
+    indata = _small_3d_input()
+    _requires_exact_derivatives(indata)
+    model = autodiff._solve_model(indata._to_cpp_vmecindata(), _boundary(indata))
+    state = np.asarray(model.get_state(), dtype=np.float64).copy()
+    interior, boundary = autodiff._interior_and_boundary(model)
+
+    def raw_force(value):
+        model.set_state(np.ascontiguousarray(value))
+        model.evaluate(2, 2, False)
+        return np.asarray(model.get_forces(), dtype=np.float64).copy()
+
+    generator = np.random.default_rng(0)
+    directions = [generator.standard_normal(state.size)]
+    for rows in (boundary, interior):
+        direction = np.zeros(state.size)
+        direction[rows] = generator.standard_normal(rows.size)
+        directions.append(direction)
+    step = 1.0e-6
+    for raw_direction in directions:
+        direction = raw_direction / np.linalg.norm(raw_direction)
+        model.set_state(np.ascontiguousarray(state))
+        model.evaluate(2, 2, True)
+        product = np.asarray(
+            model.exact_hessian_vector_product(np.ascontiguousarray(direction)),
+            dtype=np.float64,
+        )
+        difference = (
+            raw_force(state + step * direction) - raw_force(state - step * direction)
+        ) / (2.0 * step)
+        assert np.linalg.norm(product - difference) < 1.0e-6 * np.linalg.norm(
+            difference
+        )


### PR DESCRIPTION
**Change** - The exact force Jacobian behind the implicit boundary adjoint differentiates the spectral-condensation constraint multiplier with the state. `ComputeLocalForceDensity` recomputes `tcon` from the geometry the way `constraintForceMultiplier` does, from the even-parity radial preconditioner diagonals of `computePreconditioningMatrix` and the surface averages of `ruFull^2` and `zuFull^2`, so Enzyme carries `dtcon/dx` through the Hessian-vector product and its transpose. The composition takes `ns` and the `ns`-dependent scale `tcon_multiplier` (factored into `constraintMultiplierScale`) instead of a frozen `tcon` pointer, `LocalForceWorkSize` sizes the kernel's work buffer in one place, and `composedForceResidual` builds its composition with `makeLocalForceComposition`. The freeze of the multiplier (`freeze_constraint_multiplier_`, `set_freeze_constraint_multiplier`) is removed: the force recomputes `tcon` on every evaluation and the linearization now matches it, so `_implicit_boundary_vjp` and the tangent helper of the tests no longer freeze anything.

**Cause** - The converged state satisfies F(x; tcon(x), p) = 0 with tcon a function of x through the preconditioner diagonal. The exact product held tcon frozen, so the implicit tangent and adjoint solved with dF/dx alone and dropped dF/dtcon * dtcon/dx. On `cth_like_fixed_bdy_iota` at ns 25 the frozen product matches a finite difference of the frozen force to 7e-9, and the Jacobian with tcon following the state differs from it by 6.5e-3 in norm along the boundary tangent; in the soft directions of the solve that term dominates the gradient. The adjoint and the forward tangent agreed with each other to nine digits throughout, which is why the transpose test of #710 could not see it.

**Evidence** - Operator level, `cth_like_fixed_bdy_iota` at ns 9, converged to ftol 1e-16: the exact product against a central difference of the raw force (step 1e-6), which recomputes the multiplier from the state,

| direction | relative error |
|---|---|
| random | 7.4e-9 |
| boundary rows only | 7.2e-8 |
| interior rows only | 1.4e-8 |

second order in the step (7e-5 at 1e-4, 7e-7 at 1e-5). Before this change the boundary direction differs at 6.5e-3 (ns 25), while the product matched a difference of the force with the multiplier held frozen to 7e-9.

Solve level, `cth_like_fixed_bdy_iota` (mpol 5, ntor 4, ncurr 0) at ns 25, every solve converged to ftol 1e-16, the reference a central difference Richardson-extrapolated from relative steps 1e-3 and 1e-4. Relative error of the gradient before and after, and how far the two step sizes agree with each other:

<details><summary>all 35 rows</summary>

| objective | coefficient | before | after | difference stable to |
|---|---|---|---|---|
| axis R(phi=0) | rbc(0,+0) | 9.2e-05 | 1.0e-04 | 6e-05 |
| r_cc[mid,1,0] | rbc(0,+0) | 1.5e-01 | 1.5e-01 | 2e-02 |
| lambda_sc[mid,1,0] | rbc(0,+0) | 8.0e-03 | 8.0e-03 | 6e-03 |
| r_cc[mid,2,1] | rbc(0,+0) | 1.5e+01 | 1.5e+01 | 1e+01 |
| QS total | rbc(0,+0) | 1.9e-02 | 1.9e-02 | 1e-02 |
| axis R(phi=0) | rbc(1,+0) | 5.8e-04 | 2.6e-05 | 7e-06 |
| r_cc[mid,1,0] | rbc(1,+0) | 6.4e-04 | 6.3e-04 | 4e-06 |
| lambda_sc[mid,1,0] | rbc(1,+0) | 4.1e-04 | 3.3e-04 | 2e-04 |
| r_cc[mid,2,1] | rbc(1,+0) | 4.3e-02 | 4.7e-02 | 3e-03 |
| QS total | rbc(1,+0) | 8.0e-05 | 9.3e-05 | 1e-05 |
| axis R(phi=0) | zbs(1,+0) | 1.6e-01 | 1.4e-03 | 2e-04 |
| r_cc[mid,1,0] | zbs(1,+0) | 1.5e-02 | 1.5e-02 | 1e-04 |
| lambda_sc[mid,1,0] | zbs(1,+0) | 7.2e-04 | 1.4e-03 | 1e-04 |
| r_cc[mid,2,1] | zbs(1,+0) | 1.3e-02 | 2.1e-03 | 3e-04 |
| QS total | zbs(1,+0) | 7.9e-05 | 6.5e-06 | 4e-07 |
| axis R(phi=0) | rbc(2,+0) | 6.3e-05 | 7.0e-06 | 4e-09 |
| r_cc[mid,1,0] | rbc(2,+0) | 6.4e-02 | 6.4e-02 | 3e-06 |
| lambda_sc[mid,1,0] | rbc(2,+0) | 3.3e-04 | 3.3e-04 | 6e-07 |
| r_cc[mid,2,1] | rbc(2,+0) | 1.0e-01 | 9.8e-02 | 1e-04 |
| QS total | rbc(2,+0) | 1.1e-03 | 1.1e-03 | 1e-05 |
| axis R(phi=0) | rbc(1,+1) | 9.2e-04 | 5.6e-04 | 1e-03 |
| r_cc[mid,1,0] | rbc(1,+1) | 1.5e+00 | 1.5e+00 | 1e-02 |
| lambda_sc[mid,1,0] | rbc(1,+1) | 8.3e-03 | 8.3e-03 | 2e-03 |
| r_cc[mid,2,1] | rbc(1,+1) | 1.8e+00 | 1.8e+00 | 2e-01 |
| QS total | rbc(1,+1) | 2.2e-05 | 2.4e-05 | 8e-04 |
| axis R(phi=0) | zbs(1,-1) | 1.6e-03 | 1.3e-03 | 3e-07 |
| r_cc[mid,1,0] | zbs(1,-1) | 4.0e+00 | 4.0e+00 | 2e-06 |
| lambda_sc[mid,1,0] | zbs(1,-1) | 3.5e-02 | 3.5e-02 | 1e-06 |
| r_cc[mid,2,1] | zbs(1,-1) | 6.5e-01 | 6.5e-01 | 9e-06 |
| QS total | zbs(1,-1) | 3.2e-04 | 3.2e-04 | 4e-08 |
| axis R(phi=0) | rbc(0,+1) | 3.9e-05 | 4.6e-05 | 1e-04 |
| r_cc[mid,1,0] | rbc(0,+1) | 1.3e-02 | 1.3e-02 | 2e-02 |
| lambda_sc[mid,1,0] | rbc(0,+1) | 1.8e-03 | 1.8e-03 | 5e-03 |
| r_cc[mid,2,1] | rbc(0,+1) | 3.7e-02 | 3.7e-02 | 1e-01 |
| QS total | rbc(0,+1) | 1.4e-03 | 1.4e-03 | 4e-03 |

</details>

The rows this change moves are the ones the multiplier's dependence on the elongation and the shaping enters: the axis position against zbs(1,0) from 1.6e-1 to 1.4e-3, r_cc[mid,2,1] against zbs(1,0) from 1.3e-2 to 2.1e-3, the quasisymmetry total against zbs(1,0) from 7.9e-5 to 6.5e-6, the axis against rbc(1,0) from 5.8e-4 to 2.6e-5 and against rbc(2,0) from 6.3e-5 to 7.0e-6. The rows that stay put are covered under Scope.

**Tests** - `tests/test_autodiff.py::test_exact_hessian_vector_product_is_the_derivative_of_the_force`: on the three-dimensional Solov'ev case of the file, the exact product against the central difference of the raw force in a random, a boundary-only and an interior-only direction, to 1e-6 (measured 1e-8). Enzyme-gated like its siblings; the transpose, geometry-VJP and quasisymmetry tests of the file and `tests/test_hessian.py` pass unchanged, as do the CMake `local_force_hessian_test` and `jacobian_kernel_autodiff_test` binaries and the `ideal_mhd_model` and `vmec` Bazel targets under GCC. Pre-commit clean.

**Scope** - The equilibrium solve is untouched: the multiplier was never frozen on the iteration path, and `constraintForceMultiplier` computes the same profile from the same factored scale. Builds without Enzyme keep raising in `_implicit_boundary_vjp`; the only change outside Enzyme is that `VmecModel.set_freeze_constraint_multiplier` no longer exists.

The gradient rows that remain off against the converged difference (the interior coefficients against the n = 1 boundary modes, and the 1e-3 residue on a few physical rows) are not in the linearization. `zeroZForceForM1` stops driving the m = 1 `z_cs` coefficients, the combination the m = 1 constraint is meant to hold at zero, once `fsqz` drops below 1e-6, so on every interior surface those coefficients keep the value the transient left them; they carry no force row and a Jacobian column of norm up to 26, and a re-solve at a perturbed boundary moves them by that history. The linear system holds them fixed, which is the derivative of the equilibrium at the gauge the run reached. Seeding the exact interior system with their measured motion instead reproduces the converged difference on every row at ns 9: r_cc[mid,1,0] against zbs(1,-1) from 3.1 to 1.4e-4, against rbc(1,+1) from 1.2 to 1.0e-4, lambda_sc[mid,1,0] against zbs(1,-1) from 3.9e-1 to 2.8e-5, the axis against zbs(1,-1) from 3.1e-2 to 1.5e-5.
