### PR TITLE
Abandon a multigrid sequence whose step ends far from its tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,6 @@ VMEC++:
 
 ### Limitations with respect to the Fortran implementations
 - free-boundary works only for `ntor > 0` - axisymmetric (`ntor = 0`) free-boundary runs don't work yet
-- `lgiveup`/`fgiveup` logic for early termination of a multi-grid sequence is not implemented yet
 - `lbsubs` logic in computing outputs is not implemented yet
 - `lrfp` flag is available for wout compatibility, but RFP-specific physics is not implemented yet - only stellarators/Tokamaks for now
 - several profile parameterizations are not fully implemented yet:

--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -446,6 +446,15 @@ class VmecInput(BaseModelWithNumpy):
     tcon0: float = 1.0
     """Constraint force scaling factor for ns --> 0."""
 
+    lgiveup: bool = False
+    """Abandon the whole multigrid sequence when a step ends with any residual still
+    above ``fgiveup`` times its tolerance, rather than carrying a state that far out
+    onto a finer grid."""
+
+    fgiveup: float = 30.0
+    """Multiple of ``ftol_array`` a step's residuals must be under for the sequence to
+    continue when ``lgiveup`` is set."""
+
     lforbal: bool = False
     """Hack: directly compute innermost flux surface geometry from radial force balance"""
 

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.cc
@@ -230,6 +230,8 @@ VmecINDATA::VmecINDATA() {
   lforbal = false;
   iteration_style = IterationStyle::VMEC_8_52;
   return_outputs_even_if_not_converged = false;
+  lgiveup = false;
+  fgiveup = 30.0;
 
   // zero-initialized magnetic axis
   raxis_c.setZero(ntor + 1);
@@ -356,6 +358,8 @@ absl::Status VmecINDATA::WriteTo(H5::H5File& file) const {
   WriteH5Dataset(lforbal, "/indata/lforbal", file);
   WriteH5Dataset(return_outputs_even_if_not_converged,
                  "/indata/return_outputs_even_if_not_converged", file);
+  WriteH5Dataset(lgiveup, "/indata/lgiveup", file);
+  WriteH5Dataset(fgiveup, "/indata/fgiveup", file);
 
   // 1D arrays
   WriteH5Dataset(ns_array, "/indata/ns_array", file);
@@ -467,6 +471,10 @@ absl::Status VmecINDATA::LoadInto(VmecINDATA& m_indata, H5::H5File& from_file) {
                   "/indata/return_outputs_even_if_not_converged", from_file);
   } else {
     m_indata.return_outputs_even_if_not_converged = false;
+  }
+  if (from_file.nameExists("/indata/lgiveup")) {
+    ReadH5Dataset(m_indata.lgiveup, "/indata/lgiveup", from_file);
+    ReadH5Dataset(m_indata.fgiveup, "/indata/fgiveup", from_file);
   }
 
   // 1D arrays
@@ -967,6 +975,22 @@ absl::StatusOr<VmecINDATA> VmecINDATA::FromJson(
         maybe_return_outputs_even_if_not_converged->value();
   }
 
+  auto maybe_lgiveup = JsonReadBool(j, "lgiveup");
+  if (!maybe_lgiveup.ok()) {
+    return maybe_lgiveup.status();
+  }
+  if (maybe_lgiveup->has_value()) {
+    vmec_indata.lgiveup = maybe_lgiveup->value();
+  }
+
+  auto maybe_fgiveup = JsonReadDouble(j, "fgiveup");
+  if (!maybe_fgiveup.ok()) {
+    return maybe_fgiveup.status();
+  }
+  if (maybe_fgiveup->has_value()) {
+    vmec_indata.fgiveup = maybe_fgiveup->value();
+  }
+
   // -----------------------------------------------
 
   // Axis Fourier coefficient arrays must have length ntor+1. Arrays that are
@@ -1270,6 +1294,8 @@ absl::StatusOr<std::string> VmecINDATA::ToJson() const {
   output["iteration_style"] = ToString(iteration_style);
   output["return_outputs_even_if_not_converged"] =
       return_outputs_even_if_not_converged;
+  output["lgiveup"] = lgiveup;
+  output["fgiveup"] = fgiveup;
 
   // Initial Guess for Magnetic Axis Geometry
   output["raxis_c"] = raxis_c;
@@ -1573,6 +1599,13 @@ absl::Status IsConsistent(const VmecINDATA& vmec_indata,
     return absl::InvalidArgumentError(absl::StrFormat(
         "input variable 'delt' has to be in the range ]0.0, 10.0], but is %g\n",
         vmec_indata.delt));
+  }
+
+  if (vmec_indata.lgiveup && vmec_indata.fgiveup <= 0.0) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "input variable 'fgiveup' is a multiple of ftol and must be positive "
+        "when 'lgiveup' is set, but is %g\n",
+        vmec_indata.fgiveup));
   }
 
   // tcon0

--- a/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
+++ b/src/vmecpp/cpp/vmecpp/common/vmec_indata/vmec_indata.h
@@ -230,6 +230,15 @@ class VmecINDATA {
   // was in when it gave up, and can be arbitrarily unphysical.
   bool return_outputs_even_if_not_converged;
 
+  // Abandon the whole multigrid sequence when a step ends with any residual
+  // still above fgiveup times its tolerance, rather than carrying a state that
+  // far out onto a finer grid. Off by default.
+  bool lgiveup;
+
+  // Multiple of ftol_array a step's residuals must be under for the sequence to
+  // continue when lgiveup is set.
+  double fgiveup;
+
   // ---------------------------------
   // initial guess for magnetic axis
 

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -832,6 +832,8 @@ PYBIND11_MODULE(_vmecpp, m) {
   DefEigenProperty(pyindata, "aphi", &VmecINDATA::aphi);
   pyindata.def_readwrite("delt", &VmecINDATA::delt)
       .def_readwrite("tcon0", &VmecINDATA::tcon0)
+      .def_readwrite("lgiveup", &VmecINDATA::lgiveup)
+      .def_readwrite("fgiveup", &VmecINDATA::fgiveup)
       .def_readwrite("lforbal", &VmecINDATA::lforbal)
       .def_readwrite("iteration_style", &VmecINDATA::iteration_style)
       .def_readwrite("return_outputs_even_if_not_converged",

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -398,7 +398,15 @@ absl::StatusOr<bool> Vmec::run(const VmecCheckpoint& checkpoint,
         break;
       }
 
-      // TODO(jons): insert lgiveup/fgiveup logic here
+      // A step that ends this far from its tolerance will not be rescued by a
+      // finer grid, so abandon the sequence rather than interpolate that state
+      // onto one.
+      if (indata_.lgiveup && (fc_.fsqr > fc_.ftolv * indata_.fgiveup ||
+                              fc_.fsqz > fc_.ftolv * indata_.fgiveup ||
+                              fc_.fsql > fc_.ftolv * indata_.fgiveup)) {
+        giving_up = true;
+        break;
+      }
 
       // If this point is reached, the current multi-grid step should have
       // properly converged.

--- a/tests/test_giveup.py
+++ b/tests/test_giveup.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+"""Abandoning a multigrid sequence whose early steps converge poorly.
+
+``lgiveup`` ends the sequence at the first step that runs out of iterations with a
+residual above ``fgiveup`` times its tolerance, instead of interpolating that state
+onto the next grid and spending the remaining budget on it.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import vmecpp
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEST_DATA_DIR = REPO_ROOT / "src" / "vmecpp" / "cpp" / "vmecpp" / "test_data"
+CASE = TEST_DATA_DIR / "cth_like_fixed_bdy.json"
+
+
+def _sequence_that_stalls_on_its_first_step() -> vmecpp.VmecInput:
+    """Three grids, each with too few iterations to reach a tolerance of 1e-14."""
+    vmec_input = vmecpp.VmecInput.from_file(CASE)
+    vmec_input.ns_array = np.array([5, 11, 25])
+    vmec_input.ftol_array = np.array([1.0e-14, 1.0e-14, 1.0e-14])
+    vmec_input.niter_array = np.array([30, 30, 30])
+    return vmec_input
+
+
+def test_defaults_match_fortran():
+    vmec_input = vmecpp.VmecInput.from_file(CASE)
+    assert vmec_input.lgiveup is False
+    assert vmec_input.fgiveup == 30.0
+
+
+def test_sequence_runs_to_the_last_grid_when_unset():
+    """Without the flag every grid of the schedule is attempted."""
+    with pytest.raises(RuntimeError, match=r"ns = 25"):
+        vmecpp.run(
+            _sequence_that_stalls_on_its_first_step(), verbose=False, max_threads=1
+        )
+
+
+def test_sequence_stops_at_the_first_grid_that_converges_poorly():
+    vmec_input = _sequence_that_stalls_on_its_first_step()
+    vmec_input.lgiveup = True
+    with pytest.raises(RuntimeError, match=r"ns = 5"):
+        vmecpp.run(vmec_input, verbose=False, max_threads=1)
+
+
+def test_a_step_within_fgiveup_of_its_tolerance_continues():
+    """The threshold is what decides, so raising it past the residual carries on."""
+    vmec_input = _sequence_that_stalls_on_its_first_step()
+    vmec_input.lgiveup = True
+    vmec_input.fgiveup = 1.0e30
+    with pytest.raises(RuntimeError, match=r"ns = 25"):
+        vmecpp.run(vmec_input, verbose=False, max_threads=1)
+
+
+def test_a_converging_sequence_is_unaffected():
+    """Every step meets its tolerance, so the flag has nothing to act on."""
+    vmec_input = vmecpp.VmecInput.from_file(CASE)
+    without = vmecpp.run(vmec_input, verbose=False, max_threads=1)
+
+    vmec_input.lgiveup = True
+    with_flag = vmecpp.run(vmec_input, verbose=False, max_threads=1)
+
+    assert with_flag.wout.niter == without.wout.niter
+    np.testing.assert_array_equal(with_flag.wout.rmnc, without.wout.rmnc)
+    np.testing.assert_array_equal(with_flag.wout.zmns, without.wout.zmns)
+
+
+def test_a_non_positive_fgiveup_is_rejected():
+    vmec_input = vmecpp.VmecInput.from_file(CASE)
+    vmec_input.lgiveup = True
+    vmec_input.fgiveup = 0.0
+    with pytest.raises(AttributeError, match="fgiveup"):
+        vmecpp.run(vmec_input, verbose=False, max_threads=1)
+
+
+def test_both_fields_survive_a_json_round_trip(tmp_path):
+    vmec_input = vmecpp.VmecInput.from_file(CASE)
+    vmec_input.lgiveup = True
+    vmec_input.fgiveup = 12.5
+
+    json_path = tmp_path / "with_giveup.json"
+    json_path.write_text(vmec_input.to_json())
+    reloaded = vmecpp.VmecInput.from_file(json_path)
+
+    assert reloaded.lgiveup is True
+    assert reloaded.fgiveup == 12.5


### PR DESCRIPTION
**Change** - `VmecInput` gains `lgiveup` and `fgiveup`, off by default with `fgiveup` at 30, the values LIBSTELL sets. With `lgiveup` set, a multigrid step that exhausts its iteration budget with `fsqr`, `fsqz` or `fsql` still above `fgiveup` times its `ftol` ends the sequence instead of interpolating that state onto the next grid, and the run reports the step it stopped at. `README.md` drops the entry listing the logic as missing.

**Cause** - `Vmec::run` carried `TODO(jons): insert lgiveup/fgiveup logic here` at the point `runvmec.f:382` makes the same test. Without it a sequence whose coarse grid cannot reach its tolerance spends the rest of its budget on the finer grids, where every iteration costs more and the state each one starts from is the one that already failed.

**Evidence** - the twelve QUASR configurations of `tests/test_free_boundary_quasr.py`, run fixed-boundary at mpol = ntor = 6 on `ns_array` [8, 16, 31], single-threaded, over three iteration budgets:

| ftol | niter per step | stopped early | wall time, unset | set |
| --- | --- | --- | --- | --- |
| 1e-12 | 1500 | 1 of 12 | 36.3 s | 32.9 s |
| 1e-11 | 400 | 10 of 12 | 10.6 s | 2.9 s |
| 1e-11 | 250 | 11 of 12 | 7.2 s | 1.4 s |

A configuration that stops at the first step costs 13 percent of what it costs otherwise, the two finer grids carrying the rest. The configurations that run the whole sequence take the same iterations either way: at the first budget the eleven that do not stop early converge in 1131, 1041, 1499, 1500, 1143, 1121, 1497, 1498, 1387, 1236 and 1152 iterations with the flag set and unset alike.

**Tests** - `tests/test_giveup.py`: the defaults; a three-step schedule too short to converge stopping at `ns = 5` with the flag and at `ns = 25` without it; an `fgiveup` above the residual carrying the same schedule to its last step; a converging run reproducing its iteration count and its `rmnc` and `zmns` exactly; the rejection of a non-positive `fgiveup`; and a JSON round trip. `pytest tests/` is 236 passed, 4 skipped and `bazel test --config=opt //vmecpp/...` is 24 of 24. Pre-commit clean.

**Scope** - unset, the multigrid loop is the one that was there and every existing test reproduces its iteration count. The check reads the residuals already in `FlowControl` and runs once per multigrid step. The HDF5 read is guarded on the dataset being present, so inputs written before this still load.
