### PR TITLE
Pin the m=1 gauge in VmecModel so the equilibrium and its Jacobian are functions of the boundary

### DIFF
--- a/src/vmecpp/autodiff.py
+++ b/src/vmecpp/autodiff.py
@@ -6,6 +6,14 @@ and solves the transposed interior force system. This is the usual implicit
 layer for a differentiable code: JAX differentiates the consumer objective,
 and VMEC++ supplies the producer's residual transpose.
 
+The solve pins the m=1 poloidal-origin gauge (``VmecModel.always_fix_m1_gauge``):
+the native iteration lets that gauge drift under its force until ``fsqz`` drops
+below 1e-6 and freezes it wherever it is, so the converged state would depend on
+the iteration history and the fixed-gauge force Jacobian would not describe it.
+With the gauge pinned, the gauge entries of the state are a linear function of
+the boundary, and the VJP pulls them back to the boundary like the boundary
+entries themselves.
+
 The first public parameterization is the fixed-boundary case, with either a
 prescribed iota or a prescribed toroidal current profile (``ncurr``). The
 differentiable parameter is one dense array with rows ``rbc`` and ``zbs`` and
@@ -92,6 +100,7 @@ def _solve_model(template, boundary: np.ndarray):
             continue
         if model is None:
             model = _vmecpp.VmecModel.create(indata, ns)
+            model.always_fix_m1_gauge = True
         else:
             model.refine_to(ns)
         model.solve()
@@ -162,6 +171,51 @@ def _interior_and_boundary(model) -> tuple[np.ndarray, np.ndarray]:
     boundary_array = np.asarray(sorted(boundary), dtype=np.int64)
     interior_array = np.setdiff1d(np.arange(state_size), boundary_array)
     return interior_array, boundary_array
+
+
+def _gauge_entries(model) -> np.ndarray:
+    """State entries holding the m=1 poloidal-origin gauge on interior surfaces.
+
+    ``FourierCoeffs::m1Constraint`` stores ``(r_ss - z_cs) / 2`` for ``m = 1``
+    in the ``z_cs`` slot. Its force is zeroed when the gauge is fixed, so with
+    ``always_fix_m1_gauge`` the solve leaves these entries at the initial guess:
+    the boundary value scaled by ``sqrt(s)`` on every surface. The ``n = 0``
+    entry is identically zero and is left to the structural deflation.
+    """
+    if not model.lthreed:
+        return np.zeros(0, dtype=np.int64)
+    slices = _span_slices(model)
+    modes_per_surface = model.mpol * (model.ntor + 1)
+    span = slices["z_cs"]
+    entries = [
+        span.start + j * modes_per_surface + 1 * (model.ntor + 1) + n
+        for j in range(1, model.ns - 1)
+        for n in range(1, model.ntor + 1)
+    ]
+    return np.asarray(entries, dtype=np.int64)
+
+
+def _gauge_radial_weight(model, gauge: np.ndarray) -> np.ndarray:
+    """``sqrt(s_j)`` for every gauge entry: the factor mapping the boundary gauge
+    to surface ``j`` in ``FourierGeometry::interpFromBoundaryAndAxis``."""
+    modes_per_surface = model.mpol * (model.ntor + 1)
+    span_start = _span_slices(model)["z_cs"].start
+    surface = (gauge - span_start) // modes_per_surface
+    return np.sqrt(surface / (model.ns - 1.0))
+
+
+def _pull_gauge_back_to_boundary(
+    model, state_bar: np.ndarray, gauge: np.ndarray
+) -> np.ndarray:
+    """Fold the gauge cotangents onto the boundary gauge entries they derive from."""
+    result = state_bar.copy()
+    modes_per_surface = model.mpol * (model.ntor + 1)
+    span_start = _span_slices(model)["z_cs"].start
+    mode = (gauge - span_start) % modes_per_surface
+    edge = span_start + (model.ns - 1) * modes_per_surface + mode
+    np.add.at(result, edge, _gauge_radial_weight(model, gauge) * state_bar[gauge])
+    result[gauge] = 0.0
+    return result
 
 
 def _boundary_from_state_vjp(model, state_bar: np.ndarray) -> np.ndarray:
@@ -293,6 +347,12 @@ def _implicit_boundary_vjp(model, geometry_bar: np.ndarray) -> np.ndarray:
             "No finite-difference derivative is used."
         )
         raise RuntimeError(error_message)
+    if not model.always_fix_m1_gauge:
+        error_message = (
+            "VMEC++ adjoint: the model was solved with a free m=1 gauge; the exact "
+            "force Jacobian describes the solve only with always_fix_m1_gauge"
+        )
+        raise RuntimeError(error_message)
     coefficient_bar = np.asarray(geometry_bar[2 * model.ns :], dtype=np.float64)
     poloidal_flux_bar = np.asarray(
         geometry_bar[model.ns : 2 * model.ns], dtype=np.float64
@@ -302,6 +362,11 @@ def _implicit_boundary_vjp(model, geometry_bar: np.ndarray) -> np.ndarray:
     )
     state = np.asarray(model.get_state(), dtype=np.float64)
     interior, boundary = _interior_and_boundary(model)
+    # The pinned gauge entries are prescribed by the boundary, like the boundary
+    # entries themselves: they leave the interior system and are pulled back.
+    gauge = _gauge_entries(model)
+    interior = np.setdiff1d(interior, gauge)
+    prescribed = np.concatenate([boundary, gauge])
     model.set_state(np.ascontiguousarray(state))
     model.evaluate(2, 2, True)
     state_size = state.size
@@ -348,9 +413,9 @@ def _implicit_boundary_vjp(model, geometry_bar: np.ndarray) -> np.ndarray:
         raise RuntimeError(error_message)
     embedded = np.zeros(state_size)
     embedded[interior] = adjoint
-    internal_boundary_bar = state_bar[boundary] - transpose(embedded)[boundary]
     full_state_bar = np.zeros(state_size)
-    full_state_bar[boundary] = internal_boundary_bar
+    full_state_bar[prescribed] = state_bar[prescribed] - transpose(embedded)[prescribed]
+    full_state_bar = _pull_gauge_back_to_boundary(model, full_state_bar, gauge)
     return _boundary_from_state_vjp(model, full_state_bar)
 
 

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.cc
@@ -184,6 +184,29 @@ void FourierGeometry::interpFromBoundaryAndAxis(
   }  // j
 }
 
+void FourierGeometry::setM1GaugeFromBoundary(const FourierBasisFastPoloidal& t,
+                                             const Boundaries& b,
+                                             const RadialProfiles& p) {
+  const int m = 1;
+  if (s_.mpol <= m) {
+    return;
+  }
+  for (int jF = nsMin_; jF < nsMax_; ++jF) {
+    const double interpolationWeight = p.sqrtSF[jF - r_.nsMinF1];
+    for (int n = 0; n < s_.ntor + 1; ++n) {
+      const int idx_bdy = m * (s_.ntor + 1) + n;
+      const int idx_fc = ((jF - nsMin_) * s_.mpol + m) * (s_.ntor + 1) + n;
+      const double basis_norm = 1.0 / (t.mscale[m] * t.nscale[n]);
+      if (s_.lthreed) {
+        zmncs[idx_fc] = basis_norm * interpolationWeight * b.zbcs[idx_bdy];
+      }
+      if (s_.lasym) {
+        zmncc[idx_fc] = basis_norm * interpolationWeight * b.zbcc[idx_bdy];
+      }
+    }
+  }
+}
+
 void FourierGeometry::InitFromState(
     const FourierBasisFastPoloidal& fb, const RowMatrixXd& rmnc,
     const RowMatrixXd& zmns, const RowMatrixXd& lmns_full,

--- a/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/fourier_geometry/fourier_geometry.h
@@ -26,6 +26,13 @@ class FourierGeometry : public FourierCoeffs {
   void interpFromBoundaryAndAxis(const FourierBasisFastPoloidal& t,
                                  const Boundaries& b, const RadialProfiles& p);
 
+  // Set the m=1 gauge combinations (the zmncs and, for lasym, zmncc slots
+  // that FourierCoeffs::m1Constraint couples to rmnss / rmnsc) on every
+  // owned surface to their interpFromBoundaryAndAxis value, the boundary
+  // gauge scaled by sqrt(s). Leaves all other coefficients untouched.
+  void setM1GaugeFromBoundary(const FourierBasisFastPoloidal& t,
+                              const Boundaries& b, const RadialProfiles& p);
+
   // Initialize the state of this FourierGeometry with the given Fourier
   // coefficients. If a Boundaries object is specified (defaults to nullptr; in
   // order to avoid a copy when using std::optional), the geometry of the

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -228,9 +228,12 @@ class VmecModel {
   // lambda-constraint components. That raw gradient is what gradient-based
   // optimizers minimizing the MHD energy functional need; mhd_energy is already
   // set earlier in update(), so it is valid at the checkpoint too.
-  // The native iteration leaves the m=1 gauge free until the previous Z
-  // residual crosses its threshold. External evaluations fix it immediately so
-  // F(x) does not depend on the previously evaluated state.
+  // always_fix_m1_gauge selects the force system: with true the m=1 gauge
+  // force is zeroed (the system solve() iterates when the model's
+  // always_fix_m1_gauge property is set), with false the gauge force is
+  // kept until fsqz < 1e-6 as in the native iteration, so F(x) then also
+  // depends on the previously evaluated residual. The exact Hessian-vector
+  // products take the same flag and differentiate the same system.
   void Evaluate(int iter1, int iter2, bool precondition = true,
                 bool always_fix_m1_gauge = true) {
     bool need_restart = false;
@@ -388,6 +391,11 @@ class VmecModel {
                        delt0, std::nullopt, interpolation);
     last_preconditioner_update_ = 0;
     last_full_update_nestor_ = 0;
+  }
+
+  bool always_fix_m1_gauge() const { return vmec_->always_fix_m1_gauge_; }
+  void set_always_fix_m1_gauge(bool value) const {
+    vmec_->always_fix_m1_gauge_ = value;
   }
 
   // Reference C++ inner iteration (the loop being ported), for verification.
@@ -619,8 +627,11 @@ class VmecModel {
   // of geometryFromFourier: T v = geom(x+v) - geom(x), so no finite-difference
   // step enters. The constraint multiplier tcon is recomputed from the geometry
   // inside the composition, as the raw force recomputes it from the state. The
-  // model state is restored to x on return.
-  Eigen::VectorXd ExactHessianVectorProduct(const Eigen::VectorXd &v) {
+  // model state is restored to x on return. always_fix_m1_gauge has the
+  // meaning it has in Evaluate: H is the Jacobian of the force that
+  // Evaluate returns for the same flag.
+  Eigen::VectorXd ExactHessianVectorProduct(const Eigen::VectorXd &v,
+                                            bool always_fix_m1_gauge = true) {
     RequireLforbalDisabledForExactDerivatives();
     vmecpp::IdealMhdModel &model = *vmec_->m_[0];
     const int gS = static_cast<int>(model.r1_e.size());
@@ -643,7 +654,7 @@ class VmecModel {
                        dgeom.data(), gS, /*primal=*/false);
     model.applyExactForceJacobian(
         exact_primal_.data(), dgeom.data(), gS, *vmec_->physical_f_[0],
-        *vmec_->decomposed_f_[0], /*fix_m1_gauge=*/true);
+        *vmec_->decomposed_f_[0], always_fix_m1_gauge);
     return FlattenActive(*vmec_->decomposed_f_[0], vmec_->s_);
   }
 
@@ -651,7 +662,8 @@ class VmecModel {
   // internal basis. The force Jacobian is non-symmetric (VMEC's force is a
   // scaled gradient), so the adjoint boundary gradient needs H^T, not H. Uses
   // the same cached primal geometry as ExactHessianVectorProduct.
-  Eigen::VectorXd ExactHessianVectorProductTranspose(const Eigen::VectorXd &w) {
+  Eigen::VectorXd ExactHessianVectorProductTranspose(
+      const Eigen::VectorXd &w, bool always_fix_m1_gauge = true) {
     RequireLforbalDisabledForExactDerivatives();
     vmecpp::IdealMhdModel &model = *vmec_->m_[0];
     const int gS = static_cast<int>(model.r1_e.size());
@@ -668,7 +680,7 @@ class VmecModel {
     model.applyExactForceJacobianTranspose(
         exact_primal_.data(), gS, *vmec_->decomposed_f_[0],
         *vmec_->physical_f_[0], *vmec_->physical_x_[0],
-        *vmec_->physical_x_backup_[0], /*fix_m1_gauge=*/true);
+        *vmec_->physical_x_backup_[0], always_fix_m1_gauge);
     return FlattenActive(*vmec_->physical_x_backup_[0], vmec_->s_);
   }
 
@@ -1628,6 +1640,15 @@ PYBIND11_MODULE(_vmecpp, m) {
       .def("refine_to", &VmecModel::RefineTo, py::arg("new_ns"),
            py::arg("interpolation") = py::none())
       .def("solve", &VmecModel::Solve)
+      .def_property("always_fix_m1_gauge", &VmecModel::always_fix_m1_gauge,
+                    &VmecModel::set_always_fix_m1_gauge,
+                    "Zero the m=1 gauge force from the first iteration of "
+                    "solve() and set the gauge from the boundary in "
+                    "refine_to(). The converged gauge then equals the "
+                    "boundary gauge scaled by sqrt(s), independent of the "
+                    "iteration and multigrid history, and the exact "
+                    "Hessian-vector products with always_fix_m1_gauge=True "
+                    "are the Jacobian of the iterated system.")
       .def("get_state", &VmecModel::GetState)
       .def("set_state", &VmecModel::SetState, py::arg("state"))
       .def("get_forces", &VmecModel::GetForces)
@@ -1644,9 +1665,11 @@ PYBIND11_MODULE(_vmecpp, m) {
       // deflating the augmented Hessian's structural null space needs both a
       // row and a column probe.
       .def("exact_hessian_vector_product",
-           &VmecModel::ExactHessianVectorProduct, py::arg("v"))
+           &VmecModel::ExactHessianVectorProduct, py::arg("v"),
+           py::arg("always_fix_m1_gauge") = true)
       .def("exact_hessian_vector_product_transpose",
-           &VmecModel::ExactHessianVectorProductTranspose, py::arg("w"))
+           &VmecModel::ExactHessianVectorProductTranspose, py::arg("w"),
+           py::arg("always_fix_m1_gauge") = true)
       .def("chip_state_vjp", &VmecModel::ChipStateVjp, py::arg("chip_bar"))
 #endif  // VMECPP_ENABLE_ENZYME
       .def_property_readonly("force_eval_count", &VmecModel::force_eval_count)

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.cc
@@ -785,6 +785,17 @@ absl::StatusOr<bool> Vmec::InitializeRadial(
       }
     }
 
+    // With the m=1 gauge force zeroed throughout, the gauge stays at its
+    // initial value. Set it from the boundary here so that it does not
+    // carry the hot-restart state or the coarse-grid interpolation (whose
+    // odd-m axis extrapolation does not reproduce the sqrt(s) profile).
+    if (always_fix_m1_gauge_) {
+      for (int thread_id = 0; thread_id < num_threads_; ++thread_id) {
+        decomposed_x_[thread_id]->setM1GaugeFromBoundary(t_, b_,
+                                                         *p_[thread_id]);
+      }
+    }
+
     // restart_reason == NO_RESTART at entry of restart_iter means to store xc
     // in xstore. The backup is taken AFTER the multigrid interpolation, so
     // that the first rollback target of a continuation stage is the
@@ -1516,7 +1527,8 @@ absl::StatusOr<bool> Vmec::UpdateForwardModel(
       *decomposed_x_[thread_id], *physical_x_[thread_id],
       *decomposed_f_[thread_id], *physical_f_[thread_id], need_restart,
       last_preconditioner_update_, last_full_update_nestor_, fc_, iter1_,
-      iter2_, checkpoint, iterations_before_checkpointing, verbose_);
+      iter2_, checkpoint, iterations_before_checkpointing, verbose_,
+      always_fix_m1_gauge_);
   if (!reached_checkpoint.ok()) {
     return reached_checkpoint;
   }

--- a/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/vmec/vmec.h
@@ -200,6 +200,13 @@ class Vmec {
   VmecConstants constants_;
   HandoverStorage h_;
   FlowControl fc_;
+  // Zero the m=1 gauge force (FourierForces::zeroZForceForM1) from the first
+  // iteration instead of only once fsqz < 1e-6, and set the gauge from the
+  // boundary in InitializeRadial. The converged gauge then equals the
+  // boundary gauge scaled by sqrt(s) on every surface, independent of the
+  // iteration and multigrid history, and the fixed-gauge force Jacobian is
+  // the linearization of the iterated system.
+  bool always_fix_m1_gauge_ = false;
   MGridProvider mgrid_;
   OutputQuantities output_quantities_;
 

--- a/tests/test_autodiff.py
+++ b/tests/test_autodiff.py
@@ -226,6 +226,11 @@ def _tangent_through_the_solve(indata, boundary, seed_state):
     model = autodiff._solve_model(indata._to_cpp_vmecindata(), boundary)
     state = np.asarray(model.get_state(), dtype=np.float64)
     interior, edge = autodiff._interior_and_boundary(model)
+    # The pinned m=1 gauge entries are prescribed by the boundary, like the
+    # edge entries; the parser tangent below carries their sqrt(s) profile.
+    gauge = autodiff._gauge_entries(model)
+    edge = np.concatenate([edge, gauge])
+    interior = np.setdiff1d(interior, gauge)
     model.set_state(np.ascontiguousarray(state))
     model.evaluate(2, 2, True)
     keep = autodiff._structural_nullfree_interior(model, interior)

--- a/tests/test_m1_gauge.py
+++ b/tests/test_m1_gauge.py
@@ -1,0 +1,260 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+"""The pinned m=1 poloidal-origin gauge and the boundary adjoint that relies on it.
+
+``FourierCoeffs::m1Constraint`` stores, for every ``m = 1`` mode, the pair
+``(rss + zcs) / 2`` and ``(rss - zcs) / 2``; the second one is a poloidal-angle
+origin per toroidal harmonic. The native iteration lets it drift under its force
+until ``fsqz < 1e-6`` and freezes it wherever it is, so the converged state is a
+function of the iteration history. ``VmecModel.always_fix_m1_gauge`` zeroes that
+force from the first iteration and sets the gauge from the boundary at every
+multigrid step; the converged gauge is then the boundary gauge scaled by
+``sqrt(s)``, and the fixed-gauge force Jacobian is the linearization of the
+iterated system.
+"""
+
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import vmecpp
+from vmecpp import autodiff
+from vmecpp.cpp import _vmecpp  # type: ignore
+
+jax.config.update("jax_enable_x64", True)
+
+EXAMPLES_DATA = Path(__file__).resolve().parents[1] / "examples" / "data"
+
+# Power-series fit of iotaf from examples/data/wout_cth_like_fixed_bdy.nc, so the
+# ncurr=0 case below has the equilibrium's own rotational transform.
+_CTH_LIKE_IOTA = np.asarray([1.239, 0.328, -0.768])
+
+
+def _cth_like_input(ns_array, ftol: float = 1.0e-16, niter: int = 5000):
+    source = vmecpp.VmecInput.from_file(EXAMPLES_DATA / "cth_like_fixed_bdy.json")
+    ns_array = np.asarray(ns_array, dtype=np.int64)
+    return source.model_copy(
+        update={
+            "ncurr": 0,
+            "piota_type": "power_series",
+            "ai": _CTH_LIKE_IOTA,
+            "ns_array": ns_array,
+            "ftol_array": np.full(ns_array.size, ftol),
+            "niter_array": np.full(ns_array.size, niter, dtype=np.int64),
+        }
+    )
+
+
+def _small_3d_input() -> vmecpp.VmecInput:
+    """Solovev with one toroidal boundary mode (as in test_autodiff.py)."""
+    source = vmecpp.VmecInput.from_file(EXAMPLES_DATA / "solovev.json")
+    mpol = source.mpol
+    rbc = np.zeros((mpol, 3))
+    zbs = np.zeros((mpol, 3))
+    rbc[:, 1] = np.asarray(source.rbc)[:, 0]
+    zbs[:, 1] = np.asarray(source.zbs)[:, 0]
+    rbc[1, 2] = 0.01
+    zbs[1, 2] = 0.01
+    return source.model_copy(
+        update={
+            "ntor": 1,
+            "rbc": rbc,
+            "zbs": zbs,
+            "raxis_c": np.asarray([4.0, 0.0]),
+            "zaxis_s": np.asarray([0.0, 0.0]),
+            "ns_array": np.asarray([5]),
+            "ftol_array": np.asarray([1.0e-15]),
+            "niter_array": np.asarray([4000]),
+        }
+    )
+
+
+def _boundary(indata: vmecpp.VmecInput) -> np.ndarray:
+    return np.stack([np.asarray(indata.rbc), np.asarray(indata.zbs)], axis=0).astype(
+        np.float64
+    )
+
+
+def _requires_exact_derivatives(model) -> None:
+    if not model.has_exact_force_jacobian:
+        pytest.skip("needs an Enzyme-enabled build for the exact force Jacobian")
+
+
+def _solve(indata: vmecpp.VmecInput, always_fix_m1_gauge: bool):
+    """Solve through every entry of ns_array, as autodiff._solve_model does."""
+    cpp_indata = indata._to_cpp_vmecindata()
+    model = None
+    for ns in (int(value) for value in np.asarray(indata.ns_array)):
+        if model is None:
+            model = _vmecpp.VmecModel.create(cpp_indata, ns)
+            model.always_fix_m1_gauge = always_fix_m1_gauge
+        else:
+            model.refine_to(ns)
+        model.solve()
+    assert model is not None
+    return model
+
+
+def test_pinned_gauge_stays_at_the_boundary_interpolation() -> None:
+    indata = _cth_like_input([25])
+    cpp_indata = indata._to_cpp_vmecindata()
+    model = _vmecpp.VmecModel.create(cpp_indata, 25)
+    model.always_fix_m1_gauge = True
+    initial = np.asarray(model.get_state(), dtype=np.float64).copy()
+    model.solve()
+    solved = np.asarray(model.get_state(), dtype=np.float64)
+
+    gauge = autodiff._gauge_entries(model)
+    assert gauge.size == (model.ns - 2) * model.ntor
+    np.testing.assert_allclose(solved[gauge], initial[gauge], rtol=0.0, atol=1.0e-12)
+
+    # The gauge is sqrt(s) times the boundary gauge on every surface.
+    modes_per_surface = model.mpol * (model.ntor + 1)
+    span = autodiff._span_slices(model)["z_cs"]
+    edge = span.start + (model.ns - 1) * modes_per_surface
+    boundary_gauge = solved[edge + (gauge - span.start) % modes_per_surface]
+    np.testing.assert_allclose(
+        solved[gauge],
+        autodiff._gauge_radial_weight(model, gauge) * boundary_gauge,
+        rtol=0.0,
+        atol=1.0e-15,
+    )
+
+    # The native iteration moves the gauge by an amount comparable to its size.
+    native = _vmecpp.VmecModel.create(cpp_indata, 25)
+    native.solve()
+    drift = np.abs(np.asarray(native.get_state())[gauge] - initial[gauge]).max()
+    assert drift > 1.0e-5
+    assert np.abs(initial[gauge]).max() < 1.0e-3
+
+
+def test_pinned_gauge_solve_is_independent_of_the_multigrid_history() -> None:
+    direct = _solve(_cth_like_input([25]), always_fix_m1_gauge=True)
+    staged = _solve(_cth_like_input([13, 25]), always_fix_m1_gauge=True)
+    direct_state = np.asarray(direct.get_state(), dtype=np.float64)
+    staged_state = np.asarray(staged.get_state(), dtype=np.float64)
+    gauge = autodiff._gauge_entries(direct)
+    np.testing.assert_allclose(
+        staged_state[gauge], direct_state[gauge], rtol=0.0, atol=1.0e-14
+    )
+    # The remaining difference is the convergence floor at ftol = 1e-16: the
+    # R, Z blocks agree to 2e-8 and lambda (the slowest to converge) to 1.4e-6.
+    slices = autodiff._span_slices(direct)
+    for name, span in slices.items():
+        floor = 1.0e-5 if name.startswith("lambda") else 1.0e-7
+        np.testing.assert_allclose(
+            staged_state[span], direct_state[span], rtol=0.0, atol=floor
+        )
+
+    # The native gauge carries the multigrid history into the geometry: 4e-5 in
+    # z_cs (the gauge slot) and 5e-6 in the other R, Z blocks.
+    native_direct = _solve(_cth_like_input([25]), always_fix_m1_gauge=False)
+    native_staged = _solve(_cth_like_input([13, 25]), always_fix_m1_gauge=False)
+    native_difference = np.abs(
+        np.asarray(native_staged.get_state()) - np.asarray(native_direct.get_state())
+    )
+    assert native_difference[gauge].max() > 1.0e-6
+    assert native_difference[slices["r_cc"]].max() > 1.0e-6
+
+
+@pytest.mark.parametrize("always_fix_m1_gauge", [True, False])
+def test_exact_hvp_differentiates_the_force_with_the_same_gauge_flag(
+    always_fix_m1_gauge: bool,
+) -> None:
+    """At the initial guess fsqz is large, so the two flags select different forces:
+
+    the free-gauge force has nonzero gauge rows, the fixed-gauge force has none.
+    """
+    indata = _small_3d_input()
+    model = _vmecpp.VmecModel.create(indata._to_cpp_vmecindata(), 5)
+    _requires_exact_derivatives(model)
+    state = np.asarray(model.get_state(), dtype=np.float64).copy()
+    gauge = autodiff._gauge_entries(model)
+
+    def raw_force(value):
+        model.set_state(np.ascontiguousarray(value))
+        model.evaluate(2, 2, False, always_fix_m1_gauge)
+        return np.asarray(model.get_forces(), dtype=np.float64).copy()
+
+    generator = np.random.default_rng(0)
+    direction = generator.standard_normal(state.size)
+    direction /= np.linalg.norm(direction)
+    step = 1.0e-6
+    difference = (
+        raw_force(state + step * direction) - raw_force(state - step * direction)
+    ) / (2.0 * step)
+
+    model.set_state(np.ascontiguousarray(state))
+    model.evaluate(2, 2, True, always_fix_m1_gauge)
+    product = np.asarray(
+        model.exact_hessian_vector_product(
+            np.ascontiguousarray(direction), always_fix_m1_gauge
+        ),
+        dtype=np.float64,
+    )
+    assert np.linalg.norm(product - difference) < 1.0e-6 * np.linalg.norm(difference)
+    gauge_rows = np.abs(product[gauge]).max()
+    if always_fix_m1_gauge:
+        assert gauge_rows == 0.0
+    else:
+        assert gauge_rows > 1.0e-3 * np.abs(product).max()
+
+
+def _scalar_of_the_geometry(solver, mid: int):
+    def objective(boundary):
+        result = solver(boundary)
+        return jnp.sum(result.r_cc[mid, 1, :] ** 2) + jnp.sum(result.lambda_sc**2)
+
+    return objective
+
+
+def _richardson_central_difference(function, boundary, index, step):
+    def central(h):
+        plus = boundary.copy()
+        minus = boundary.copy()
+        plus[index] += h
+        minus[index] -= h
+        return (function(plus) - function(minus)) / (2.0 * h)
+
+    coarse = central(step)
+    fine = central(step / 2.0)
+    return (4.0 * fine - coarse) / 3.0, abs(fine - coarse)
+
+
+def test_implicit_vjp_matches_the_pinned_gauge_re_solve() -> None:
+    """The boundary gradient of a scalar of the geometry against Richardson-
+    extrapolated central differences of the pinned-gauge solve, for the n != 0 m = 1
+    modes whose linearized response the fixed-gauge Jacobian did not describe under the
+    native gauge, and for rbc(1, 0).
+
+    Measured: the adjoint agrees to 8e-6, 2e-6 and 6e-6 (relative), with the
+    two central differences (h, h/2) spread over 5e-6, 8e-6 and 7e-7. The same
+    differences of the native-gauge solve spread over 3e-5, 2e-5 and 3e-5 and
+    sit 3e-4, 1.2e-3 and 5e-4 away from the adjoint.
+    """
+    indata = _cth_like_input([25])
+    _requires_exact_derivatives(
+        _vmecpp.VmecModel.create(indata._to_cpp_vmecindata(), 25)
+    )
+    solver = autodiff.make_solver(indata)
+    boundary = _boundary(indata)
+    ntor = indata.ntor
+    objective = _scalar_of_the_geometry(solver, mid=12)
+
+    gradient = np.asarray(jax.grad(objective)(jnp.asarray(boundary)))
+
+    def value(candidate):
+        return float(objective(jnp.asarray(candidate)))
+
+    for index, step in (
+        ((0, 1, ntor + 1), 1.0e-4),  # rbc(1, +1)
+        ((1, 1, ntor - 1), 1.0e-4),  # zbs(1, -1)
+        ((0, 1, ntor), 1.0e-4),  # rbc(1, 0)
+    ):
+        reference, spread = _richardson_central_difference(value, boundary, index, step)
+        assert abs(gradient[index] - reference) < 1.0e-4 * abs(reference)
+        assert spread < 1.0e-4 * abs(reference)


### PR DESCRIPTION
# Pin the m=1 gauge in `VmecModel` so the equilibrium and its Jacobian are functions of the boundary

## Scope

`FourierCoeffs::m1Constraint` (`fourier_coefficients.cc`) stores, for every `m = 1, n >= 1` mode, the pair `(rss + zcs)/2` and `(rss - zcs)/2`; the second one, in the `zcs` slot, is a poloidal-angle origin per toroidal harmonic (`rss = zcs` is the quasi-polar constraint). `FourierForces::zeroZForceForM1` zeroes its force, but `IdealMhdModel::update` only does so when `always_fix_m1_gauge || fsqz < 1e-6 || iter2 < 2` (`ideal_mhd_model.cc`, around line 941). The native `solve()` therefore lets the gauge drift under its force during the first iterations and freezes it wherever it is once `fsqz < 1e-6`: the converged state is a history-dependent function of the boundary.

Measured on `examples/data/cth_like_fixed_bdy.json` with `ncurr = 0` and the wout's iota profile prescribed (`ai = [1.239, 0.328, -0.768]`), `ns = 25`, `ftol = 1e-16`:

- the gauge moves by 8.5e-5 during the native solve, against a gauge size of 7.4e-5;
- a direct `ns = 25` solve and a `13 -> 25` multigrid solve of the same boundary differ by 5e-6 in `r_cc`, 4e-5 in `z_cs` and 1.2e-3 in `lambda_cs`;
- `ExactHessianVectorProduct(Transpose)` in `pybind_vmec.cc` hard-wired `fix_m1_gauge = true` although the C++ kernels take the flag, so the Jacobian behind `vmecpp.autodiff` was the fixed-gauge one and did not describe the native solve.

This PR makes the fixed-gauge solve available on `VmecModel`, gives `evaluate` and the exact Hessian-vector products one gauge semantics, and lets `vmecpp.autodiff` solve and differentiate the pinned-gauge system. The native `run()` and the default `VmecModel.solve()` are unchanged.

## Tests and measurements

New `tests/test_m1_gauge.py` (cth_like, `ncurr = 0`, `ns = 25`, `ftol = 1e-16`, Enzyme-dependent tests skip without the exact Jacobian):

- `test_pinned_gauge_stays_at_the_boundary_interpolation`: the converged gauge entries equal the initial guess to 1e-12 (measured: 0.0) and equal `sqrt(s)` times the boundary gauge to 1e-15; the native solve moves them by 8.5e-5.
- `test_pinned_gauge_solve_is_independent_of_the_multigrid_history`: direct `ns 25` vs `13 -> 25`, pinned: gauge entries identical (0.0), `r_cc, r_ss, z_sc, z_cs` agree to 2.2e-8, 1.4e-8, 1.6e-8, 1.4e-8, `lambda_sc, lambda_cs` to 3.4e-7, 1.4e-6 (the convergence floor at `ftol = 1e-16`; `lambda_cs` converges slowest). Native: 5.4e-6, 5.6e-6, 5.4e-6, 4.0e-5, 1.3e-5, 1.2e-3.
- `test_exact_hvp_differentiates_the_force_with_the_same_gauge_flag[True|False]`: at the initial guess of the 3D solovev case (`fsqz` large, so the flags select different forces), the exact HVP matches central differences of `get_forces` evaluated with the same flag to 1e-6 relative; the gauge rows are exactly zero with the flag and O(1) without.
- `test_implicit_vjp_matches_the_pinned_gauge_re_solve`: gradient of `sum(r_cc[12, 1, :]**2) + sum(lambda_sc**2)` w.r.t. `rbc(1, +1)`, `zbs(1, -1)`, `rbc(1, 0)` against Richardson-extrapolated central differences (`h = 1e-4`, `h/2`) of the pinned-gauge re-solve:

  | mode | adjoint | Richardson FD (pinned) | rel. error | FD spread h vs h/2 (pinned) | FD spread (native) | native FD vs adjoint |
  |---|---|---|---|---|---|---|
  | `rbc(1,+1)` | -31.780242 | -31.780490 | 7.8e-6 | 5.1e-6 | 2.5e-5 | 3.2e-4 |
  | `zbs(1,-1)` | -8.891567 | -8.891547 | 2.2e-6 | 8.1e-6 | 1.6e-5 | 1.2e-3 |
  | `rbc(1,0)` | 10.249372 | 10.249315 | 5.6e-6 | 7.4e-7 | 3.0e-5 | 4.7e-4 |

  The test asserts agreement to 1e-4 and FD spread below 1e-4. The native-gauge finite differences are not reproducible below 2e-5 to 3e-5 between step sizes, and their extrapolated values sit 3e-4 to 1.2e-3 from the adjoint: with the free gauge there is no derivative at that level to compare against.

Cost and accuracy of the pinned solve, same case:

- force evaluations to convergence: 1405 native, 1405 pinned; `mhd_energy` 1.2810136e-3 both (reference at mpol 8, ntor 6: 1.2810131e-3);
- truncation error against a native `mpol 8, ntor 6` solve of the same boundary, max over the low modes: `r_cc` 4.04e-4 pinned vs 4.05e-4 native, `r_ss` 3.93e-4 vs 3.94e-4, `z_sc` 3.47e-4 vs 3.47e-4, `z_cs` 3.54e-4 vs 3.54e-4, `lambda_sc` 4.47e-3 vs 4.48e-3, `lambda_cs` 4.33e-3 vs 4.33e-3.

Existing tests: `tests/test_autodiff.py`, `test_geometry.py` (8 passed, 1 skipped: the no-Enzyme fallback test), `test_hessian.py`, `test_iteration.py`, `test_internal_gradient.py`, `test_preconditioner.py` (31 passed) with the Enzyme-enabled build, `OMP_NUM_THREADS=1`. `pre-commit` (clang-format, ruff, docformatter, pyright) passes on the changed files.

Runtime: `test_implicit_vjp_matches_the_pinned_gauge_re_solve` takes about 60 s, of which the adjoint GMRES solve (`rtol 1e-8`, restart 200) at ns 25, mpol 5, ntor 4 is the bulk; the 13 re-solves take under 2 s each.