### PR TITLE
Let Python attach attributes to VmecModel

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -1520,7 +1520,10 @@ PYBIND11_MODULE(_vmecpp, m) {
   // Single-resolution iteration model: exposes the forward model and the
   // time-step / restart primitives so the equilibrium iteration can be driven
   // from Python (see vmecpp._iteration).
-  py::class_<VmecModel>(m, "VmecModel")
+  // py::dynamic_attr() adds a per-instance __dict__ (extra pointer plus a
+  // dict allocated on first use) so Python code can attach its own state,
+  // e.g. a cached factorization or metadata, to a solved model.
+  py::class_<VmecModel>(m, "VmecModel", py::dynamic_attr())
       .def_static("create", &VmecModel::Create, py::arg("indata"),
                   py::arg("ns"), py::arg("initial_state") = std::nullopt)
       .def("evaluate", &VmecModel::Evaluate, py::arg("iter1"), py::arg("iter2"),

--- a/tests/test_vmec_model_dynamic_attr.py
+++ b/tests/test_vmec_model_dynamic_attr.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+# <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+"""VmecModel accepts arbitrary Python attributes.
+
+``py::class_<VmecModel>`` is registered with ``py::dynamic_attr()``, giving each
+instance a ``__dict__``. This lets Python code attach state to a solved model,
+for example a cached factorization or metadata, without VMEC++ having to know
+about it.
+"""
+
+from pathlib import Path
+
+import numpy as np
+
+from vmecpp.cpp import _vmecpp  # type: ignore
+
+SOLOVEV = Path(__file__).resolve().parents[1] / "examples" / "data" / "solovev.json"
+
+
+def _model(ns: int = 11):
+    return _vmecpp.VmecModel.create(_vmecpp.VmecINDATA.from_file(str(SOLOVEV)), ns)
+
+
+def test_arbitrary_attribute_can_be_set_and_read_back() -> None:
+    model = _model()
+    model.cached_factorization = {"marker": 42}
+
+    assert model.cached_factorization == {"marker": 42}
+
+
+def test_dynamic_attribute_does_not_interfere_with_get_state_and_solve() -> None:
+    model = _model()
+    model.some_metadata = "arbitrary"
+
+    state_before = np.asarray(model.get_state(), dtype=np.float64).copy()
+    model.solve()
+    state_after = np.asarray(model.get_state(), dtype=np.float64)
+
+    assert model.some_metadata == "arbitrary"
+    assert state_before.shape == state_after.shape
+    assert np.all(np.isfinite(state_after))


### PR DESCRIPTION
## Scope

Bug: `py::class_<VmecModel>` in `src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc` is
declared without `py::dynamic_attr()`. Python code that wants to attach state to a solved
model instance, for example a cached factorization or some metadata, cannot: `model.some_cache
= ...` raises `AttributeError`. Code that wraps such a setattr in a silent `try/except
AttributeError` hides the failure instead of surfacing it.

## Change

Add `py::dynamic_attr()` to the `VmecModel` class binding. This gives each `VmecModel`
instance a per-instance `__dict__`, the same mechanism pybind11 uses for any Python class:
one extra pointer in the instance layout, plus a dict allocated lazily the first time an
attribute is set. No other binding or method changes.

## Tests and measurements

Added `tests/test_vmec_model_dynamic_attr.py`:
- setting and reading back an arbitrary Python attribute on a `VmecModel` created from
  `examples/data/solovev.json`;
- setting an attribute, then calling `solve()`, and checking the attribute is unchanged and
  `get_state()` still returns a finite, correctly shaped array (dynamic attributes do not
  interfere with the C++-backed state).

Both tests pass locally. Full existing test suite unaffected (no other binding changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
