### PR TITLE
Describe the rotated surface normal and the toroidal step in regularized_integrals.cc

### DIFF
--- a/src/vmecpp/cpp/vmecpp/free_boundary/regularized_integrals/regularized_integrals.cc
+++ b/src/vmecpp/cpp/vmecpp/free_boundary/regularized_integrals/regularized_integrals.cc
@@ -109,10 +109,11 @@ void RegularizedIntegrals::update(const Eigen::VectorXd& bDotN) {
     // index of toridal field period; 0, 1, ..., (nfp-1)
     int p = 0;
 
-    // xper == xp in first period
-    // yper == yp in first period
-    // sxsave == snr in first period (TODO(jons): really?)
-    // sysave == snv in first period (TODO(jons): really?)
+    // xper, yper are the Cartesian coordinates of the source point rotated
+    // into field period p. sxsave, sysave are the Cartesian x and y components
+    // of the surface normal there: rcosuv and rsinuv carry r1b times the
+    // cosine and sine of the toroidal angle, so dividing by r1b turns
+    // (snr, snv) into the Cartesian pair rotated by that angle.
     double xper = xp * sg_.cos_per[p] - yp * sg_.sin_per[p];
     double yper = xp * sg_.sin_per[p] + yp * sg_.cos_per[p];
 
@@ -175,8 +176,9 @@ void RegularizedIntegrals::update(const Eigen::VectorXd& bDotN) {
         for (int k = k_start; k < k_end; ++k, ++kl) {
           const int ip = ip_idx_base + kl;
 
-          // 2 pi from Laplace equation
-          // 1/nfp to make the toroidal integral below over the whole machine
+          // 2 pi / nfp is the toroidal step of the sum over the nfp
+          // field-period images, which turns that sum into the toroidal
+          // integral over the whole machine.
           greenp[ip] +=
               twopidivnfp * (htemp_buf[k] * ftemp_buf[k] *
                                  (sg_.rcosuv[kl] * sxsave +
@@ -211,8 +213,9 @@ void RegularizedIntegrals::update(const Eigen::VectorXd& bDotN) {
             (gsave[kl] - 2 * (xper * sg_.rcosuv[kl] + yper * sg_.rsinuv[kl]));
         double htemp = sqrt(ftemp);
 
-        // 2 pi from Laplace equation (TODO(jons): really?)
-        // 1/nfp to make the toroidal integral below over the whole machine
+        // 2 pi / nfp is the toroidal step of the sum over the nfp
+        // field-period images, which turns that sum into the toroidal integral
+        // over the whole machine.
         greenp[ip_idx_base + kl] +=
             twopidivnfp * htemp * ftemp *
             (sg_.rcosuv[kl] * sxsave + sg_.rsinuv[kl] * sysave + dsave[kl]);
@@ -237,8 +240,8 @@ void RegularizedIntegrals::updateAxisymmetric(const Eigen::VectorXd& bDotN) {
   absl::c_fill_n(greenp, numLocal * nThetaEven, 0);
   absl::c_fill_n(gstore, nThetaEven, 0);
 
-  // 2 pi from the Laplace equation; 1/nvper_ turns the toroidal image sum into
-  // a toroidal integral over the whole machine.
+  // 2 pi / nvper_ is the toroidal step of the sum over the nvper_ images,
+  // which turns that sum into the toroidal integral over the whole machine.
   const double toroidal_measure = 2.0 * M_PI / nvper_;
 
   for (int klp = tp_.ztMin; klp < tp_.ztMax; ++klp) {


### PR DESCRIPTION
**Change** - `regularized_integrals.cc` states what `sxsave` and `sysave` hold and what the `2 pi / nfp` prefactor of `greenp` and `gstore` is.

**Cause** - three of those comments ended in a question mark and two of them were wrong. `sxsave` and `sysave` were described as `snr` and `snv` "in first period", and the prefactor as a 2 pi from the Laplace equation multiplied by a 1/nfp for the period count.

**Evidence** - `rcosuv[kl]` is `r1b[kl] cos(phi_k)` and `rsinuv[kl]` is `r1b[kl] sin(phi_k)` (`surface_geometry.cc`), and `cos_per[0]` and `sin_per[0]` are 1 and 0, so the two expressions reduce to `sxsave = snr cos(phi_kp) - snv sin(phi_kp)` and `sysave = snr sin(phi_kp) + snv cos(phi_kp)`, the Cartesian x and y components of the surface normal at the source point. They coincide with `snr` and `snv` at `phi = 0` alone: on `cth_like_free_bdy`, with nfp 5 and nzeta 36, the toroidal angle of the source point covers 0 to 70 degrees over the grid, where `cos(phi_kp)` runs from 1.000 to 0.342.

The `2 pi / nfp` is a single factor, the toroidal step of the sum over the nfp field-period images. `precal.f90` says so where `alp` is defined, "The ALP=2*pi/nfper factor is needed to normalize integral over field periods". Reading the 2 pi as the Laplace equation's leaves the 1/nfp to be accounted for on its own, which is the state `fouri.f90` records at its use of `onp`: "1/nfp to match 1/nfp in alp in cmns (2 pi of alp alreafy somewhere else (???))". The axisymmetric branch writes the same factor as `2 pi / nvper_` over nvper_ images.

**Tests** - `bazel test --config=opt //vmecpp/...` is 24 of 24 and `//vmecpp_large_cpp_tests/free_boundary/...` is 7 of 7. `CheckGreenF` compares `greenp` and `gstore` against the educational_VMEC dumps and records where the factor sits, dividing `2 pi / nfp` out to match Fortran. Pre-commit clean.

**Scope** - comments only.
