### PR TITLE
Support ncurr=1 (prescribed toroidal current) in the implicit adjoint

### DIFF
--- a/src/vmecpp/autodiff.py
+++ b/src/vmecpp/autodiff.py
@@ -6,13 +6,14 @@ and solves the transposed interior force system. This is the usual implicit
 layer for a differentiable code: JAX differentiates the consumer objective,
 and VMEC++ supplies the producer's residual transpose.
 
-The first public parameterization is the fixed-boundary, prescribed-iota case.
-The differentiable parameter is one dense array with rows ``rbc`` and ``zbs``
-and shape ``(2, mpol, 2 * ntor + 1)``. This first solver wrapper deliberately
-supports the stellarator-symmetric fixed-boundary, prescribed-iota case. The
-geometry API itself already supports asymmetric snapshots; profile and
-free-boundary parameter VJPs remain explicit unsupported cases until their
-residual dependence is exposed by the exact C++ derivative path.
+The first public parameterization is the fixed-boundary case, with either a
+prescribed iota or a prescribed toroidal current profile (``ncurr``). The
+differentiable parameter is one dense array with rows ``rbc`` and ``zbs`` and
+shape ``(2, mpol, 2 * ntor + 1)``. This first solver wrapper deliberately
+supports the stellarator-symmetric fixed-boundary case. The geometry API
+itself already supports asymmetric snapshots; profile and free-boundary
+parameter VJPs remain explicit unsupported cases until their residual
+dependence is exposed by the exact C++ derivative path.
 """
 
 from __future__ import annotations
@@ -268,7 +269,12 @@ def _implicit_boundary_vjp(model, geometry_bar: np.ndarray) -> np.ndarray:
         )
         raise RuntimeError(error_message)
     coefficient_bar = np.asarray(geometry_bar[2 * model.ns :], dtype=np.float64)
-    state_bar = np.asarray(model.geometry_state_vjp(coefficient_bar), dtype=np.float64)
+    poloidal_flux_bar = np.asarray(
+        geometry_bar[model.ns : 2 * model.ns], dtype=np.float64
+    )
+    state_bar = np.asarray(
+        model.geometry_state_vjp(coefficient_bar, poloidal_flux_bar), dtype=np.float64
+    )
     state = np.asarray(model.get_state(), dtype=np.float64)
     interior, boundary = _interior_and_boundary(model)
     model.set_state(np.ascontiguousarray(state))
@@ -338,9 +344,6 @@ class DifferentiableVmec:
     def __post_init__(self) -> None:
         if self.vmec_input.lfreeb:
             error_message = "DifferentiableVmec currently requires lfreeb=false"
-            raise ValueError(error_message)
-        if self.vmec_input.ncurr != 0:
-            error_message = "DifferentiableVmec currently requires ncurr=0"
             raise ValueError(error_message)
         if self.vmec_input.lasym:
             error_message = (

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -2645,8 +2645,8 @@ void IdealMhdModel::applyExactForceJacobian(const double* geomP,
   const int nWork = LocalForceWorkSize(comp);
   std::vector<double> work(nWork, 0.0);
   std::vector<double> dwork(nWork, 0.0);
-  std::vector<double> force(20 * nForce, 0.0);
-  std::vector<double> dforce(20 * nForce, 0.0);
+  std::vector<double> force(kLocalForceBlocks * nForce, 0.0);
+  std::vector<double> dforce(kLocalForceBlocks * nForce, 0.0);
 
   // single nonlinear forward pass: J_g . (T v)
   ExactForceDensityJvp(geomP, dgeom, work.data(), dwork.data(), force.data(),
@@ -2704,7 +2704,7 @@ void IdealMhdModel::exactForceDensityTangent(const double* geomP,
   const int nWork = LocalForceWorkSize(comp);
   std::vector<double> work(nWork, 0.0);
   std::vector<double> dwork(nWork, 0.0);
-  std::vector<double> force(20 * nForce, 0.0);
+  std::vector<double> force(kLocalForceBlocks * nForce, 0.0);
   ExactForceDensityJvp(geomP, dgeom, work.data(), dwork.data(), force.data(),
                        dforce_out, &comp);
 }
@@ -2718,10 +2718,10 @@ void IdealMhdModel::exactForceDensityCotangent(const double* geomP,
   const int nWork = LocalForceWorkSize(comp);
   std::vector<double> work(nWork, 0.0);
   std::vector<double> work_bar(nWork, 0.0);
-  std::vector<double> force(20 * nForce, 0.0);
+  std::vector<double> force(kLocalForceBlocks * nForce, 0.0);
   // force_bar is the output cotangent seed; Enzyme consumes (and may clobber)
   // the shadow, so pass a private copy. geom_bar_out is zeroed by the caller.
-  std::vector<double> fbar(force_bar, force_bar + 20 * nForce);
+  std::vector<double> fbar(force_bar, force_bar + kLocalForceBlocks * nForce);
   ExactForceDensityVjp(geomP, geom_bar_out, work.data(), work_bar.data(),
                        force.data(), fbar.data(), &comp);
 }
@@ -3071,8 +3071,8 @@ void IdealMhdModel::applyExactForceJacobianTranspose(
     dft_ForcesToFourierTranspose_2d_symm(m_physical_f);
   }
 
-  // Gather the force-density member cotangents into the 20-block flat layout.
-  std::vector<double> force_bar(20 * nForce, 0.0);
+  // Gather the force-density member cotangents into the flat block layout.
+  std::vector<double> force_bar(kLocalForceBlocks * nForce, 0.0);
   auto gather = [&](int b, const Eigen::VectorXd& src) {
     for (int i = 0; i < nForce; ++i) force_bar[b * nForce + i] = src[i];
   };
@@ -3156,6 +3156,75 @@ void IdealMhdModel::applyExactForceJacobianTranspose(
   m_physical_scratch.decomposeInto(m_decomposed_out, m_p_.scalxc);
 }
 
+// Transpose of the geometry-to-chi' map for ncurr==1: (dchi'/dx)^T chip_bar,
+// in the decomposed internal basis. chip_bar has one entry per half surface
+// (index jH-nsMinH). Seeds the reverse-mode force-density kernel on block 20
+// alone (all force-member cotangents zero) and reuses the B^T untransform of
+// applyExactForceJacobianTranspose, since chi' shares the same nonlinear
+// geometry dependence (guu, bsupu, bsupv, gsqrt) as the force densities.
+void IdealMhdModel::chipStateVjp(const double* geomP, int geom_stride,
+                                 const double* chip_bar,
+                                 FourierGeometry& m_physical_scratch,
+                                 FourierGeometry& m_decomposed_out) {
+  const int gS = geom_stride;
+  const int nForce = (r_.nsMaxFIncludingLcfs - r_.nsMinF) * s_.nZnT;
+  const int nH = r_.nsMaxH - r_.nsMinH;
+
+  std::vector<double> force_bar(kLocalForceBlocks * nForce, 0.0);
+  for (int jH = 0; jH < nH; ++jH) {
+    force_bar[20 * nForce + jH] = chip_bar[jH];
+  }
+
+  std::vector<double> geom_bar(20 * gS, 0.0);
+  exactForceDensityCotangent(geomP, force_bar.data(), gS, geom_bar.data());
+
+  // B^T: transpose of packGeometry's linear pre-chain, restricted to the
+  // blocks chi' actually depends on (r1, ru, zu, lu/lv via bsupu/bsupv; chi'
+  // does not depend on rv/zv, the constraint blocks, or the primal's phipF
+  // shift, which drops out of a tangent/cotangent map).
+  auto scat = [&](int b, Eigen::VectorXd& dst) {
+    const int sz = std::min(gS, static_cast<int>(dst.size()));
+    for (int i = 0; i < sz; ++i) dst[i] = geom_bar[b * gS + i];
+  };
+  scat(0, r1_e);
+  scat(1, r1_o);
+  scat(2, z1_e);
+  scat(3, z1_o);
+  scat(4, ru_e);
+  scat(5, ru_o);
+  scat(6, zu_e);
+  scat(7, zu_o);
+  for (int i = 0; i < gS; ++i) {
+    lu_e[i] = constants_.lamscale * geom_bar[12 * gS + i];
+    lu_o[i] = constants_.lamscale * geom_bar[13 * gS + i];
+  }
+  if (s_.lthreed) {
+    scat(8, rv_e);
+    scat(9, rv_o);
+    scat(10, zv_e);
+    scat(11, zv_o);
+    for (int i = 0; i < gS; ++i) {
+      lv_e[i] = constants_.lamscale * geom_bar[14 * gS + i];
+      lv_o[i] = constants_.lamscale * geom_bar[15 * gS + i];
+    }
+  }
+  // chi' has zero cotangent on the constraint blocks, but the transpose DFT
+  // unconditionally reads rCon/zCon as reused cotangent scratch (see
+  // applyExactForceJacobianTranspose's scat(16, rCon)/scat(17, zCon)); zero
+  // them so a stale primal or cotangent left by an earlier call on this model
+  // does not leak in.
+  rCon.setZero();
+  zCon.setZero();
+  if (s_.lthreed) {
+    dft_FourierToRealTranspose_3d_symm(m_physical_scratch);
+  } else {
+    dft_FourierToRealTranspose_2d_symm(m_physical_scratch);
+  }
+  m_physical_scratch.extrapolateTowardsAxisTranspose();
+  m_physical_scratch.m1Constraint(1.0, signOfJacobian);
+  m_physical_scratch.decomposeInto(m_decomposed_out, m_p_.scalxc);
+}
+
 // Diagnostic: max |composed force density - production force density| at the
 // current state, to isolate composition bugs from the transform/tangent path.
 double IdealMhdModel::composedForceResidual(const double* geomP,
@@ -3163,7 +3232,7 @@ double IdealMhdModel::composedForceResidual(const double* geomP,
   LocalForceComposition comp = makeLocalForceComposition(geom_stride);
   const int nForce = comp.force_stride;
   std::vector<double> work(LocalForceWorkSize(comp), 0.0);
-  std::vector<double> force(20 * nForce, 0.0);
+  std::vector<double> force(kLocalForceBlocks * nForce, 0.0);
   ComputeLocalForceDensity(geomP, work.data(), force.data(), &comp);
 
   double maxd = 0.0;

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.h
@@ -221,14 +221,16 @@ class IdealMhdModel {
   // current state, to isolate composition bugs from the transform/tangent path.
   double composedForceResidual(const double* geomP, int geom_stride);
 
-  // Raw force-density tangent (20 blocks of (nsMaxFIncludingLcfs-nsMinF)*nZnT)
-  // from one Enzyme forward pass, no transform. For isolating the JVP from the
-  // spectral-transform wrapping.
+  // Raw force-density tangent (kLocalForceBlocks blocks of
+  // (nsMaxFIncludingLcfs-nsMinF)*nZnT; block 20 is chi' for ncurr==1, see
+  // local_force_composition.h) from one Enzyme forward pass, no transform. For
+  // isolating the JVP from the spectral-transform wrapping.
   void exactForceDensityTangent(const double* geomP, const double* dgeom,
                                 int geom_stride, double* dforce_out);
 
   // Reverse-mode force-density cotangent: J_g^T applied to the force-density
-  // cotangent force_bar (20 blocks of (nsMaxFIncludingLcfs-nsMinF)*nZnT),
+  // cotangent force_bar (kLocalForceBlocks blocks of
+  // (nsMaxFIncludingLcfs-nsMinF)*nZnT; block 20 is the chi' cotangent),
   // accumulated into geom_bar_out (20 blocks of geom_stride, zeroed by caller),
   // by one Enzyme reverse pass. The transpose of exactForceDensityTangent.
   void exactForceDensityCotangent(const double* geomP, const double* force_bar,
@@ -254,6 +256,16 @@ class IdealMhdModel {
                                         FourierGeometry& m_physical_scratch,
                                         FourierGeometry& m_decomposed_out,
                                         bool fix_m1_gauge);
+
+  // (dchi'/dx)^T chip_bar for ncurr==1, in the decomposed internal basis.
+  // chip_bar holds one entry per half surface (index jH-nsMinH, the space
+  // chipH occupies). Reuses the reverse-mode force-density kernel seeded on
+  // its chi' output block alone, and the geometry-side (B^T) half of
+  // applyExactForceJacobianTranspose, since chi' depends on the same geometry
+  // blocks (r1, ru, zu, lu, lv) the force densities do.
+  void chipStateVjp(const double* geomP, int geom_stride,
+                    const double* chip_bar, FourierGeometry& m_physical_scratch,
+                    FourierGeometry& m_decomposed_out);
 
   // Transposes of the spectral transforms, for the transposed exact Hessian.
   // dft_ForcesToFourierTranspose: (forcesToFourier)^T, decomposed-force coeff

--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/local_force_composition.h
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/local_force_composition.h
@@ -32,7 +32,10 @@ namespace vmecpp {
 //   r1_e r1_o z1_e z1_o ru_e ru_o zu_e zu_o rv_e rv_o zv_e zv_o lu_e lu_o lv_e
 //   lv_o
 // Force layout (each block ForceStride doubles): the 12 MHD densities then
-//   blmn_e blmn_o clmn_e clmn_o.
+//   blmn_e blmn_o clmn_e clmn_o. Block 20 is the ncurr==1 chi' profile
+//   (index jH-nsMinH, the rest of the block unused), differentiated alongside
+//   the force densities so its state derivative comes out of the same Enzyme
+//   pass; ncurr==0 does not populate it (chi' is a fixed input profile).
 struct LocalForceComposition {
   int nZnT;
   int geom_stride;   // doubles per geometry block (>= (nsMaxF1-nsMinF1)*nZnT)
@@ -84,6 +87,10 @@ struct LocalForceComposition {
   const double* sinmu = nullptr;
   const double* cosmu = nullptr;
 };
+
+// Number of force blocks ComputeLocalForceDensity writes: the 12 MHD/lambda
+// densities, 4 constraint densities, and the ncurr==1 chi' block.
+inline constexpr int kLocalForceBlocks = 21;
 
 // Doubles of work that ComputeLocalForceDensity slices for composition c: the
 // half-grid fields and per-point scratch, plus the constraint scratch when
@@ -165,6 +172,7 @@ inline void ComputeLocalForceDensity(const double* geom, double* work,
                         c->nsMinH, c->nsMaxH, gsqrt, guu, guv, gvv);
   ComputeBsupContra(lue, luo, lve, lvo, gsqrt, c->sqrtSH, c->lthreed, nZnT,
                     c->nsMinF1, c->nsMinH, c->nsMaxH, bsupu, bsupv);
+  double* chip_out = force + 20 * fS;
   for (int jH = c->nsMinH; jH < c->nsMaxH; ++jH) {
     // For a prescribed-current profile (ncurr==1), chi' is recomputed from the
     // geometry each step (constrained toroidal current), so differentiate it
@@ -187,6 +195,10 @@ inline void ComputeLocalForceDensity(const double* geom, double* work,
       if (avg_guu_gsqrt != 0.0) {
         chip = (c->currH[jH - c->nsMinH] - jvPlasma) / avg_guu_gsqrt;
       }
+      // Expose chi' as its own output block so a cotangent seeded there alone
+      // yields (dchi'/dx)^T through the same reverse pass as the force
+      // cotangent; ncurr==0 leaves this block untouched (chi' is prescribed).
+      chip_out[jH - c->nsMinH] = chip;
     }
     for (int kl = 0; kl < nZnT; ++kl) {
       const int ih = (jH - c->nsMinH) * nZnT + kl;

--- a/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/pybind11/pybind_vmec.cc
@@ -426,13 +426,23 @@ class VmecModel {
   }
 
   // Transpose of the linear state-to-geometry coefficient map used by
-  // MakeGeometry. The input contains twelve dense coefficient blocks in the
-  // same order as GeometryCoefficients (r_cc, r_ss, r_sc, r_cs, z_sc, z_cs,
-  // z_cc, z_ss, lambda_sc, lambda_cs, lambda_cc, lambda_ss), each with
-  // surface-major (j, m, n) storage. Flux cotangents are intentionally not
-  // part of this low-level map: with ncurr=0 both flux profiles are prescribed
-  // input profiles and therefore have zero state derivative.
-  Eigen::VectorXd GeometryStateVjp(const Eigen::VectorXd &coefficient_bar) {
+  // MakeGeometry. coefficient_bar contains twelve dense coefficient blocks in
+  // the same order as GeometryCoefficients (r_cc, r_ss, r_sc, r_cs, z_sc,
+  // z_cs, z_cc, z_ss, lambda_sc, lambda_cs, lambda_cc, lambda_ss), each with
+  // surface-major (j, m, n) storage.
+  //
+  // poloidal_flux_bar is the separate cotangent of MakeGeometry's poloidal_flux
+  // output (one entry per full surface); pass an empty vector where it is
+  // zero. With ncurr=0 both flux profiles are prescribed input profiles and
+  // have zero state derivative, so the toroidal_flux cotangent never enters
+  // this map. With ncurr=1 the toroidal flux is still prescribed, but the
+  // poloidal flux is chi_j = sum_{k<j} c_k iota_k with c_k the (state-
+  // independent) half-grid flux step, and iota_k = chi'_k / phipH_k depends on
+  // the state through the prescribed-current chi' (see
+  // local_force_composition.h); that dependence is added to the state
+  // cotangent here via chip_state_vjp.
+  Eigen::VectorXd GeometryStateVjp(const Eigen::VectorXd &coefficient_bar,
+                                   const Eigen::VectorXd &poloidal_flux_bar) {
     if (vmec_->indata_.lfreeb) {
       throw std::runtime_error(
           "VmecModel.geometry_state_vjp currently supports fixed-boundary "
@@ -443,10 +453,10 @@ class VmecModel {
           "VmecModel.geometry_state_vjp currently supports stellarator-"
           "symmetric models only");
     }
-    if (vmec_->indata_.ncurr != 0) {
+    if (poloidal_flux_bar.size() != 0 &&
+        poloidal_flux_bar.size() != vmec_->fc_.ns) {
       throw std::runtime_error(
-          "VmecModel.geometry_state_vjp requires ncurr=0; current-constrained "
-          "flux derivatives are not yet exposed");
+          "VmecModel.geometry_state_vjp: poloidal_flux_bar has wrong length");
     }
     const int modes_per_surface = vmec_->s_.mpol * (vmec_->s_.ntor + 1);
     const int coefficient_size = vmec_->fc_.ns * modes_per_surface;
@@ -525,7 +535,40 @@ class VmecModel {
 
     add_block(state_bar.lmnsc, 8, true);
     if (vmec_->s_.lthreed) add_block(state_bar.lmncs, 9, true);
-    return FlattenActive(state_bar, vmec_->s_);
+    Eigen::VectorXd result = FlattenActive(state_bar, vmec_->s_);
+
+    if (vmec_->indata_.ncurr != 0 && poloidal_flux_bar.size() != 0 &&
+        poloidal_flux_bar.cwiseAbs().maxCoeff() != 0.0) {
+#ifdef VMECPP_ENABLE_ENZYME
+      // chi_j = sum_{k<j} c_k iotaH_k, c_k = signOfJacobian * 2 pi deltaS
+      // phipH_k (MakeGeometry's poloidal_flux recursion). iotaH_k =
+      // chipH_k / phipH_k, and for ncurr==1 chipH_k is the state-dependent
+      // prescribed-current chi' differentiated in local_force_composition.h.
+      const Eigen::VectorXd &phip_h = vmec_->p_[0]->phipH;
+      const int nHalf = vmec_->fc_.ns - 1;
+      Eigen::VectorXd chip_bar = Eigen::VectorXd::Zero(nHalf);
+      double tail = 0.0;
+      for (int j = vmec_->fc_.ns - 1; j >= 1; --j) {
+        tail += poloidal_flux_bar[j];
+        const int k = j - 1;
+        if (phip_h[k] == 0.0) {
+          throw std::runtime_error(
+              "VmecModel.geometry_state_vjp: invalid phipH for the ncurr=1 "
+              "flux cotangent");
+        }
+        const double c_k = static_cast<double>(vmecpp::Vmec::kSignOfJacobian) *
+                           2.0 * std::numbers::pi * vmec_->fc_.deltaS *
+                           phip_h[k];
+        chip_bar[k] = c_k * tail / phip_h[k];
+      }
+      result += ChipStateVjp(chip_bar);
+#else
+      throw std::runtime_error(
+          "VmecModel.geometry_state_vjp: a nonzero poloidal_flux_bar with "
+          "ncurr=1 requires an Enzyme-enabled build for chi'_state_vjp");
+#endif  // VMECPP_ENABLE_ENZYME
+    }
+    return result;
   }
 
   // Hessian-vector product of VMEC's augmented functional, computed inside
@@ -626,6 +669,29 @@ class VmecModel {
         *vmec_->physical_x_backup_[0], /*fix_m1_gauge=*/true);
     return FlattenActive(*vmec_->physical_x_backup_[0], vmec_->s_);
   }
+
+  // (dchi'/dx)^T chip_bar for ncurr==1, in the decomposed internal basis:
+  // the state cotangent from a chi' cotangent alone (one entry per half
+  // surface), with no force-member cotangent. Uses the same cached primal
+  // geometry as ExactHessianVectorProduct(Transpose). GeometryStateVjp uses
+  // this to convert the poloidal-flux cotangent into a state cotangent when
+  // ncurr==1.
+  Eigen::VectorXd ChipStateVjp(const Eigen::VectorXd &chip_bar) {
+    RequireLforbalDisabledForExactDerivatives();
+    vmecpp::IdealMhdModel &model = *vmec_->m_[0];
+    const int gS = static_cast<int>(model.r1_e.size());
+    if (!exact_primal_valid_ ||
+        exact_primal_.size() != static_cast<Eigen::Index>(20 * gS)) {
+      exact_primal_.setZero(20 * gS);
+      model.packGeometry(*vmec_->decomposed_x_[0], *vmec_->physical_x_[0],
+                         exact_primal_.data(), gS, /*primal=*/true);
+      exact_primal_valid_ = true;
+    }
+    vmec_->physical_x_backup_[0]->setZero();
+    model.chipStateVjp(exact_primal_.data(), gS, chip_bar.data(),
+                       *vmec_->physical_x_[0], *vmec_->physical_x_backup_[0]);
+    return FlattenActive(*vmec_->physical_x_backup_[0], vmec_->s_);
+  }
 #endif  // VMECPP_ENABLE_ENZYME
 
   // Apply VMEC's preconditioner M^-1 to a vector in the decomposed internal
@@ -714,6 +780,11 @@ class VmecModel {
 
   int ijacob() const { return vmec_->fc_.ijacob; }
   Eigen::VectorXd raxis_c() const { return vmec_->b_.raxis_c; }
+  // Half-grid chi' (chipH), valid after evaluate(): iota*phip when ncurr=0,
+  // the current-constrained profile computeBContra solves for when ncurr=1.
+  // Exposed to let callers (and tests) check chip_state_vjp and
+  // geometry_state_vjp's ncurr=1 flux route against a finite difference.
+  Eigen::VectorXd chip_h() const { return vmec_->p_[0]->chipH; }
   static bool openmp_enabled() {
 #ifdef _OPENMP
     return true;
@@ -1546,7 +1617,8 @@ PYBIND11_MODULE(_vmecpp, m) {
       .def("get_forces", &VmecModel::GetForces)
       .def("get_geometry", &VmecModel::GetGeometry)
       .def("geometry_state_vjp", &VmecModel::GeometryStateVjp,
-           py::arg("coefficient_bar"))
+           py::arg("coefficient_bar"),
+           py::arg("poloidal_flux_bar") = Eigen::VectorXd())
       .def("apply_preconditioner", &VmecModel::ApplyPreconditioner,
            py::arg("v"))
       .def("hessian_vector_product", &VmecModel::HessianVectorProduct,
@@ -1559,6 +1631,7 @@ PYBIND11_MODULE(_vmecpp, m) {
            &VmecModel::ExactHessianVectorProduct, py::arg("v"))
       .def("exact_hessian_vector_product_transpose",
            &VmecModel::ExactHessianVectorProductTranspose, py::arg("w"))
+      .def("chip_state_vjp", &VmecModel::ChipStateVjp, py::arg("chip_bar"))
 #endif  // VMECPP_ENABLE_ENZYME
       .def_property_readonly("force_eval_count", &VmecModel::force_eval_count)
       .def("reset_force_eval_count", &VmecModel::reset_force_eval_count)
@@ -1590,5 +1663,6 @@ PYBIND11_MODULE(_vmecpp, m) {
       .def_property_readonly("restart_reasons", &VmecModel::restart_reasons)
       .def_property_readonly("ijacob", &VmecModel::ijacob)
       .def_property_readonly("raxis_c", &VmecModel::raxis_c)
+      .def_property_readonly("chip_h", &VmecModel::chip_h)
       .def_static("openmp_enabled", &VmecModel::openmp_enabled);
 }  // NOLINT(readability/fn_size)

--- a/tests/test_autodiff_ncurr1.py
+++ b/tests/test_autodiff_ncurr1.py
@@ -1,0 +1,300 @@
+# SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+# <info@proximafusion.com>
+#
+# SPDX-License-Identifier: MIT
+"""The implicit adjoint for ncurr=1 (prescribed toroidal current).
+
+For ncurr=1 the half-grid chi' (chipH) is not a fixed input profile: it is
+solved from the prescribed toroidal current at every force evaluation
+(IdealMhdModel::computeBContra), so it depends on the state through the same
+geometry (guu, bsupu, bsupv, gsqrt) the force densities do. The Enzyme kernel
+that differentiates the force densities (local_force_composition.h) already
+differentiates that chi' solve; chip_state_vjp exposes it as its own reverse
+pass, and geometry_state_vjp routes the poloidal_flux cotangent through it.
+
+These tests use examples/data/cth_like_fixed_bdy.json, an ncurr=1 case, at a
+reduced ns/ftol for speed.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import vmecpp
+from vmecpp import autodiff
+from vmecpp.cpp import _vmecpp  # type: ignore
+
+jax.config.update("jax_enable_x64", True)
+
+
+def _ncurr1_input() -> vmecpp.VmecInput:
+    source = vmecpp.VmecInput.from_file("examples/data/cth_like_fixed_bdy.json")
+    assert source.ncurr == 1
+    return source.model_copy(
+        update={
+            "ns_array": np.asarray([15]),
+            "ftol_array": np.asarray([1.0e-16]),
+            "niter_array": np.asarray([4000]),
+        }
+    )
+
+
+def _requires_exact_derivatives(indata: vmecpp.VmecInput) -> None:
+    ns = int(np.asarray(indata.ns_array)[-1])
+    model = _vmecpp.VmecModel.create(indata._to_cpp_vmecindata(), ns)
+    if not model.has_exact_force_jacobian:
+        pytest.skip("needs an Enzyme-enabled build for the exact residual transpose")
+
+
+def _boundary(indata: vmecpp.VmecInput) -> np.ndarray:
+    return np.stack([np.asarray(indata.rbc), np.asarray(indata.zbs)], axis=0).astype(
+        np.float64
+    )
+
+
+def _solved_model(indata: vmecpp.VmecInput):
+    ns = int(np.asarray(indata.ns_array)[-1])
+    model = _vmecpp.VmecModel.create(indata._to_cpp_vmecindata(), ns)
+    model.solve()
+    return model
+
+
+def test_exact_hvp_matches_finite_difference_with_prescribed_current() -> None:
+    """The Enzyme kernel already differentiates chi' for ncurr=1 (PR #841's tcon branch
+    shares the state-dependent chip), so the exact HVP should already be the derivative
+    of the raw force -- not just of a frozen-iota force."""
+    indata = _ncurr1_input()
+    _requires_exact_derivatives(indata)
+    model = _solved_model(indata)
+    state = np.asarray(model.get_state(), dtype=np.float64).copy()
+
+    def raw_force(x):
+        model.set_state(np.ascontiguousarray(x))
+        model.evaluate(2, 2, False)
+        return np.asarray(model.get_forces(), dtype=np.float64).copy()
+
+    model.set_state(np.ascontiguousarray(state))
+    model.evaluate(2, 2, True)
+    rng = np.random.default_rng(0)
+    direction = rng.standard_normal(state.size)
+    direction /= np.linalg.norm(direction)
+
+    hv = np.asarray(
+        model.exact_hessian_vector_product(np.ascontiguousarray(direction)),
+        dtype=np.float64,
+    )
+
+    errors = {}
+    for h in (1.0e-4, 1.0e-5, 1.0e-6):
+        fd = (raw_force(state + h * direction) - raw_force(state - h * direction)) / (
+            2 * h
+        )
+        model.set_state(np.ascontiguousarray(state))
+        model.evaluate(2, 2, True)
+        errors[h] = np.linalg.norm(hv - fd) / np.linalg.norm(fd)
+    # O(h^2) convergence of the central difference to the exact HVP.
+    assert errors[1.0e-6] < 1.0e-6
+    assert errors[1.0e-6] < errors[1.0e-5] < errors[1.0e-4]
+
+
+def test_exact_hvp_differs_from_a_frozen_iota_model() -> None:
+    """A converged ncurr=1 equilibrium re-run with ncurr=0 and its converged iota
+    prescribed as a fixed profile is a different functional (chi' no longer responds to
+    the state), so its HVP at the same state should disagree with the ncurr=1 exact HVP
+    at a resolvable level, even though both reproduce the same force residual at that
+    one state."""
+    indata = _ncurr1_input()
+    _requires_exact_derivatives(indata)
+    output = vmecpp.run(indata, verbose=_vmecpp.OutputMode.SILENT)
+    iotaf = np.asarray(output.wout.iotaf)
+    s_full = np.linspace(0.0, 1.0, iotaf.size)
+
+    frozen_indata = vmecpp.populate_raw_profile(
+        indata, "iota", lambda s: np.interp(s, s_full, iotaf)
+    ).model_copy(update={"ncurr": 0})
+
+    model = _solved_model(indata)
+    state = np.asarray(model.get_state(), dtype=np.float64).copy()
+    model.set_state(np.ascontiguousarray(state))
+    model.evaluate(2, 2, True)
+    rng = np.random.default_rng(0)
+    direction = rng.standard_normal(state.size)
+    direction /= np.linalg.norm(direction)
+    hv_ncurr1 = np.asarray(
+        model.exact_hessian_vector_product(np.ascontiguousarray(direction)),
+        dtype=np.float64,
+    )
+
+    frozen_model = _vmecpp.VmecModel.create(frozen_indata._to_cpp_vmecindata(), 15)
+    frozen_model.set_state(np.ascontiguousarray(state))
+    frozen_model.evaluate(2, 2, True)
+    # Both models reproduce the same converged residual at this shared state.
+    assert frozen_model.fsqr < 1.0e-6
+    hv_frozen = np.asarray(
+        frozen_model.exact_hessian_vector_product(np.ascontiguousarray(direction)),
+        dtype=np.float64,
+    )
+    relative_difference = np.linalg.norm(hv_ncurr1 - hv_frozen) / np.linalg.norm(
+        hv_ncurr1
+    )
+    assert relative_difference > 5.0e-4
+
+
+def test_chip_state_vjp_matches_finite_difference_of_chip_h() -> None:
+    """chip_state_vjp is (dchi'/dx)^T seeded on an arbitrary chip_bar; check it against
+    a central difference of chipH(x) along a random direction."""
+    indata = _ncurr1_input()
+    _requires_exact_derivatives(indata)
+    model = _solved_model(indata)
+    state = np.asarray(model.get_state(), dtype=np.float64).copy()
+    model.set_state(np.ascontiguousarray(state))
+    model.evaluate(2, 2, True)
+
+    rng = np.random.default_rng(1)
+    chip_bar = rng.standard_normal(model.ns - 1)
+    state_bar = np.asarray(
+        model.chip_state_vjp(np.ascontiguousarray(chip_bar)), dtype=np.float64
+    )
+
+    # linearity of the reverse-mode map is a cheap, independent sanity check
+    state_bar_2x = np.asarray(
+        model.chip_state_vjp(np.ascontiguousarray(2.0 * chip_bar)), dtype=np.float64
+    )
+    np.testing.assert_allclose(state_bar_2x, 2.0 * state_bar, rtol=1.0e-12)
+
+    direction = rng.standard_normal(state.size)
+    direction /= np.linalg.norm(direction)
+
+    def chip_h(x):
+        model.set_state(np.ascontiguousarray(x))
+        model.evaluate(2, 2, True)
+        return np.asarray(model.chip_h, dtype=np.float64).copy()
+
+    errors = {}
+    for h in (1.0e-3, 1.0e-4, 1.0e-5, 1.0e-6):
+        d_chip = (chip_h(state + h * direction) - chip_h(state - h * direction)) / (
+            2 * h
+        )
+        model.set_state(np.ascontiguousarray(state))
+        model.evaluate(2, 2, True)
+        lhs = chip_bar @ d_chip
+        rhs = state_bar @ direction
+        errors[h] = abs(lhs - rhs) / abs(lhs)
+    assert errors[1.0e-6] < 1.0e-6
+    assert errors[1.0e-6] < errors[1.0e-5] < errors[1.0e-4] < errors[1.0e-3]
+
+
+def test_geometry_state_vjp_poloidal_flux_route_matches_finite_difference() -> None:
+    """geometry_state_vjp's ncurr=1 flux conversion (poloidal_flux_bar -> iota_bar ->
+    chip_bar -> chip_state_vjp), checked end to end against a central difference of
+    MakeGeometry's own poloidal_flux."""
+    indata = _ncurr1_input()
+    _requires_exact_derivatives(indata)
+    model = _solved_model(indata)
+    state = np.asarray(model.get_state(), dtype=np.float64).copy()
+    model.set_state(np.ascontiguousarray(state))
+    model.evaluate(2, 2, True)
+
+    rng = np.random.default_rng(2)
+    poloidal_flux_bar = rng.standard_normal(model.ns)
+    coefficient_size = 12 * model.ns * model.mpol * (model.ntor + 1)
+    coefficient_bar = np.zeros(coefficient_size)
+    state_bar = np.asarray(
+        model.geometry_state_vjp(
+            np.ascontiguousarray(coefficient_bar),
+            np.ascontiguousarray(poloidal_flux_bar),
+        ),
+        dtype=np.float64,
+    )
+
+    def poloidal_flux(x):
+        model.set_state(np.ascontiguousarray(x))
+        model.evaluate(2, 2, True)
+        return np.asarray(model.get_geometry().poloidal_flux, dtype=np.float64).copy()
+
+    direction = rng.standard_normal(state.size)
+    direction /= np.linalg.norm(direction)
+
+    errors = {}
+    for h in (1.0e-3, 1.0e-4, 1.0e-5):
+        d_flux = (
+            poloidal_flux(state + h * direction) - poloidal_flux(state - h * direction)
+        ) / (2 * h)
+        model.set_state(np.ascontiguousarray(state))
+        model.evaluate(2, 2, True)
+        lhs = poloidal_flux_bar @ d_flux
+        rhs = state_bar @ direction
+        errors[h] = abs(lhs - rhs) / abs(lhs)
+    assert errors[1.0e-5] < 1.0e-4
+    assert errors[1.0e-5] < errors[1.0e-4] < errors[1.0e-3]
+
+
+def test_differentiable_vmec_accepts_ncurr1() -> None:
+    indata = _ncurr1_input()
+    solver = autodiff.make_solver(indata)
+    assert solver.vmec_input.ncurr == 1
+
+
+def test_quasisymmetry_gradient_through_a_prescribed_current_solve() -> None:
+    """End to end: jax.grad of a poloidal_flux + boundary objective through an
+    ncurr=1 solve, against a Richardson-extrapolated central difference of the
+    re-solved equilibrium.
+
+    VMEC's m=1 constraint gauge moves during the native transient, so small
+    relative perturbations (with Richardson extrapolation) are needed for a
+    stable finite-difference reference.
+    """
+    indata = _ncurr1_input()
+    _requires_exact_derivatives(indata)
+    solver = autodiff.make_solver(indata)
+    boundary = _boundary(indata)
+    ns = int(np.asarray(indata.ns_array)[-1])
+    mid = ns // 2
+
+    def objective(value):
+        geometry = solver(value)
+        dchi = geometry.poloidal_flux[mid + 1] - geometry.poloidal_flux[mid]
+        dphi = geometry.toroidal_flux[mid + 1] - geometry.toroidal_flux[mid]
+        iota_mid = dchi / dphi
+        return iota_mid + 10.0 * geometry.r_cc[mid, 1, 0] ** 2
+
+    value, gradient = jax.value_and_grad(objective)(jnp.asarray(boundary))
+    gradient = np.asarray(gradient)
+    assert np.isfinite(float(value))
+    assert np.all(np.isfinite(gradient))
+
+    def objective_np(value: np.ndarray) -> float:
+        model = autodiff._solve_model(indata._to_cpp_vmecindata(), value)
+        geometry = model.get_geometry()
+        dchi = geometry.poloidal_flux[mid + 1] - geometry.poloidal_flux[mid]
+        dphi = geometry.toroidal_flux[mid + 1] - geometry.toroidal_flux[mid]
+        iota_mid = dchi / dphi
+        r_cc = np.asarray(geometry.coefficients.r_cc).reshape(
+            model.ns, model.mpol, model.ntor + 1
+        )
+        return float(iota_mid + 10.0 * r_cc[mid, 1, 0] ** 2)
+
+    # the three largest-amplitude boundary modes (rbc[m=1,n=0], zbs[m=1,n=0],
+    # rbc[m=0,n=0]); a relative perturbation on a near-zero mode collapses to
+    # an absolute step far below the equilibrium's own noise floor
+    modes = [(0, 1, 4), (1, 1, 4), (0, 0, 4)]
+    for row, m, n in modes:
+        base = boundary[row, m, n]
+        deltas = {}
+        for relative_step in (1.0e-3, 5.0e-4):
+            h = relative_step * abs(base)
+            plus = boundary.copy()
+            plus[row, m, n] += h
+            minus = boundary.copy()
+            minus[row, m, n] -= h
+            deltas[h] = (objective_np(plus) - objective_np(minus)) / (2 * h)
+        h_coarse, h_fine = sorted(deltas, reverse=True)  # h_coarse = 2 * h_fine
+        richardson = (4.0 * deltas[h_fine] - deltas[h_coarse]) / 3.0
+        fd_floor = abs(deltas[h_fine] - richardson)  # FD stability at the finer step
+        exact = gradient[row, m, n]
+        relative_error = abs(richardson - exact) / max(abs(exact), 1.0e-300)
+        assert relative_error < 2.0e-3, (
+            f"mode {(row, m, n)}: richardson={richardson}, exact={exact}, "
+            f"relerr={relative_error}, fd_floor={fd_floor}"
+        )


### PR DESCRIPTION
## Scope

The implicit adjoint (`DifferentiableVmec` / `VmecModel.geometry_state_vjp`) rejected `ncurr = 1` (prescribed toroidal current) equilibria outright. Prescribed-current is the common case for stellarator design, so the adjoint was unusable for it. This change makes it work, without touching the `ncurr = 0` path.

## Background

For `ncurr = 1`, `IdealMhdModel::computeBContra` solves an affine Ampere constraint `<B_theta>_k = currH_k` for chi' on each half surface `k` from the live geometry (`guu`, `bsupu`, `bsupv`, `gsqrt`), rather than reading a fixed iota profile. `local_force_composition.h` already differentiates that solve, as a side effect of #841 (which needed the same chi'-consistent `bsupu` to differentiate the constraint-force multiplier `tcon`). So the existing Enzyme forward/reverse passes already carry `d(chi')/dx` for `ncurr = 1` -- what was missing was a way to route `geometry_state_vjp`'s `poloidal_flux` cotangent through it.

## Change

- `local_force_composition.h`: chi' becomes an explicit 21st output block of `ComputeLocalForceDensity`, populated only for `ncurr == 1`. This is the only change to the kernel; `ncurr == 0` does not populate the new block and its other outputs are unchanged, so `ncurr == 0` behavior is unaffected.
- `ideal_mhd_model.{h,cc}`: `IdealMhdModel::chipStateVjp` seeds the existing reverse-mode kernel on that block alone and reuses the geometry-side half of `applyExactForceJacobianTranspose` to produce `(dchi'/dx)^T chip_bar` in the decomposed state basis.
- `pybind_vmec.cc`:
  - `VmecModel.chip_state_vjp` exposes `chipStateVjp`.
  - `VmecModel.geometry_state_vjp` takes an additional `poloidal_flux_bar` argument. For `ncurr = 1` it converts the poloidal-flux cotangent -- `chi_j = sum_{k<j} c_k * iota_k` with `c_k` the state-independent flux step -- into `chip_bar = iota_bar / phipH` and adds `chip_state_vjp(chip_bar)` to the state cotangent.
  - `VmecModel.chip_h` exposes `chipH` (used by the new tests, and generally useful for anyone probing the current-constrained profile).
- `autodiff.py`: `DifferentiableVmec` no longer rejects `ncurr = 1`; the poloidal_flux cotangent is routed to `geometry_state_vjp` instead of being silently dropped.

## Tests and measurements

All measurements on `examples/data/cth_like_fixed_bdy.json` (an `ncurr = 1` stellarator case), `ns = 15`, `ftol = 1e-16`.

- **Exact HVP already includes the chi' derivative for `ncurr = 1`.** `exact_hessian_vector_product` vs. a central difference of the raw force: relative error 1.17e-8 at `h = 1e-6`, with clean O(h^2) convergence (1.17e-4 at `h = 1e-4`, 1.17e-6 at `h = 1e-5`). This uses only the pre-existing machinery from #841 and confirms the premise before adding any new code path.
- **The `ncurr = 1` functional really differs from a frozen-iota one.** The same converged state re-evaluated with `ncurr = 0` and the converged iota profile prescribed (via `populate_raw_profile`) reproduces the same force residual (`fsqr < 1e-6`) but its exact HVP differs from the `ncurr = 1` exact HVP by 1.5e-3 relative -- the two are different functionals, as expected, not numerically identical up to solver noise.
- **`chip_state_vjp` vs. central difference of `chipH(x)`:** relative error 1.2e-8 at `h = 1e-6`, clean O(h^2) convergence down from 1.2e-2 at `h = 1e-3`.
- **`geometry_state_vjp`'s `poloidal_flux` route end to end** (`poloidal_flux_bar` -> `chip_bar` -> `chip_state_vjp`) vs. a central difference of `MakeGeometry`'s own `poloidal_flux`: relative error 5.6e-8 at `h = 1e-5`, clean O(h^2) convergence.
- **End-to-end `jax.grad`** of `J = iota_half[mid] + 10 * r_cc[mid, 1, 0]^2` through a re-solved `ncurr = 1` equilibrium, differentiating through three boundary modes, checked against Richardson-extrapolated central differences (relative steps `1e-3`/`5e-4`) of the re-solved equilibrium: relative errors 3.2e-4, 5.5e-4, 1.5e-3. The FD reference itself is noise-dominated below roughly 1e-3 relative on this case -- smaller steps do not improve agreement and instead drift, consistent with the native m=1 gauge transient moving between re-solves; this is a property of the finite-difference reference, not of the analytic gradient, and is why the test uses a modest number of moderate steps with Richardson extrapolation rather than pushing `h` to zero.