### PR TITLE
Serialize bdotb with the rest of the wout

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/output_quantities.cc
@@ -932,9 +932,7 @@ absl::Status vmecpp::WOutFileContents::WriteTo(H5::H5File& file) const {
   WRITEMEMBER(phips);
   WRITEMEMBER(over_r);
   WRITEMEMBER(jdotb);
-  // TODO(jurasic) We will deprecate HDF5 soon, regenerate large_cpp_tests
-  // reference files with all quantities once that is done
-  //  WRITEMEMBER(bdotb);
+  WRITEMEMBER(bdotb);
   WRITEMEMBER(bdotgradv);
   WRITEMEMBER(DMerc);
   WRITEMEMBER(DShear);
@@ -1102,9 +1100,8 @@ absl::Status vmecpp::WOutFileContents::LoadInto(WOutFileContents& m_obj,
     ReadHalfGridCompat(m_obj.over_r, "overr");
   }
   READMEMBER(jdotb);
-  // TODO(jurasic) We will deprecate HDF5 soon, regenerate large_cpp_tests
-  // reference files with all quantities once that is done
-  //  READMEMBER(bdotb);
+  // Files written before bdotb was serialized carry no such dataset.
+  READMEMBER_OPTIONAL(bdotb);
   READMEMBER(bdotgradv);
   READMEMBER(DMerc);
   READMEMBER_COMPAT(DShear, "Dshear");

--- a/src/vmecpp/cpp/vmecpp/vmec/output_quantities/test_helpers.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/output_quantities/test_helpers.h
@@ -83,6 +83,7 @@ inline void CheckWOutEquality(const vmecpp::WOutFileContents& wout1,
   EXPECT_EQ(wout1.phips, wout2.phips);
   EXPECT_EQ(wout1.over_r, wout2.over_r);
   EXPECT_EQ(wout1.jdotb, wout2.jdotb);
+  EXPECT_EQ(wout1.bdotb, wout2.bdotb);
   EXPECT_EQ(wout1.bdotgradv, wout2.bdotgradv);
   EXPECT_EQ(wout1.DMerc, wout2.DMerc);
   EXPECT_EQ(wout1.DShear, wout2.DShear);


### PR DESCRIPTION
**Change** - `WOutFileContents::WriteTo` in `output_quantities.cc` writes `bdotb`, and `LoadInto` reads it back, guarded on the dataset being present so files written before this still load.

**Cause** - both calls were commented out, so `OutputQuantities::Save` wrote a wout without the flux-surface average of `B.B` and a reload left that array empty while every other profile came back at length `ns`. `CheckWOutEquality`, which both round-trip tests use, compares `jdotb` and `bdotgradv` on either side of it and skips `bdotb`, so nothing reported the loss.

**Evidence** - on `cth_like_fixed_bdy` at ns = 25 the in-memory array holds 25 values, 0.33097 at the axis falling to 0.31729 and rising to 0.32078 at the edge, and the reloaded one holds none. With the write in place the two are equal element for element.

**Tests** - `CheckWOutEquality` gains `bdotb` beside `jdotb`. `OutputQuantitiesIO.WOut` and `OutputQuantitiesIO.OutputQuantities` both fail without the serialization, reporting those 25 values against `{}`, and pass with it. `bazel test --config=opt //vmecpp/...` is 24 of 24 and `//vmecpp_large_cpp_tests/...` is 20 of 20, including the hot-restart cases, which load the two checked-in `.out.h5` files that carry no such dataset. `--config=asan` on the round-trip test is clean. Pre-commit clean.

**Scope** - the value written is the one `ComputeWOutFileContents` already assigns from `jxbout.bdotb`.
