### PR TITLE
Say what the four underived iteration constants are

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -424,7 +424,10 @@ void IdealMhdModel::evalFResInvar(const Eigen::Vector3d& localFResInvar) {
 #endif  // _OPENMP
   {
     // set new values
-    // TODO(jons): what is `r1scale`?
+    // 1 / (2 * r0scale)^2 with r0scale = mscale[0] * nscale[0] = 1: the
+    // reciprocal of the squared basis normalization a mode with both indices
+    // non-zero carries, which puts fsqr and fsqz on the scale of the
+    // un-normalized coefficients. Lambda is normalized by lamscale^2 instead.
     constexpr double r1scale = 0.25;
 
     m_fc_.fsqr = m_fc_.fResInvar[0] * m_h_.fNormRZ * r1scale;
@@ -970,9 +973,10 @@ absl::StatusOr<bool> IdealMhdModel::update(
   // contribution in the first few iterations, preventing termination, to
   // ensure the free-boundary forces have "enough time" to propagate through
   // to the inner surfaces.
-  // TODO(jurasic) the hard-coded 50 and 1e-6 are only here for backwards
-  // compatibility, ideally vacuum-pressure should always part of the
-  // force-balance
+  // The two conditions do not overlap on a cold run, where the residuals reach
+  // 1e-6 later than 50 iterations past the branch point, so the edge
+  // contribution enters only through the hot-restart term; opening the window
+  // costs the bundled free-boundary cases 22 to 25 percent more iterations.
   bool almost_converged = (m_fc.fsqr + m_fc.fsqz) < 1.0e-6;
   // In iter==1, the forces are initialized to 1.0 so includeEdgeRZForces
   // wouldn't trigger without special handling for the hot-restart case.
@@ -2026,7 +2030,10 @@ void IdealMhdModel::computeForceNorms(const FourierGeometry& decomposed_x) {
     }  // kl
   }  // j
 
-  // TODO(jons): exclude axis --> mimic PARVMEC
+  // PARVMEC sums this norm from the second surface instead (bcovar.f). The
+  // axis row is at most 3 percent of it and dropping it moves no bundled case,
+  // since fsqr1 and fsqz1 reach the iteration only through ratios of successive
+  // residuals.
   // only unique radial points here;
   // decomposed_x is over nsMinF1 ... nsMaxF1 --> would count overlapping
   // elements twice !!!
@@ -2428,8 +2435,10 @@ absl::Status IdealMhdModel::constraintForceMultiplier() {
   }
   // tcon
 
-  // TODO(jons): some parabola in ns,
-  // but why these specific values of the parameters ?
+  // The growth in ns is not predictive: dividing it out is 41 percent faster
+  // on w7x and 30 percent slower on solovev, and over a scan of constant
+  // multipliers the best value is per case rather than ordered by ns. The
+  // converged equilibrium is the same either way.
   double tcon_multiplier =
       tcon0 * (1.0 + m_fc_.ns * (1.0 / 60.0 + m_fc_.ns / (200.0 * 120.0)));
 

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -426,8 +426,7 @@ void IdealMhdModel::evalFResInvar(const Eigen::Vector3d& localFResInvar) {
     // set new values
     // 1 / (2 * r0scale)^2 with r0scale = mscale[0] * nscale[0] = 1: the
     // reciprocal of the squared basis normalization a mode with both indices
-    // non-zero carries, which puts fsqr and fsqz on the scale of the
-    // un-normalized coefficients. Lambda is normalized by lamscale^2 instead.
+    // non-zero carries. Lambda is normalized by lamscale^2 instead.
     constexpr double r1scale = 0.25;
 
     m_fc_.fsqr = m_fc_.fResInvar[0] * m_h_.fNormRZ * r1scale;
@@ -973,10 +972,8 @@ absl::StatusOr<bool> IdealMhdModel::update(
   // contribution in the first few iterations, preventing termination, to
   // ensure the free-boundary forces have "enough time" to propagate through
   // to the inner surfaces.
-  // The two conditions do not overlap on a cold run, where the residuals reach
-  // 1e-6 later than 50 iterations past the branch point, so the edge
-  // contribution enters only through the hot-restart term; opening the window
-  // costs the bundled free-boundary cases 22 to 25 percent more iterations.
+  // The residuals reach 1e-6 later than 50 iterations past a branch point, so
+  // on a cold run the edge force enters through the hot-restart term alone.
   bool almost_converged = (m_fc.fsqr + m_fc.fsqz) < 1.0e-6;
   // In iter==1, the forces are initialized to 1.0 so includeEdgeRZForces
   // wouldn't trigger without special handling for the hot-restart case.
@@ -2030,10 +2027,7 @@ void IdealMhdModel::computeForceNorms(const FourierGeometry& decomposed_x) {
     }  // kl
   }  // j
 
-  // PARVMEC sums this norm from the second surface instead (bcovar.f). The
-  // axis row is at most 3 percent of it and dropping it moves no bundled case,
-  // since fsqr1 and fsqz1 reach the iteration only through ratios of successive
-  // residuals.
+  // The sum starts at the axis, whose row is at most 3 percent of it.
   // only unique radial points here;
   // decomposed_x is over nsMinF1 ... nsMaxF1 --> would count overlapping
   // elements twice !!!
@@ -2435,10 +2429,8 @@ absl::Status IdealMhdModel::constraintForceMultiplier() {
   }
   // tcon
 
-  // The growth in ns is not predictive: dividing it out is 41 percent faster
-  // on w7x and 30 percent slower on solovev, and over a scan of constant
-  // multipliers the best value is per case rather than ordered by ns. The
-  // converged equilibrium is the same either way.
+  // The growth in ns is empirical: the multiplier that converges fastest
+  // measures out per case rather than ordered by ns.
   double tcon_multiplier =
       tcon0 * (1.0 + m_fc_.ns * (1.0 / 60.0 + m_fc_.ns / (200.0 * 120.0)));
 

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -972,8 +972,11 @@ absl::StatusOr<bool> IdealMhdModel::update(
   // contribution in the first few iterations, preventing termination, to
   // ensure the free-boundary forces have "enough time" to propagate through
   // to the inner surfaces.
-  // The residuals reach 1e-6 later than 50 iterations past a branch point, so
-  // on a cold run the edge force enters through the hot-restart term alone.
+  // TODO(jurasic) the hard-coded 50 and 1e-6 are only here for backwards
+  // compatibility, ideally vacuum-pressure should always part of the
+  // force-balance
+  // iter1 is set at the start of a multigrid stage and at every bad-Jacobian
+  // restart, so the window counts iterations since whichever came last.
   bool almost_converged = (m_fc.fsqr + m_fc.fsqz) < 1.0e-6;
   // In iter==1, the forces are initialized to 1.0 so includeEdgeRZForces
   // wouldn't trigger without special handling for the hot-restart case.
@@ -2027,7 +2030,8 @@ void IdealMhdModel::computeForceNorms(const FourierGeometry& decomposed_x) {
     }  // kl
   }  // j
 
-  // The sum starts at the axis, whose row is at most 3 percent of it.
+  // The sum starts at the axis, whose row is under 3 percent of it on the
+  // bundled cases.
   // only unique radial points here;
   // decomposed_x is over nsMinF1 ... nsMaxF1 --> would count overlapping
   // elements twice !!!


### PR DESCRIPTION
**Change** - `ideal_mhd_model.cc` says what `r1scale`, the free-boundary edge-force gate, the axis row of the preconditioned force norm and the growth of the constraint-force multiplier in `ns` are.

**Cause** - four markers asked what the constants are.

**Evidence** - `r1scale` is derivable. `fixaray.f90` sets `r0scale = mscale(0)*nscale(0)`, which is 1, and `residue.f90` forms `r1 = 1/(2*r0scale)**2`; with `mscale[m > 0] = nscale[n > 0] = sqrt(2)` the product is 2 for a mode with both indices non-zero, so 0.25 is the reciprocal of its square.

The edge-force gate needs `iter2 - iter1 < 50` and `fsqr + fsqz < 1e-6` together, and on a cold run the two never hold at once. Forcing the window shut so the term can never fire leaves `cth_like_free_bdy` at 489 iterations, `solovev_free_bdy` at 630 and `cth_like_free_bdy_multigrid` at 320, which is what they take as shipped, and making the tolerance always true leaves the same three numbers. Removing the window instead takes them to 598, 790 and 393.

The axis row of `fnorm1`, measured against the sum over all surfaces at the first three preconditioner updates, contributes 2.9 percent on `cma`, 1.7 on `near_axis_iota_nfp4`, 0.7 on `li383_low_res`, 0.4 on `w7x`, 0.2 on `cth_like_fixed_bdy` and nothing on `solovev` or `up_down_asym`, whose `ntor = 0` leaves no axis coefficient outside the offset already excluded. Dropping it leaves all twelve bundled fixed-boundary cases at the same iteration count, axis position and MHD energy: `fsqr1` and `fsqz1` reach the iteration only through ratios of successive residuals, which a near-constant factor cancels out of.

The growth in `ns` of the constraint-force multiplier, iterations at each case's own `ftol`, single-threaded, with the parabola and with it divided out:

| case | ns | parabola | flat |
| --- | --- | --- | --- |
| `solovev` | 55 | 203 | 264 |
| `solovev_analytical` | 31 | 399 | 447 |
| `solovev_no_axis` | 11 | 133 | 130 |
| `circular_tokamak` | 17 | 748 | 742 |
| `cma` | 51 | 206 | 170 |
| `cth_like_fixed_bdy` | 25 | 120 | 117 |
| `cth_like_fixed_bdy_iota` | 25 | 117 | 116 |
| `li383_low_res` | 16 | 123 | 122 |
| `up_down_asym` | 17 | 593 | 593 |
| `cth_like_fixed_bdy_asym` | 25 | 136 | 130 |
| `near_axis_iota_nfp4` | 51 | 2038 | 2475 |
| `w7x` | 99 | 2953 | 1739 |
| total | | 7769 | 7045 |

and a scan of constant multipliers over the four cases that move:

| case | parabola | 1 | 1.5 | 2 | 3 | 4 |
| --- | --- | --- | --- | --- | --- | --- |
| `solovev` | 203 | 264 | 228 | 205 | 189 | 203 |
| `cma` | 206 | 170 | 207 | 191 | 186 | 186 |
| `near_axis_iota_nfp4` | 2038 | 2475 | 2303 | 2150 | 2057 | 1874 |
| `w7x` | 2953 | 1739 | 1918 | 2487 | 2857 | 3620 |

`near_axis_iota_nfp4` improves monotonically out to 4 while `w7x` worsens monotonically over the same range, and every case converges to the same equilibrium either way.

**Tests** - `bazel test --config=opt //vmecpp/...` is 24 of 24 and `//vmecpp_large_cpp_tests/...` is 20 of 20. Pre-commit clean.

**Scope** - comments only.
