### PR TITLE
JAX port of the wout output post processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,35 @@ vmec_input.niter_array = vmec_input.niter_array[-1:]
 hot_restarted_output = vmecpp.run(vmec_input, restart_from=vmec_output)
 ```
 
+## Differentiable runs
+
+`vmecpp.run(vmec_input, differentiable=True)` solves the same equilibrium through
+`vmecpp.autodiff` and returns the `wout` quantities (`rmnc`, `zmns`, `lmns`, `iotaf`,
+`bmnc`, `gmnc`, `bsubumnc`, `bsubvmnc`, `bsupumnc`, `bsupvmnc`, `bsubsmns`, `phi`, `chi`,
+`aspect`, `volume_p`, `volavgB`, `betatotal`, ...) as JAX arrays, so `jax.grad` can
+differentiate an objective written in them with respect to the boundary coefficients.
+The output stage is a JAX port of the C++ one (`vmecpp.autodiff_wout`); the solve and
+the exact adjoint of the force residual run in VMEC++. The path covers fixed-boundary,
+stellarator-symmetric, `ncurr = 0` inputs and the gradient needs a build with
+`-DVMECPP_ENABLE_ENZYME=ON`.
+
+```python
+import jax
+import jax.numpy as jnp
+import vmecpp
+from vmecpp import autodiff
+
+jax.config.update("jax_enable_x64", True)
+
+vmec_input = vmecpp.VmecInput.from_file("cth_like_fixed_bdy.json")
+result = vmecpp.run(vmec_input, differentiable=True)
+print(result.wout.aspect, result.wout.iotaf)
+
+# d(aspect ratio) / d(rbc, zbs): the boundary array is stack(rbc, zbs)
+boundary = jnp.stack([jnp.asarray(vmec_input.rbc), jnp.asarray(vmec_input.zbs)])
+gradient = jax.grad(lambda b: autodiff.run(vmec_input, boundary=b).wout.aspect)(boundary)
+```
+
 ## Full tests and validation against the reference Fortran VMEC v8.52
 
 When developing the C++ core, it's advisable to locally run the full C++ tests for debugging or to validate changes before submitting them.

--- a/src/vmecpp/__init__.py
+++ b/src/vmecpp/__init__.py
@@ -42,6 +42,9 @@ from vmecpp._pydantic_numpy import (
 from vmecpp._rescale import rescale
 from vmecpp.cpp import _vmecpp  # type: ignore # bindings to the C++ core
 
+if typing.TYPE_CHECKING:
+    from vmecpp import autodiff
+
 logger = logging.getLogger(__name__)
 
 
@@ -2466,6 +2469,7 @@ def _print_progress_tip_once() -> None:
         )
 
 
+@typing.overload
 def run(
     input: VmecInput,
     magnetic_field: MagneticFieldResponseTable | None = None,
@@ -2473,7 +2477,31 @@ def run(
     max_threads: int | None = None,
     verbose: bool | int | OutputMode = OutputMode.PROGRESS,
     restart_from: VmecOutput | None = None,
-) -> VmecOutput:
+    differentiable: typing.Literal[False] = False,
+) -> VmecOutput: ...
+
+
+@typing.overload
+def run(
+    input: VmecInput,
+    magnetic_field: MagneticFieldResponseTable | None = None,
+    *,
+    max_threads: int | None = None,
+    verbose: bool | int | OutputMode = OutputMode.PROGRESS,
+    restart_from: VmecOutput | None = None,
+    differentiable: typing.Literal[True],
+) -> autodiff.DifferentiableRun: ...
+
+
+def run(
+    input: VmecInput,
+    magnetic_field: MagneticFieldResponseTable | None = None,
+    *,
+    max_threads: int | None = None,
+    verbose: bool | int | OutputMode = OutputMode.PROGRESS,
+    restart_from: VmecOutput | None = None,
+    differentiable: bool = False,
+) -> VmecOutput | autodiff.DifferentiableRun:
     """Run VMEC++ using the provided input. This is the main entrypoint for both fixed-
     and free-boundary calculations.
 
@@ -2494,6 +2522,13 @@ def run(
             convergence when running VMEC++ on a configuration that is very similar to the `restart_from` equilibrium.
             If `input.mpol`/`input.ntor` is a sequence (see below), this is used to hot-restart
             only the first continuation step; later steps always hot-restart from the previous one.
+        differentiable: if True, solve through the JAX-differentiable path and return a
+            `vmecpp.autodiff.DifferentiableRun` whose `wout` arrays and `geometry` are JAX
+            pytrees; `jax.grad` through it yields derivatives with respect to the boundary
+            coefficients `stack(rbc, zbs)` (see `vmecpp.autodiff.run`). This path covers the
+            fixed-boundary, stellarator-symmetric, `ncurr = 0` case today and needs an
+            Enzyme-enabled build for the gradient; `magnetic_field` and `restart_from` are
+            not supported with it.
 
     If `input.mpol` and/or `input.ntor` is a sequence rather than a plain int, `run` performs
     continuation in Fourier resolution: each entry pairs with the corresponding `input.ns_array`
@@ -2510,6 +2545,14 @@ def run(
         0.2033313711
     """
     input = VmecInput.model_validate(input)
+
+    if differentiable:
+        if magnetic_field is not None or restart_from is not None:
+            msg = "differentiable=True does not support magnetic_field or restart_from"
+            raise ValueError(msg)
+        from vmecpp import autodiff  # noqa: PLC0415
+
+        return autodiff.run(input)
 
     if not isinstance(input.mpol, int) or not isinstance(input.ntor, int):
         return _run_fourier_continuation(

--- a/src/vmecpp/autodiff.py
+++ b/src/vmecpp/autodiff.py
@@ -25,7 +25,7 @@ import jax.numpy as jnp
 import numpy as np
 from scipy.sparse.linalg import LinearOperator, gmres
 
-from vmecpp import geometry
+from vmecpp import autodiff_wout, geometry
 from vmecpp.cpp import _vmecpp  # type: ignore
 
 _GEOMETRY_COEFFICIENTS = (
@@ -456,4 +456,51 @@ def make_solver(vmec_input) -> DifferentiableVmec:
     return DifferentiableVmec(vmec_input)
 
 
-__all__ = ["DifferentiableVmec", "make_solver"]
+@dataclass(frozen=True)
+class DifferentiableRun:
+    """The result of :func:`run`: ``wout`` arrays and the geometry they derive from."""
+
+    wout: autodiff_wout.WoutArrays
+    geometry: geometry.Geometry
+
+
+jax.tree_util.register_dataclass(
+    DifferentiableRun, data_fields=["wout", "geometry"], meta_fields=[]
+)
+
+
+def run(vmec_input, *, boundary=None) -> DifferentiableRun:
+    """Solve vmec_input and return its ``wout`` arrays as a differentiable pytree.
+
+    Args:
+        vmec_input: A fixed-boundary, stellarator-symmetric, ``ncurr = 0``
+            :class:`vmecpp.VmecInput`.
+        boundary: The boundary coefficients ``stack(rbc, zbs)`` of shape
+            ``(2, mpol, 2 * ntor + 1)``; defaults to the boundary of
+            ``vmec_input``. May be a JAX tracer, so the result can be
+            differentiated with respect to it.
+
+    Example:
+
+        result = autodiff.run(input)
+        gradient = jax.grad(lambda b: autodiff.run(input, boundary=b).wout.aspect)(
+            jnp.stack([input.rbc, input.zbs])
+        )
+
+    The solve runs through :func:`make_solver`; the output stage is the JAX
+    port in :mod:`vmecpp.autodiff_wout`. The VJP needs an Enzyme-enabled build.
+    """
+    solver = make_solver(vmec_input)
+    if boundary is None:
+        boundary = jnp.stack(
+            [
+                jnp.asarray(vmec_input.rbc, dtype=jnp.float64),
+                jnp.asarray(vmec_input.zbs, dtype=jnp.float64),
+            ]
+        )
+    solved = solver(boundary)
+    wout = autodiff_wout.wout_arrays(solved, vmec_input)
+    return DifferentiableRun(wout=wout, geometry=solved)
+
+
+__all__ = ["DifferentiableRun", "DifferentiableVmec", "make_solver", "run"]

--- a/src/vmecpp/autodiff_wout.py
+++ b/src/vmecpp/autodiff_wout.py
@@ -1,0 +1,836 @@
+"""JAX port of the VMEC++ output stage: ``wout`` arrays from a converged geometry.
+
+The solver returns the equilibrium as a :class:`vmecpp.geometry.Geometry` in the
+internal product basis. Objectives are usually written in the quantities of a
+``wout`` file. This module maps the geometry to those quantities with the same
+discretization as the C++ output stage: the full-grid inverse DFT with the odd-m
+``sqrt(s)`` scaling, the half-grid Jacobian, metric and magnetic field, the
+Nyquist-band forward DFT, and the radial interpolation rules of the profiles.
+
+Only the geometry leaves are traced. Radial grids, angular grids, mode tables,
+the toroidal-flux profile and the mass profile are concrete NumPy arrays taken
+from the input, so :func:`wout_arrays` works under ``jax.jit`` and ``jax.grad``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+import math
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from vmecpp import geometry as vmec_geometry
+
+MU_0 = 4.0e-7 * math.pi
+
+# Blending weight of the two full-grid estimates of B_v in the hybrid lambda
+# force, 2 * kPDamp * (1 - s) in the C++ radial profiles.
+_P_DAMP = 0.05
+
+# Weight of the odd-m correction term in the half-grid Jacobian.
+_D_S_HALF_D_S_INTERP = 0.25
+
+_WOUT_ARRAY_FIELDS = (
+    "rmnc",
+    "zmns",
+    "lmns",
+    "lmns_full",
+    "gmnc",
+    "bmnc",
+    "bsubumnc",
+    "bsubvmnc",
+    "bsupumnc",
+    "bsupvmnc",
+    "bsubsmns",
+    "iotas",
+    "iotaf",
+    "phi",
+    "chi",
+    "phipf",
+    "chipf",
+    "presf",
+    "pres",
+    "aspect",
+    "volume_p",
+    "volavgB",
+    "betatotal",
+    "b0",
+    "xm",
+    "xn",
+    "xm_nyq",
+    "xn_nyq",
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class WoutArrays:
+    """The ``wout`` quantities of an equilibrium as JAX arrays.
+
+    Two-dimensional Fourier arrays use the ``(mn, ns)`` layout of
+    :class:`vmecpp.VmecWOut`. Half-grid arrays (``lmns``, ``gmnc``, ``bmnc``,
+    ``bsub*``, ``bsup*``, ``iotas``, ``pres``) carry a zero in column 0;
+    ``bsubsmns`` carries the linear extrapolation of the classic output there.
+    """
+
+    rmnc: jax.Array
+    zmns: jax.Array
+    lmns: jax.Array
+    lmns_full: jax.Array
+    gmnc: jax.Array
+    bmnc: jax.Array
+    bsubumnc: jax.Array
+    bsubvmnc: jax.Array
+    bsupumnc: jax.Array
+    bsupvmnc: jax.Array
+    bsubsmns: jax.Array
+    iotas: jax.Array
+    iotaf: jax.Array
+    phi: jax.Array
+    chi: jax.Array
+    phipf: jax.Array
+    chipf: jax.Array
+    presf: jax.Array
+    pres: jax.Array
+    aspect: jax.Array
+    volume_p: jax.Array
+    volavgB: jax.Array
+    betatotal: jax.Array
+    b0: jax.Array
+    xm: jax.Array
+    xn: jax.Array
+    xm_nyq: jax.Array
+    xn_nyq: jax.Array
+
+
+jax.tree_util.register_dataclass(
+    WoutArrays, data_fields=list(_WOUT_ARRAY_FIELDS), meta_fields=[]
+)
+
+
+def wout_arrays(
+    geometry: vmec_geometry.Geometry, vmec_input: Any, *, iota_half=None
+) -> WoutArrays:
+    """Map a converged geometry to the ``wout`` arrays of the C++ output stage.
+
+    Args:
+        geometry: The solved equilibrium in the internal product basis.
+        vmec_input: The :class:`vmecpp.VmecInput` the geometry was solved for;
+            supplies the grid sizes, mode tables and the flux and mass profiles.
+        iota_half: Rotational transform on the half grid. Defaults to the ratio
+            of the poloidal and toroidal flux increments of ``geometry``.
+
+    The mass profile is evaluated in NumPy from the input and is not
+    differentiated. Stellarator-symmetric geometries only.
+    """
+    setup = _make_setup(vmec_input)
+    ns = setup.ns
+    delta_s = 1.0 / (ns - 1)
+
+    toroidal_flux = jnp.asarray(geometry.toroidal_flux)
+    poloidal_flux = jnp.asarray(geometry.poloidal_flux)
+    if iota_half is None:
+        iota_h = jnp.diff(poloidal_flux) / jnp.diff(toroidal_flux)
+    else:
+        iota_h = jnp.asarray(iota_half, dtype=toroidal_flux.dtype)
+    phip_f = jnp.asarray(setup.phip_full)
+    phip_h = jnp.asarray(setup.phip_half)
+    chip_h = iota_h * phip_h
+
+    # Inverse DFT to the full-grid real-space geometry, split by m parity.
+    r = _real_space(setup, geometry.r_cc, geometry.r_ss, cosine=True)
+    z = _real_space(setup, geometry.z_sc, geometry.z_cs, cosine=False)
+    # The solver normalizes lambda by lamscale / phi'; undo it so the theta
+    # derivative combines with phi' as in the C++ B^v.
+    scaled_lambda_sc = jnp.asarray(geometry.lambda_sc) * phip_f[:, None, None]
+    scaled_lambda_cs = jnp.asarray(geometry.lambda_cs) * phip_f[:, None, None]
+    lam = _real_space(
+        setup, scaled_lambda_sc, scaled_lambda_cs, cosine=False, extrapolate_m0=True
+    )
+
+    # Half-grid Jacobian and metric (jacobian_kernel.h, metric_kernel.h).
+    sqrt_s_h = jnp.asarray(setup.sqrt_s_half)[:, None, None]
+    s_f = jnp.asarray(setup.sqrt_s_full**2)[:, None, None]
+    s_i, s_o = s_f[:-1], s_f[1:]
+
+    def inner(x):
+        return x[:-1]
+
+    def outer(x):
+        return x[1:]
+
+    def half(even, odd):
+        return 0.5 * (
+            (inner(even) + outer(even)) + sqrt_s_h * (inner(odd) + outer(odd))
+        )
+
+    r12 = half(r.value_e, r.value_o)
+    ru12 = half(r.dtheta_e, r.dtheta_o)
+    zu12 = half(z.dtheta_e, z.dtheta_o)
+    rs = (
+        (outer(r.value_e) - inner(r.value_e))
+        + sqrt_s_h * (outer(r.value_o) - inner(r.value_o))
+    ) / delta_s
+    zs = (
+        (outer(z.value_e) - inner(z.value_e))
+        + sqrt_s_h * (outer(z.value_o) - inner(z.value_o))
+    ) / delta_s
+    tau1 = ru12 * zs - rs * zu12
+    tau2 = (
+        outer(r.dtheta_o) * outer(z.value_o)
+        + inner(r.dtheta_o) * inner(z.value_o)
+        - outer(z.dtheta_o) * outer(r.value_o)
+        - inner(z.dtheta_o) * inner(r.value_o)
+        + (
+            outer(r.dtheta_e) * outer(z.value_o)
+            + inner(r.dtheta_e) * inner(z.value_o)
+            - outer(z.dtheta_e) * outer(r.value_o)
+            - inner(z.dtheta_e) * inner(r.value_o)
+        )
+        / sqrt_s_h
+    )
+    tau = tau1 + _D_S_HALF_D_S_INTERP * tau2
+    gsqrt = tau * r12
+
+    def metric(a_e, a_o, b_e, b_o):
+        return 0.5 * (
+            inner(a_e) * inner(b_e)
+            + outer(a_e) * outer(b_e)
+            + s_i * inner(a_o) * inner(b_o)
+            + s_o * outer(a_o) * outer(b_o)
+        ) + 0.5 * sqrt_s_h * (
+            inner(a_e) * inner(b_o)
+            + outer(a_e) * outer(b_o)
+            + inner(b_e) * inner(a_o)
+            + outer(b_e) * outer(a_o)
+        )
+
+    guu = metric(r.dtheta_e, r.dtheta_o, r.dtheta_e, r.dtheta_o) + metric(
+        z.dtheta_e, z.dtheta_o, z.dtheta_e, z.dtheta_o
+    )
+    guv = metric(r.dtheta_e, r.dtheta_o, r.dzeta_e, r.dzeta_o) + metric(
+        z.dtheta_e, z.dtheta_o, z.dzeta_e, z.dzeta_o
+    )
+    gvv = (
+        metric(r.value_e, r.value_o, r.value_e, r.value_o)
+        + metric(r.dzeta_e, r.dzeta_o, r.dzeta_e, r.dzeta_o)
+        + metric(z.dzeta_e, z.dzeta_o, z.dzeta_e, z.dzeta_o)
+    )
+
+    # Contravariant field (bcontra_kernel.h): lambda enters as phi' (1 +
+    # d lambda / d theta) and -phi' d lambda / d zeta.
+    lu_e = lam.dtheta_e + phip_f[:, None, None]
+    lu_o = lam.dtheta_o
+    lv_e = -lam.dzeta_e
+    lv_o = -lam.dzeta_o
+    bsupv = half(lu_e, lu_o) / gsqrt
+    bsupu = half(lv_e, lv_o) / gsqrt + chip_h[:, None, None] / gsqrt
+    bsubu = guu * bsupu + guv * bsupv
+    bsubv = guv * bsupu + gvv * bsupv
+    magnetic_pressure = 0.5 * (bsupu * bsubu + bsupv * bsubv)
+    mod_b = jnp.sqrt(2.0 * jnp.abs(magnetic_pressure))
+
+    w_int = jnp.asarray(setup.w_int)[None, None, :]
+    signgs = setup.signgs
+    dvds_h = signgs * jnp.sum(gsqrt * w_int, axis=(1, 2))
+    mass_h = jnp.asarray(setup.mass_half)
+    pres_h = mass_h / dvds_h**setup.gamma if setup.gamma != 0.0 else mass_h
+    total_pressure = magnetic_pressure + pres_h[:, None, None]
+    bvco_h = jnp.sum(bsubv * w_int, axis=(1, 2))
+
+    # The output stage rebuilds B_v from the hybrid lambda force and then
+    # low-pass filters both covariant components to the solver's mode range.
+    bsubv_out = _low_pass(
+        setup, _blend_bsubv(setup, bsubv, bvco_h, gvv, gsqrt, guv, bsupu, lu_e, lu_o)
+    )
+    bsubu_out = _low_pass(setup, bsubu)
+
+    # Covariant B_s on the half grid (ComputeRemainingMetric, ComputeBSubSOnHalfGrid).
+    rv12 = half(r.dzeta_e, r.dzeta_o)
+    zv12 = half(z.dzeta_e, z.dzeta_o)
+    rs12 = rs + 0.5 * (inner(r.value_o) + outer(r.value_o)) / (2.0 * sqrt_s_h)
+    zs12 = zs + 0.5 * (inner(z.value_o) + outer(z.value_o)) / (2.0 * sqrt_s_h)
+    gsu = rs12 * ru12 + zs12 * zu12
+    gsv = rs12 * rv12 + zs12 * zv12
+    bsubs = bsupu * gsu + bsupv * gsv
+
+    # Nyquist-band forward DFT of the half-grid fields.
+    cos_kernel = jnp.asarray(setup.cos_kernel)
+    sin_kernel = jnp.asarray(setup.sin_kernel)
+
+    def half_grid_cos(field):
+        coefficients = jnp.einsum("jkl,mkl->mj", field, cos_kernel)
+        return jnp.pad(coefficients, ((0, 0), (1, 0)))
+
+    gmnc = half_grid_cos(gsqrt)
+    bmnc = half_grid_cos(mod_b)
+    bsubumnc = half_grid_cos(bsubu_out)
+    bsubvmnc = half_grid_cos(bsubv_out)
+    bsupumnc = half_grid_cos(bsupu)
+    bsupvmnc = half_grid_cos(bsupv)
+    bsubsmns = jnp.pad(jnp.einsum("jkl,mkl->mj", bsubs, sin_kernel), ((0, 0), (1, 0)))
+    # The classic output extrapolates the half-grid B_s one full step beyond
+    # the innermost half-grid point.
+    bsubsmns = bsubsmns.at[:, 0].set(2.0 * bsubsmns[:, 1] - bsubsmns[:, 2])
+
+    # Combined-basis coefficients of R, Z and lambda on the full grid.
+    rmnc = _to_combined(setup, geometry.r_cc, geometry.r_ss, cosine=True)
+    zmns = _to_combined(setup, geometry.z_sc, geometry.z_cs, cosine=False)
+    lmns_full = _to_combined(
+        setup, geometry.lambda_sc, geometry.lambda_cs, cosine=False
+    )
+    if setup.lthreed:
+        # The m = 0 lambda modes are not evolved at the axis; the output
+        # extrapolates them from the first two surfaces (in solver scaling).
+        m0 = setup.xm == 0
+        lambda_cs = jnp.asarray(geometry.lambda_cs)
+        axis = (
+            -(2.0 * lambda_cs[1, 0, :] * phip_f[1] - lambda_cs[2, 0, :] * phip_f[2])
+            / phip_f[0]
+        )
+        lmns_full = lmns_full.at[np.flatnonzero(m0), 0].set(axis)
+    lmns = _lambda_to_half_grid(setup, lmns_full)
+
+    # Radial profiles.
+    iota_f = _half_to_full(iota_h)
+    chip_f = _half_to_full(chip_h)
+    iotas = jnp.pad(iota_h, (1, 0))
+    chi = signgs * poloidal_flux
+    phipf = signgs * 2.0 * math.pi * phip_f
+    chipf = signgs * 2.0 * math.pi * chip_f
+    presf = _half_to_full(pres_h) / MU_0
+    pres = jnp.pad(pres_h, (1, 0)) / MU_0
+
+    # Scalars (ComputeThreed1GeometricMagneticQuantities).
+    w_lcfs = jnp.asarray(setup.w_int)[None, :]
+    r_lcfs = r.value_e[-1] + r.value_o[-1]
+    zu_lcfs = z.dtheta_e[-1] + z.dtheta_o[-1]
+    cross_area_p = 2.0 * math.pi * jnp.abs(jnp.sum(r_lcfs * zu_lcfs * w_lcfs))
+    volume_p = 2.0 * math.pi**2 * jnp.abs(jnp.sum(r_lcfs**2 * zu_lcfs * w_lcfs))
+    rmajor_p = volume_p / (2.0 * math.pi * cross_area_p)
+    aminor_p = jnp.sqrt(cross_area_p / math.pi)
+    aspect = rmajor_p / aminor_p
+
+    anorm = 2.0 * math.pi * delta_s
+    vnorm = 2.0 * math.pi * anorm
+    sump = vnorm * jnp.sum(dvds_h * pres_h)
+    tau_w = signgs * w_int * gsqrt
+    sumbtot = 2.0 * (vnorm * jnp.sum(total_pressure * tau_w) - sump)
+    betatotal = 2.0 * sump / sumbtot
+    volavgb = jnp.sqrt(jnp.abs(sumbtot / volume_p))
+    bvco_out = jnp.sum(bsubv_out * w_int, axis=(1, 2))
+    b0 = (1.5 * bvco_out[0] - 0.5 * bvco_out[1]) / r.value_e[0, 0, 0]
+
+    return WoutArrays(
+        rmnc=rmnc,
+        zmns=zmns,
+        lmns=lmns,
+        lmns_full=lmns_full,
+        gmnc=gmnc,
+        bmnc=bmnc,
+        bsubumnc=bsubumnc,
+        bsubvmnc=bsubvmnc,
+        bsupumnc=bsupumnc,
+        bsupvmnc=bsupvmnc,
+        bsubsmns=bsubsmns,
+        iotas=iotas,
+        iotaf=iota_f,
+        phi=toroidal_flux,
+        chi=chi,
+        phipf=phipf,
+        chipf=chipf,
+        presf=presf,
+        pres=pres,
+        aspect=aspect,
+        volume_p=volume_p,
+        volavgB=volavgb,
+        betatotal=betatotal,
+        b0=b0,
+        xm=jnp.asarray(setup.xm),
+        xn=jnp.asarray(setup.xn),
+        xm_nyq=jnp.asarray(setup.xm_nyq),
+        xn_nyq=jnp.asarray(setup.xn_nyq),
+    )
+
+
+def toroidal_flux_derivative(vmec_input: Any, s: np.ndarray) -> np.ndarray:
+    """``d phi / d s`` of the input flux profile, before the ``2 pi`` and sign
+    factors."""
+    aphi = np.asarray(vmec_input.aphi, dtype=np.float64)
+    if aphi.size == 0:
+        aphi = np.asarray([1.0])
+    powers = np.arange(1, aphi.size + 1)
+    derivative = np.polyval((powers * aphi)[::-1], s)
+    edge_flux = np.polyval(np.concatenate([aphi[::-1], [0.0]]), 1.0)
+    scale = vmec_input.signgs * vmec_input.phiedge * vmec_input.bloat / (2.0 * math.pi)
+    if edge_flux != 0.0:
+        scale /= edge_flux
+    return scale * derivative
+
+
+def mass_profile(vmec_input: Any, s_half: np.ndarray) -> np.ndarray:
+    """The half-grid mass profile ``mu_0 p`` of the C++ radial profiles."""
+    aphi = np.asarray(vmec_input.aphi, dtype=np.float64)
+    if aphi.size == 0:
+        aphi = np.asarray([1.0])
+    evaluation_position = np.minimum(s_half, vmec_input.spres_ped)
+    toroidal_flux = np.polyval(np.concatenate([aphi[::-1], [0.0]]), evaluation_position)
+    normalized = np.minimum(
+        np.abs(np.minimum(toroidal_flux, 1.0) * vmec_input.bloat), 1.0
+    )
+    pressure = _evaluate_profile(
+        vmec_input.pmass_type,
+        np.asarray(vmec_input.am, dtype=np.float64),
+        np.asarray(vmec_input.am_aux_s, dtype=np.float64),
+        np.asarray(vmec_input.am_aux_f, dtype=np.float64),
+        normalized,
+    )
+    mass = MU_0 * vmec_input.pres_scale * pressure
+    if vmec_input.gamma != 0.0:
+        r00 = float(np.asarray(vmec_input.rbc)[0, vmec_input.ntor])
+        phip_half = toroidal_flux_derivative(vmec_input, s_half)
+        mass = mass * (np.abs(phip_half) * r00) ** vmec_input.gamma
+    return mass
+
+
+@dataclasses.dataclass(frozen=True)
+class _RealSpace:
+    """Full-grid real-space values of one Fourier series, split by m parity.
+
+    Arrays have shape ``(ns, nzeta, ntheta_reduced)``; the odd-m part carries
+    the solver's ``1 / sqrt(s)`` scaling.
+    """
+
+    value_e: jax.Array
+    value_o: jax.Array
+    dtheta_e: jax.Array
+    dtheta_o: jax.Array
+    dzeta_e: jax.Array
+    dzeta_o: jax.Array
+
+
+@dataclasses.dataclass(frozen=True)
+class _Setup:
+    """Static grids, mode tables and profiles of one input (all NumPy)."""
+
+    ns: int
+    mpol: int
+    ntor: int
+    nfp: int
+    lthreed: bool
+    signgs: int
+    gamma: float
+    ntheta_reduced: int
+    nzeta: int
+    theta: np.ndarray
+    zeta: np.ndarray
+    w_int: np.ndarray
+    xm: np.ndarray
+    xn: np.ndarray
+    xm_nyq: np.ndarray
+    xn_nyq: np.ndarray
+    sqrt_s_full: np.ndarray
+    sqrt_s_half: np.ndarray
+    odd_scale: np.ndarray
+    phip_full: np.ndarray
+    phip_half: np.ndarray
+    mass_half: np.ndarray
+    radial_blending: np.ndarray
+    cos_kernel: np.ndarray
+    sin_kernel: np.ndarray
+    low_pass_analysis: tuple[np.ndarray, np.ndarray]
+    low_pass_synthesis: tuple[np.ndarray, np.ndarray]
+
+
+def _make_setup(vmec_input: Any) -> _Setup:
+    if vmec_input.lasym:
+        error_message = (
+            "wout_arrays requires a stellarator-symmetric input (lasym=false)"
+        )
+        raise ValueError(error_message)
+    if not isinstance(vmec_input.mpol, int) or not isinstance(vmec_input.ntor, int):
+        error_message = "wout_arrays requires scalar mpol and ntor"
+        raise ValueError(error_message)
+    mpol = vmec_input.mpol
+    ntor = vmec_input.ntor
+    nfp = vmec_input.nfp
+    ns = int(np.asarray(vmec_input.ns_array)[-1])
+    if ns < 3:
+        error_message = "wout_arrays requires ns >= 3"
+        raise ValueError(error_message)
+
+    # Sizes::computeDerivedSizes
+    ntheta = max(vmec_input.ntheta, 2 * mpol + 6)
+    ntheta_even = 2 * (ntheta // 2)
+    ntheta_reduced = ntheta_even // 2 + 1
+    nzeta = (
+        max(vmec_input.nzeta, 1) if ntor == 0 else max(vmec_input.nzeta, 2 * ntor + 4)
+    )
+    mnyq = max(0, ntheta_even // 2, mpol - 1)
+    nnyq = max(0, nzeta // 2, ntor)
+
+    theta = 2.0 * math.pi * np.arange(ntheta_reduced) / ntheta_even
+    zeta = 2.0 * math.pi * np.arange(nzeta) / nzeta
+    w_int = np.full(ntheta_reduced, 1.0 / (nzeta * (ntheta_reduced - 1)))
+    w_int[0] /= 2.0
+    w_int[-1] /= 2.0
+
+    xm, xn = _mode_table(mpol, ntor, nfp)
+    xm_nyq, xn_nyq = _mode_table(mnyq + 1, nnyq, nfp)
+
+    s_full = np.arange(ns) / (ns - 1.0)
+    sqrt_s_full = np.sqrt(s_full)
+    sqrt_s_full[-1] = 1.0
+    sqrt_s_half = np.sqrt((np.arange(ns - 1) + 0.5) / (ns - 1.0))
+    # Odd-m coefficients are divided by sqrt(s), the axis taking the value of
+    # the first surface (RadialProfiles::scalxc).
+    odd_scale = 1.0 / np.maximum(sqrt_s_full, math.sqrt(1.0 / (ns - 1)))
+
+    phip_full = toroidal_flux_derivative(vmec_input, s_full)
+    phip_half = toroidal_flux_derivative(vmec_input, sqrt_s_half**2)
+    mass_half = mass_profile(vmec_input, sqrt_s_half**2)
+    radial_blending = 2.0 * _P_DAMP * (1.0 - s_full)
+
+    cos_kernel, sin_kernel = _nyquist_kernels(
+        theta, zeta, ntheta_reduced, nzeta, mnyq, nnyq, xm_nyq, xn_nyq // nfp
+    )
+    low_pass_analysis, low_pass_synthesis = _low_pass_kernels(
+        theta, zeta, ntheta_reduced, nzeta, mpol, ntor, mnyq, nnyq
+    )
+
+    return _Setup(
+        ns=ns,
+        mpol=mpol,
+        ntor=ntor,
+        nfp=nfp,
+        lthreed=ntor > 0,
+        signgs=int(vmec_input.signgs),
+        gamma=float(vmec_input.gamma),
+        ntheta_reduced=ntheta_reduced,
+        nzeta=nzeta,
+        theta=theta,
+        zeta=zeta,
+        w_int=w_int,
+        xm=xm,
+        xn=xn,
+        xm_nyq=xm_nyq,
+        xn_nyq=xn_nyq,
+        sqrt_s_full=sqrt_s_full,
+        sqrt_s_half=sqrt_s_half,
+        odd_scale=odd_scale,
+        phip_full=phip_full,
+        phip_half=phip_half,
+        mass_half=mass_half,
+        radial_blending=radial_blending,
+        cos_kernel=cos_kernel,
+        sin_kernel=sin_kernel,
+        low_pass_analysis=low_pass_analysis,
+        low_pass_synthesis=low_pass_synthesis,
+    )
+
+
+def _mode_table(m_size: int, n_size: int, nfp: int) -> tuple[np.ndarray, np.ndarray]:
+    xm = [0] * (n_size + 1)
+    xn = list(range(n_size + 1))
+    for m in range(1, m_size):
+        xm.extend([m] * (2 * n_size + 1))
+        xn.extend(range(-n_size, n_size + 1))
+    return np.asarray(xm, dtype=np.int64), nfp * np.asarray(xn, dtype=np.int64)
+
+
+def _nyquist_kernels(
+    theta, zeta, ntheta_reduced, nzeta, mnyq, nnyq, xm_nyq, n_nyq
+) -> tuple[np.ndarray, np.ndarray]:
+    """Dense forward-DFT kernels ``(mn, k, l)`` for cos(mu - nv) and sin(mu - nv)."""
+    m = np.arange(mnyq + 1)
+    mscale = np.where(m == 0, 1.0, math.sqrt(2.0))
+    int_norm = 1.0 / (nzeta * (ntheta_reduced - 1))
+    cosmui = np.cos(np.outer(m, theta)) * mscale[:, None] * int_norm
+    sinmui = np.sin(np.outer(m, theta)) * mscale[:, None] * int_norm
+    cosmui[:, 0] /= 2.0
+    cosmui[:, -1] /= 2.0
+    if mnyq != 0:
+        cosmui[mnyq] /= 2.0
+
+    n = np.arange(nnyq + 1)
+    nscale = np.where(n == 0, 1.0, math.sqrt(2.0))
+    cosnv = np.cos(np.outer(zeta, n)) * nscale[None, :]
+    sinnv = np.sin(np.outer(zeta, n)) * nscale[None, :]
+    if nnyq != 0:
+        cosnv[:, nnyq] /= 2.0
+
+    abs_n = np.abs(n_nyq)
+    sign_n = np.sign(n_nyq)
+    dmult = mscale[xm_nyq] * nscale[abs_n] * 0.5
+    dmult = np.where((xm_nyq == 0) | (n_nyq == 0), 2.0 * dmult, dmult)
+    cos_kernel = dmult[:, None, None] * (
+        cosnv[:, abs_n].T[:, :, None] * cosmui[xm_nyq][:, None, :]
+        + sign_n[:, None, None]
+        * sinnv[:, abs_n].T[:, :, None]
+        * sinmui[xm_nyq][:, None, :]
+    )
+    sin_kernel = dmult[:, None, None] * (
+        cosnv[:, abs_n].T[:, :, None] * sinmui[xm_nyq][:, None, :]
+        - sign_n[:, None, None]
+        * sinnv[:, abs_n].T[:, :, None]
+        * cosmui[xm_nyq][:, None, :]
+    )
+    return cos_kernel, sin_kernel
+
+
+def _low_pass_kernels(
+    theta, zeta, ntheta_reduced, nzeta, mpol, ntor, mnyq, nnyq
+) -> tuple[tuple[np.ndarray, np.ndarray], tuple[np.ndarray, np.ndarray]]:
+    """Projection onto the ``m < mpol, n <= ntor`` cos-cos and sin-sin modes.
+
+    Returns the analysis kernels ``(mn, k, l)`` and the synthesis kernels of
+    the two parities (LowPassFilterCovariantB).
+    """
+    m = np.arange(mpol)
+    n = np.arange(ntor + 1)
+    mscale = np.where(m == 0, 1.0, math.sqrt(2.0))
+    nscale = np.where(n == 0, 1.0, math.sqrt(2.0))
+    int_norm = 1.0 / (nzeta * (ntheta_reduced - 1))
+    cosmu = np.cos(np.outer(m, theta)) * mscale[:, None]
+    sinmu = np.sin(np.outer(m, theta)) * mscale[:, None]
+    cosmui = cosmu * int_norm
+    sinmui = sinmu * int_norm
+    cosmui[:, 0] /= 2.0
+    cosmui[:, -1] /= 2.0
+    cosnv = np.cos(np.outer(zeta, n)) * nscale[None, :]
+    sinnv = np.sin(np.outer(zeta, n)) * nscale[None, :]
+    dnorm = np.ones((mpol, ntor + 1))
+    dnorm[m == mnyq, :] /= 2.0
+    dnorm[:, (n == nnyq) & (n != 0)] /= 2.0
+
+    def kernel(poloidal, toroidal, weight):
+        return (
+            weight[:, :, None, None]
+            * poloidal[:, None, None, :]
+            * toroidal.T[None, :, :, None]
+        ).reshape(mpol * (ntor + 1), nzeta, ntheta_reduced)
+
+    analysis = (kernel(cosmui, cosnv, dnorm), kernel(sinmui, sinnv, dnorm))
+    synthesis = (
+        kernel(cosmu, cosnv, np.ones_like(dnorm)),
+        kernel(sinmu, sinnv, np.ones_like(dnorm)),
+    )
+    return analysis, synthesis
+
+
+def _low_pass(setup: _Setup, field: jax.Array) -> jax.Array:
+    """Fourier low-pass filter of a half-grid field to the solver's mode range."""
+    parts = [
+        jnp.einsum(
+            "jm,mkl->jkl",
+            jnp.einsum("jkl,mkl->jm", field, jnp.asarray(analysis)),
+            jnp.asarray(synthesis),
+        )
+        for analysis, synthesis in zip(
+            setup.low_pass_analysis, setup.low_pass_synthesis, strict=True
+        )
+    ]
+    return functools.reduce(jnp.add, parts)
+
+
+def _evaluate_profile(
+    kind: str, coefficients, knots, values, x: np.ndarray
+) -> np.ndarray:
+    if kind == "power_series":
+        return (
+            np.polyval(coefficients[::-1], x) if coefficients.size else np.zeros_like(x)
+        )
+    if kind == "two_power":
+        if coefficients.size < 3:
+            return np.zeros_like(x)
+        return coefficients[0] * (1.0 - x ** coefficients[1]) ** coefficients[2]
+    if kind == "line_segment":
+        n = min(knots.size, values.size)
+        if n < 2:
+            return np.zeros_like(x)
+        # Linear on each knot interval and along the end segments outside.
+        low = np.clip(np.searchsorted(knots[:n], x, side="right") - 1, 0, n - 2)
+        t = (x - knots[low]) / (knots[low + 1] - knots[low])
+        return (1.0 - t) * values[low] + t * values[low + 1]
+    error_message = f"wout_arrays does not evaluate the '{kind}' mass profile"
+    raise NotImplementedError(error_message)
+
+
+def _prepare_coefficients(
+    setup: _Setup, coefficients, *, extrapolate_m0: bool
+) -> jax.Array:
+    """Apply the axis rules and the odd-m scaling of the solver's inverse DFT."""
+    c = jnp.asarray(coefficients)
+    m = np.arange(setup.mpol)
+    # At the axis only m = 0 and m = 1 contribute, and the m = 1 modes (plus
+    # the m = 0 lambda modes) take the value of the first surface.
+    axis = jnp.where((m <= 1)[:, None], c[0], 0.0)
+    if setup.mpol > 1:
+        axis = axis.at[1].set(c[1, 1])
+    if extrapolate_m0:
+        axis = axis.at[0].set(c[1, 0])
+    c = c.at[0].set(axis)
+    scale = np.where((m % 2 == 1)[None, :], setup.odd_scale[:, None], 1.0)
+    return c * scale[:, :, None]
+
+
+def _real_space(
+    setup: _Setup, first, second, *, cosine: bool, extrapolate_m0: bool = False
+) -> _RealSpace:
+    """Inverse DFT of one product-basis series onto the reduced angular grid.
+
+    ``cosine=True`` reads ``first, second`` as the ``cc, ss`` coefficients of a
+    cosine-type quantity; ``cosine=False`` as the ``sc, cs`` coefficients of a
+    sine-type quantity.
+    """
+    a = _prepare_coefficients(setup, first, extrapolate_m0=extrapolate_m0)
+    b = _prepare_coefficients(setup, second, extrapolate_m0=extrapolate_m0)
+    m = np.arange(setup.mpol, dtype=np.float64)
+    n = setup.nfp * np.arange(setup.ntor + 1, dtype=np.float64)
+    cos_m = np.cos(np.outer(m, setup.theta))
+    sin_m = np.sin(np.outer(m, setup.theta))
+    cos_n = np.cos(np.outer(n / setup.nfp, setup.zeta))
+    sin_n = np.sin(np.outer(n / setup.nfp, setup.zeta))
+    d_cos_m = -m[:, None] * sin_m
+    d_sin_m = m[:, None] * cos_m
+    d_cos_n = -n[:, None] * sin_n
+    d_sin_n = n[:, None] * cos_n
+    even = (np.arange(setup.mpol) % 2 == 0).astype(np.float64)
+    odd = 1.0 - even
+
+    if cosine:
+        terms = (
+            (a, cos_m, d_cos_m, cos_n, d_cos_n),
+            (b, sin_m, d_sin_m, sin_n, d_sin_n),
+        )
+    else:
+        terms = (
+            (a, sin_m, d_sin_m, cos_n, d_cos_n),
+            (b, cos_m, d_cos_m, sin_n, d_sin_n),
+        )
+
+    def series(parity, poloidal, toroidal):
+        parts = []
+        for coefficient, p, dp, q, dq in terms:
+            masked = coefficient * parity[None, :, None]
+            pol = {"value": p, "dtheta": dp}[poloidal]
+            tor = {"value": q, "dzeta": dq}[toroidal]
+            parts.append(jnp.einsum("jmn,ml,nk->jkl", masked, pol, tor))
+        return functools.reduce(jnp.add, parts)
+
+    return _RealSpace(
+        value_e=series(even, "value", "value"),
+        value_o=series(odd, "value", "value"),
+        dtheta_e=series(even, "dtheta", "value"),
+        dtheta_o=series(odd, "dtheta", "value"),
+        dzeta_e=series(even, "value", "dzeta"),
+        dzeta_o=series(odd, "value", "dzeta"),
+    )
+
+
+def _blend_bsubv(setup, bsubv, bvco_h, gvv, gsqrt, guv, bsupu, lu_e, lu_o) -> jax.Array:
+    """The half-grid B_v of the output stage.
+
+    The output stage rebuilds the half-grid B_v from the full-grid estimate of the
+    hybrid lambda force (MeshBledingBSubZeta) and restores the enclosed poloidal current
+    on every surface (FixupPoloidalCurrent).
+    """
+    ns = setup.ns
+    zero = jnp.zeros_like(bsubv[:1])
+    bsubv_i = jnp.concatenate([zero, bsubv])
+    bsubv_o = jnp.concatenate([bsubv, zero])
+    gvv_gsqrt = gvv / gsqrt
+    gg_i = jnp.concatenate([zero, gvv_gsqrt])
+    gg_o = jnp.concatenate([gvv_gsqrt, zero])
+    guv_bsupu = guv * bsupu
+    gb_i = jnp.concatenate([zero, guv_bsupu])
+    gb_o = jnp.concatenate([guv_bsupu, zero])
+    sqrt_h = jnp.asarray(setup.sqrt_s_half)
+    s_i = jnp.concatenate([jnp.zeros(1), sqrt_h])[:, None, None]
+    s_o = jnp.concatenate([sqrt_h, jnp.zeros(1)])[:, None, None]
+
+    alternative = 0.5 * (gg_i + gg_o) * lu_e + 0.5 * (gg_i * s_i + gg_o * s_o) * lu_o
+    if setup.lthreed:
+        alternative = alternative + 0.5 * (gb_i + gb_o)
+    average = 0.5 * (bsubv_o + bsubv_i)
+    blending = jnp.asarray(setup.radial_blending)[:, None, None]
+    bsubv_full = average * (1.0 - blending) + alternative * blending
+
+    # bsubv[jH] = 2 bsubv_full[jH + 1] - bsubv[jH + 1], swept inward from the
+    # unchanged outermost half-grid point.
+    j = np.arange(1, ns - 1)
+    signed = ((-1.0) ** j)[:, None, None] * bsubv_full[1 : ns - 1]
+    tail_sum = jnp.cumsum(signed[::-1], axis=0)[::-1]
+    j_h = np.arange(ns - 2)
+    blended = ((-1.0) ** (j_h + 1))[:, None, None] * 2.0 * tail_sum + (
+        (-1.0) ** (ns - 2 - j_h)
+    )[:, None, None] * bsubv[ns - 2]
+    bsubv_blended = jnp.concatenate([blended, bsubv[ns - 2 :]])
+
+    w_int = jnp.asarray(setup.w_int)[None, None, :]
+    deviation = jnp.sum(bsubv_blended * w_int, axis=(1, 2)) - bvco_h
+    return bsubv_blended - deviation[:, None, None]
+
+
+def _to_combined(setup: _Setup, first, second, *, cosine: bool) -> jax.Array:
+    """Product to combined basis in the ``(mn, ns)`` layout of the ``wout`` file."""
+    a = jnp.asarray(first)
+    b = jnp.asarray(second)
+    m = setup.xm
+    n = setup.xn // setup.nfp
+    abs_n = np.abs(n)
+    sign_n = np.sign(n).astype(np.float64)
+    a_mn = a[:, m, abs_n].T
+    b_mn = b[:, m, abs_n].T
+    sign_b = 1.0 if cosine else -1.0
+    m0_value = a_mn if cosine else -b_mn
+    combined = jnp.where(
+        (m == 0)[:, None],
+        m0_value,
+        jnp.where(
+            (n == 0)[:, None], a_mn, 0.5 * (a_mn + sign_b * sign_n[:, None] * b_mn)
+        ),
+    )
+    # m > 0, n != 0 modes are not stored at the axis.
+    axis_mask = ((m > 0) & (n != 0))[:, None] & (np.arange(setup.ns) == 0)[None, :]
+    return jnp.where(axis_mask, 0.0, combined)
+
+
+def _lambda_to_half_grid(setup: _Setup, lmns_full: jax.Array) -> jax.Array:
+    """Radial interpolation of lambda onto the half grid (classic ``lmns``)."""
+    ns = setup.ns
+    sm = setup.sqrt_s_half / setup.sqrt_s_full[1:]
+    sp = np.empty_like(sm)
+    sp[1:] = setup.sqrt_s_half[1:] / setup.sqrt_s_full[1:-1]
+    sp[0] = sm[0]
+    outside = lmns_full[:, 1:]
+    inside = lmns_full[:, :-1]
+    low_m = (setup.xm <= 1)[:, None] & (np.arange(ns - 1) == 0)[None, :]
+    inside = jnp.where(low_m, outside, inside)
+    odd = (setup.xm % 2 == 1)[:, None]
+    half = jnp.where(
+        odd,
+        0.5 * (sm[None, :] * outside + sp[None, :] * inside),
+        0.5 * (outside + inside),
+    )
+    return jnp.pad(half, ((0, 0), (1, 0)))
+
+
+def _half_to_full(values_half: jax.Array) -> jax.Array:
+    """Average onto the interior full grid, extrapolate linearly to axis and edge."""
+    axis = 1.5 * values_half[0] - 0.5 * values_half[1]
+    edge = 1.5 * values_half[-1] - 0.5 * values_half[-2]
+    interior = 0.5 * (values_half[1:] + values_half[:-1])
+    return jnp.concatenate([axis[None], interior, edge[None]])
+
+
+__all__ = [
+    "MU_0",
+    "WoutArrays",
+    "mass_profile",
+    "toroidal_flux_derivative",
+    "wout_arrays",
+]

--- a/tests/test_autodiff_wout.py
+++ b/tests/test_autodiff_wout.py
@@ -1,0 +1,245 @@
+"""The JAX output stage against the C++ one, and gradients through it."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import vmecpp
+from vmecpp import autodiff, autodiff_wout, geometry
+from vmecpp.cpp import _vmecpp  # type: ignore
+
+jax.config.update("jax_enable_x64", True)
+
+# Every array of WoutArrays with a counterpart in VmecWOut. The full-grid
+# lambda is compared as lmns_full and, in its classic half-grid form, as lmns.
+_COMPARED_ARRAYS = (
+    "rmnc",
+    "zmns",
+    "lmns",
+    "lmns_full",
+    "gmnc",
+    "bmnc",
+    "bsubumnc",
+    "bsubvmnc",
+    "bsupumnc",
+    "bsupvmnc",
+    "bsubsmns",
+    "iotas",
+    "iotaf",
+    "phi",
+    "chi",
+    "phipf",
+    "chipf",
+    "presf",
+    "pres",
+    "xm",
+    "xn",
+    "xm_nyq",
+    "xn_nyq",
+    "aspect",
+    "volume_p",
+    "volavgB",
+    "betatotal",
+    "b0",
+)
+
+
+def _cth_like_input(
+    ns: int = 15, ftol: float = 1.0e-16, niter: int = 5000
+) -> vmecpp.VmecInput:
+    """The CTH-like fixed-boundary case with a prescribed iota profile."""
+    source = vmecpp.VmecInput.from_file("examples/data/cth_like_fixed_bdy.json")
+    return source.model_copy(
+        update={
+            "ncurr": 0,
+            "piota_type": "power_series",
+            "ai": np.asarray([0.35, 0.15]),
+            "ns_array": np.asarray([ns]),
+            "ftol_array": np.asarray([ftol]),
+            "niter_array": np.asarray([niter]),
+        }
+    )
+
+
+def _small_w7x_input() -> vmecpp.VmecInput:
+    source = vmecpp.VmecInput.from_file("examples/data/w7x.json")
+    mpol, ntor = 5, 4
+    return source.model_copy(
+        update={
+            "mpol": mpol,
+            "ntor": ntor,
+            "rbc": vmecpp.VmecInput.resize_2d_coeff(source.rbc, mpol, ntor),
+            "zbs": vmecpp.VmecInput.resize_2d_coeff(source.zbs, mpol, ntor),
+            "raxis_c": np.asarray(source.raxis_c)[: ntor + 1],
+            "zaxis_s": np.asarray(source.zaxis_s)[: ntor + 1],
+            "ncurr": 0,
+            "piota_type": "power_series",
+            "ai": np.asarray([0.85, 0.15]),
+            "ns_array": np.asarray([11]),
+            "ftol_array": np.asarray([1.0e-14]),
+            "niter_array": np.asarray([5000]),
+        }
+    )
+
+
+def _boundary(indata: vmecpp.VmecInput) -> jax.Array:
+    return jnp.stack([jnp.asarray(indata.rbc), jnp.asarray(indata.zbs)])
+
+
+def _requires_exact_derivatives(indata: vmecpp.VmecInput) -> None:
+    ns = int(np.asarray(indata.ns_array)[-1])
+    model = _vmecpp.VmecModel.create(indata._to_cpp_vmecindata(), ns)
+    if not model.has_exact_force_jacobian:
+        pytest.skip("needs an Enzyme-enabled build for the exact residual transpose")
+
+
+def _reference(name: str, wout: vmecpp.VmecWOut) -> np.ndarray:
+    return np.asarray(getattr(wout, name))
+
+
+@pytest.fixture(scope="module", params=["cth_like", "w7x_small"])
+def solved_case(request):
+    indata = _cth_like_input() if request.param == "cth_like" else _small_w7x_input()
+    output = _vmecpp.run(
+        indata._to_cpp_vmecindata(), verbose=_vmecpp.OutputMode.SILENT, max_threads=1
+    )
+    wout = vmecpp.VmecWOut._from_cpp_wout(output.wout)
+    return indata, geometry.make(output), wout
+
+
+def test_wout_arrays_match_the_cpp_output_stage(solved_case) -> None:
+    """Every array of the port against the C++ output stage of the same state.
+
+    The geometry is taken from the completed C++ run, so the comparison isolates the
+    output stage from the solve. Tolerance is roundoff relative to the largest entry of
+    each array.
+    """
+    indata, solved, wout = solved_case
+    actual = autodiff_wout.wout_arrays(solved, indata)
+    for name in _COMPARED_ARRAYS:
+        expected = _reference(name, wout)
+        value = np.asarray(getattr(actual, name))
+        assert value.shape == expected.shape, name
+        scale = max(float(np.abs(expected).max()), 1.0e-300)
+        difference = float(np.abs(value - expected).max())
+        print(f"{name}: max abs diff {difference:.3e} (max |ref| {scale:.3e})")
+        np.testing.assert_allclose(value, expected, rtol=0.0, atol=1.0e-12 * scale)
+
+
+def test_wout_arrays_accept_a_prescribed_iota(solved_case) -> None:
+    indata, solved, wout = solved_case
+    iota_half = np.asarray(wout.iotas)[1:]
+    actual = autodiff_wout.wout_arrays(solved, indata, iota_half=iota_half)
+    np.testing.assert_allclose(np.asarray(actual.iotas), wout.iotas, atol=1.0e-15)
+    np.testing.assert_allclose(np.asarray(actual.bsupumnc), wout.bsupumnc, atol=1.0e-13)
+
+
+def test_run_matches_vmecpp_run() -> None:
+    """The differentiable entry point re-solves through VmecModel; the two solver paths
+    agree to the force tolerance."""
+    indata = _cth_like_input()
+    reference = vmecpp.run(indata, max_threads=1, verbose=False).wout
+    result = autodiff.run(indata)
+    for name in ("rmnc", "zmns", "bmnc", "gmnc", "iotaf"):
+        np.testing.assert_allclose(
+            np.asarray(getattr(result.wout, name)),
+            _reference(name, reference),
+            rtol=0.0,
+            atol=1.0e-9 * float(np.abs(_reference(name, reference)).max()),
+        )
+    np.testing.assert_allclose(float(result.wout.aspect), reference.aspect, rtol=1.0e-9)
+    np.testing.assert_allclose(
+        float(result.wout.volume_p), reference.volume_p, rtol=1.0e-9
+    )
+
+
+def test_vmecpp_run_differentiable_flag_dispatches() -> None:
+    indata = _cth_like_input()
+    result = vmecpp.run(indata, differentiable=True)
+    assert isinstance(result, autodiff.DifferentiableRun)
+    assert isinstance(result.wout, autodiff_wout.WoutArrays)
+    assert result.wout.bmnc.shape == (len(result.wout.xm_nyq), 15)
+    with pytest.raises(ValueError, match="restart_from"):
+        vmecpp.run(
+            indata, differentiable=True, restart_from=vmecpp.run(indata, verbose=False)
+        )
+
+
+def test_run_is_usable_under_jit() -> None:
+    indata = _cth_like_input()
+
+    @jax.jit
+    def aspect(boundary):
+        return autodiff.run(indata, boundary=boundary).wout.aspect
+
+    value = aspect(_boundary(indata))
+    assert np.isfinite(float(value))
+    reference = autodiff.run(indata).wout.aspect
+    np.testing.assert_allclose(float(value), float(reference), rtol=1.0e-12)
+
+
+def test_wout_arrays_are_a_pytree() -> None:
+    indata = _cth_like_input()
+    result = autodiff.run(indata)
+    leaves = jax.tree_util.tree_leaves(result)
+    assert all(isinstance(leaf, jax.Array) for leaf in leaves)
+    rebuilt = jax.tree_util.tree_unflatten(jax.tree_util.tree_structure(result), leaves)
+    np.testing.assert_array_equal(
+        np.asarray(rebuilt.wout.bmnc), np.asarray(result.wout.bmnc)
+    )
+
+
+def _quasisymmetry_proxy(wout: autodiff_wout.WoutArrays) -> jax.Array:
+    mid = wout.bmnc.shape[1] // 2
+    return jnp.sum(wout.bmnc[1:, mid] ** 2) / wout.bmnc[0, mid] ** 2
+
+
+def _low_mode_direction(indata: vmecpp.VmecInput, seed: int) -> np.ndarray:
+    """A random direction on the m <= 2, |n| <= 1 boundary modes, relative size 1e-3."""
+    boundary = np.asarray(_boundary(indata))
+    generator = np.random.default_rng(seed)
+    direction = np.zeros_like(boundary)
+    ntor = indata.ntor
+    low = generator.standard_normal((2, 3, 3))
+    low[1, 0, 1] = 0.0  # zbs(m=0, n=0) is not a degree of freedom
+    direction[:, :3, ntor - 1 : ntor + 2] = low
+    return direction / np.linalg.norm(direction) * 1.0e-3 * np.linalg.norm(boundary)
+
+
+@pytest.mark.parametrize("seed", [0, 1])
+@pytest.mark.parametrize("objective_name", ["aspect", "quasisymmetry_proxy"])
+def test_gradient_matches_central_differences(objective_name: str, seed: int) -> None:
+    """jax.grad through the solve and the output stage against a central difference of
+    the fully re-solved pipeline.
+
+    With ftol = 1e-14 the re-solve noise in the objective is far below the difference
+    quotient (floor of order 1e-8 relative at a 1e-3 relative step); the remaining
+    discrepancy is the O(h^2) truncation of the central difference and the 1e-8 adjoint
+    solve tolerance, measured at 1e-5 to 6e-5 relative.
+    """
+    indata = _cth_like_input(ns=25, ftol=1.0e-14, niter=20000)
+    _requires_exact_derivatives(indata)
+
+    def objective(boundary):
+        wout = autodiff.run(indata, boundary=boundary).wout
+        if objective_name == "aspect":
+            return wout.aspect
+        return _quasisymmetry_proxy(wout)
+
+    boundary = _boundary(indata)
+    value, gradient = jax.value_and_grad(objective)(boundary)
+    gradient = np.asarray(gradient)
+    assert np.all(np.isfinite(gradient))
+
+    direction = _low_mode_direction(indata, seed)
+    plus = float(objective(boundary + direction))
+    minus = float(objective(boundary - direction))
+    finite_difference = 0.5 * (plus - minus)
+    directional = float(np.sum(gradient * direction))
+    print(
+        f"{objective_name} seed={seed}: value={float(value):.6e} "
+        f"grad.d={directional:.6e} central={finite_difference:.6e} "
+        f"rel diff={abs(directional - finite_difference) / abs(finite_difference):.2e}"
+    )
+    np.testing.assert_allclose(directional, finite_difference, rtol=2.0e-2)


### PR DESCRIPTION
# Make `vmecpp.run` differentiable (JAX port of the wout output post processing)

## Scope

`vmecpp.autodiff.make_solver` returns the equilibrium as a `Geometry` in the internal product basis (`r_cc, r_ss, z_sc, z_cs, lambda_sc, lambda_cs` on the full mesh plus the flux profiles). Objectives are written in `wout` quantities, so every user had to re-implement the basis conversion and the output stage in JAX before `jax.grad` was
useful. This change adds that port once, exposes it through `vmecpp.autodiff.run`, and lets `vmecpp.run(input, differentiable=True)` dispatch to it.

The differentiable path covers fixed-boundary, stellarator-symmetric, `ncurr = 0` inputs; the gradient needs a build with `-DVMECPP_ENABLE_ENZYME=ON`.

## Tests and measurements

`tests/test_autodiff_wout.py`, run with `OMP_NUM_THREADS=1 JAX_PLATFORMS=cpu` on the
Enzyme-enabled build.

Validation of `wout_arrays` against `vmecpp.run(...).wout` on the same converged state

CTH-like fixed boundary (`examples/data/cth_like_fixed_bdy.json`, `ncurr = 0`,
`ai = [0.35, 0.15]`, `ns = 15`, `ftol = 1e-16`; `mnmax = 41`, `mnmax_nyq = 315`):

| array | max abs diff | max abs ref | array | max abs diff | max abs ref |
|---|---|---|---|---|---|
| rmnc | 6.9e-18 | 8.0e-01 | bsupumnc | 4.8e-15 | 3.8e-01 |
| zmns | 6.9e-18 | 1.6e-01 | bsupvmnc | 8.5e-15 | 7.4e-01 |
| lmns | 1.1e-16 | 6.5e-01 | bsubsmns | 1.5e-16 | 6.7e-02 |
| lmns_full | 5.6e-17 | 6.6e-01 | iotas / iotaf | 7.2e-16 / 6.1e-16 | 0.49 / 0.50 |
| gmnc | 7.5e-17 | 8.4e-03 | phi / chi | 0 / 1.7e-18 | 3.5e-02 / 1.5e-02 |
| bmnc | 6.9e-15 | 5.7e-01 | phipf / chipf | 0 / 2.4e-17 | 3.5e-02 / 1.8e-02 |
| bsubumnc | 1.4e-16 | 1.6e-02 | presf / pres | 5.7e-14 / 8.5e-14 | 4.3e+02 |
| bsubvmnc | 5.7e-15 | 4.6e-01 | aspect, volume_p, volavgB, betatotal, b0 | 0, 1.1e-16, 3.3e-16, 8.7e-19, 0 | 5.5, 0.32, 0.56, 2.0e-03, 0.59 |

W7-X derived (`examples/data/w7x.json` truncated to `mpol = 5, ntor = 4`, `ncurr = 0`,
`ai = [0.85, 0.15]`, `ns = 11`, `ftol = 1e-14`):

| array | max abs diff | max abs ref | array | max abs diff | max abs ref |
|---|---|---|---|---|---|
| rmnc | 5.6e-17 | 5.6 | bsupumnc | 1.0e-14 | 0.41 |
| zmns | 2.8e-17 | 0.62 | bsupvmnc | 8.8e-15 | 0.40 |
| lmns | 5.6e-17 | 0.31 | bsubsmns | 6.7e-15 | 1.1 |
| lmns_full | 1.4e-17 | 0.31 | iotas / iotaf | 6.7e-16 / 6.7e-16 | 0.99 / 1.0 |
| gmnc | 1.4e-14 | 0.73 | phi / chi | 0 / 1.1e-16 | 1.7 / 1.6 |
| bmnc | 5.3e-14 | 2.3 | phipf / chipf | 0 / 1.1e-15 | 1.7 / 1.7 |
| bsubumnc | 1.1e-14 | 0.36 | presf / pres | 5.0e-11 / 3.3e-11 | 1.7e+05 / 1.6e+05 |
| bsubvmnc | 3.2e-13 | 13.7 | aspect, volume_p, volavgB, betatotal, b0 | 5.3e-15, 7.1e-15, 8.9e-16, 1.4e-17, 1.8e-15 | 11.0, 27.8, 2.3, 4.0e-02, 2.2 |

Further tests: `wout_arrays` with a prescribed `iota_half`; `autodiff.run` against
`vmecpp.run` through the two solver paths (agree to `1e-9` relative on `rmnc, zmns,
bmnc, gmnc, iotaf, aspect, volume_p` at `ftol = 1e-16`); `vmecpp.run(differentiable=True)`
returns a `DifferentiableRun` and rejects `restart_from`; `autodiff.run` under `jax.jit`
(bitwise match of `aspect` to the eager value at `1e-12`); pytree round trip.

Gradient check (`jax.grad` through the solve and the output stage against a central
difference of the fully re-solved pipeline), CTH-like case at `ns = 25`, `ftol = 1e-14`,
two random directions on the `m <= 2, |n| <= 1` boundary modes of relative size `1e-3`:

| objective | seed | value | grad . d | central difference | rel diff |
|---|---|---|---|---|---|
| aspect | 0 | 5.485830 | 2.584051e-03 | 2.584078e-03 | 1.0e-05 |
| aspect | 1 | 5.485830 | -4.292267e-03 | -4.292292e-03 | 5.8e-06 |
| sum(bmnc[mid, 1:]^2) / bmnc[mid, 0]^2 | 0 | 7.226750e-02 | 1.745426e-03 | 1.745531e-03 | 6.0e-05 |
| sum(bmnc[mid, 1:]^2) / bmnc[mid, 0]^2 | 1 | 7.226750e-02 | 1.179241e-03 | 1.179188e-03 | 4.5e-05 |

Open points:

- The mass profile is evaluated in NumPy from the input and is not differentiated; with `gamma != 0` it also uses the input `rbc(0, 0)` rather than the traced boundary.
- Profile types other than `power_series`, `two_power` and `line_segment` raise `NotImplementedError` in the output stage.
- `WoutArrays` carries the subset of `VmecWOut` listed above; `vp`, `beta_vol`, `buco`, `bvco`, `jcuru`, `jcurv`, `bsubsmns_full`, the currents and the `threed1` tables are not ported.