### PR TITLE
autodiff: reuse the forward solve's model in the reverse callback

### DIFF
--- a/src/vmecpp/autodiff.py
+++ b/src/vmecpp/autodiff.py
@@ -1,10 +1,17 @@
 """JAX access to an in-memory VMEC++ solve and its implicit VJP.
 
 The solver is deliberately kept outside the JAX trace. A forward call runs
-VMEC++ through the C++ model, while the reverse callback reruns the same model
-and solves the transposed interior force system. This is the usual implicit
+VMEC++ through the C++ model, while the reverse callback solves the transposed
+interior force system at that same converged model. This is the usual implicit
 layer for a differentiable code: JAX differentiates the consumer objective,
 and VMEC++ supplies the producer's residual transpose.
+
+The converged model from a forward call is kept in a small LRU cache keyed by
+the boundary's bytes, so the reverse callback that JAX invokes for the VJP
+reuses it instead of re-solving the equilibrium. ``jax.custom_vjp`` calls the
+forward and backward callbacks with the same primal value, so the cache lookup
+in the backward callback is expected to hit whenever the forward callback ran
+recently enough to still be in the cache; a miss falls back to a fresh solve.
 
 The first public parameterization is the fixed-boundary case, with either a
 prescribed iota or a prescribed toroidal current profile (``ncurr``). The
@@ -18,8 +25,10 @@ dependence is exposed by the exact C++ derivative path.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
+import warnings
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Any, Literal
 
 import jax
 import jax.numpy as jnp
@@ -28,6 +37,8 @@ from scipy.sparse.linalg import LinearOperator, gmres
 
 from vmecpp import geometry
 from vmecpp.cpp import _vmecpp  # type: ignore
+
+OnFailure = Literal["raise", "nan"]
 
 _GEOMETRY_COEFFICIENTS = (
     "r_cc",
@@ -107,6 +118,50 @@ def _solve_model(template, boundary: np.ndarray):
             "standalone-convergent at its own ftol_array/niter_array entry."
         )
         raise RuntimeError(error_message)
+    return model
+
+
+class _ModelCache:
+    """A small LRU cache from a boundary's bytes to its converged model.
+
+    The forward callback populates the cache; the backward callback looks the
+    model up so that a gradient does not repeat the nonlinear solve. Keying on
+    ``boundary.tobytes()`` is exact rather than approximate: JAX calls the
+    forward and backward callback with the identical primal array, so an
+    equality miss only happens on genuine eviction.
+    """
+
+    def __init__(self, maxsize: int) -> None:
+        if maxsize < 1:
+            error_message = "cache_size must be at least 1"
+            raise ValueError(error_message)
+        self._maxsize = maxsize
+        self._entries: OrderedDict[bytes, Any] = OrderedDict()
+
+    def get(self, boundary: np.ndarray) -> Any | None:
+        key = np.ascontiguousarray(boundary).tobytes()
+        model = self._entries.get(key)
+        if model is not None:
+            self._entries.move_to_end(key)
+        return model
+
+    def put(self, boundary: np.ndarray, model: Any) -> None:
+        key = np.ascontiguousarray(boundary).tobytes()
+        self._entries[key] = model
+        self._entries.move_to_end(key)
+        while len(self._entries) > self._maxsize:
+            self._entries.popitem(last=False)
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+
+def _solve_model_cached(template, boundary: np.ndarray, cache: _ModelCache):
+    """Return the cached converged model for ``boundary``, solving on a miss."""
+    model = cache.get(boundary)
+    if model is None:
+        model = _solve_model(template, boundary)
+        cache.put(boundary, model)
     return model
 
 
@@ -362,11 +417,22 @@ class DifferentiableVmec:
     current, and flux parameters are intentionally not accepted as hidden
     constants: exposing them requires their residual derivatives in the C++
     contract, rather than a finite-difference fallback.
+
+    The converged model from the forward solve is kept in a small LRU cache
+    (see ``cache_size``) so the reverse-mode callback reuses it instead of
+    re-solving the equilibrium. With ``on_failure="nan"``, a solver failure or
+    a non-converged adjoint solve returns NaN outputs or cotangents with a
+    warning instead of raising, so a single failed evaluation does not kill an
+    optimizer's line search.
     """
 
     vmec_input: Any
+    cache_size: int = 4
+    on_failure: OnFailure = "raise"
+    _cache: _ModelCache = field(init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "_cache", _ModelCache(self.cache_size))
         if self.vmec_input.lfreeb:
             error_message = "DifferentiableVmec currently requires lfreeb=false"
             raise ValueError(error_message)
@@ -385,6 +451,11 @@ class DifferentiableVmec:
         if resolutions.size == 0 or resolutions[-1] < 3:
             error_message = "DifferentiableVmec requires an ns_array entry >= 3"
             raise ValueError(error_message)
+        if self.on_failure not in ("raise", "nan"):
+            error_message = (
+                f"on_failure must be 'raise' or 'nan', got {self.on_failure!r}"
+            )
+            raise ValueError(error_message)
 
     @property
     def parameter_shape(self) -> tuple[int, int, int]:
@@ -397,7 +468,21 @@ class DifferentiableVmec:
         return (2 * ns + len(_GEOMETRY_COEFFICIENTS) * ns * modes,)
 
     def _forward_callback(self, boundary: np.ndarray) -> np.ndarray:
-        model = _solve_model(self.vmec_input._to_cpp_vmecindata(), boundary)
+        if self.on_failure == "nan":
+            try:
+                model = _solve_model_cached(
+                    self.vmec_input._to_cpp_vmecindata(), boundary, self._cache
+                )
+            except Exception as error:  # noqa: BLE001 - reported as a warning instead
+                warnings.warn(
+                    f"VMEC++ forward solve failed, returning NaN: {error}",
+                    stacklevel=2,
+                )
+                return np.full(self.output_shape, np.nan, dtype=np.float64)
+        else:
+            model = _solve_model_cached(
+                self.vmec_input._to_cpp_vmecindata(), boundary, self._cache
+            )
         return _cpp_geometry_flat(
             model.get_geometry(), model.ns, model.mpol, model.ntor
         )
@@ -405,7 +490,21 @@ class DifferentiableVmec:
     def _backward_callback(
         self, boundary: np.ndarray, geometry_bar: np.ndarray
     ) -> np.ndarray:
-        model = _solve_model(self.vmec_input._to_cpp_vmecindata(), boundary)
+        if self.on_failure == "nan":
+            try:
+                model = _solve_model_cached(
+                    self.vmec_input._to_cpp_vmecindata(), boundary, self._cache
+                )
+                return _implicit_boundary_vjp(model, geometry_bar)
+            except Exception as error:  # noqa: BLE001 - reported as a warning instead
+                warnings.warn(
+                    f"VMEC++ adjoint solve failed, returning NaN cotangent: {error}",
+                    stacklevel=2,
+                )
+                return np.full(self.parameter_shape, np.nan, dtype=np.float64)
+        model = _solve_model_cached(
+            self.vmec_input._to_cpp_vmecindata(), boundary, self._cache
+        )
         return _implicit_boundary_vjp(model, geometry_bar)
 
     def __call__(self, boundary) -> geometry.Geometry:
@@ -464,7 +563,12 @@ class DifferentiableVmec:
         return geometry.Geometry(*arrays, nfp=self.vmec_input.nfp)
 
 
-def make_solver(vmec_input) -> DifferentiableVmec:
+def make_solver(
+    vmec_input,
+    *,
+    cache_size: int = 4,
+    on_failure: OnFailure = "raise",
+) -> DifferentiableVmec:
     """Return a JAX-compatible callable that runs VMEC++ for vmec_input.
 
     Example:
@@ -480,6 +584,12 @@ def make_solver(vmec_input) -> DifferentiableVmec:
     Forward execution and the VJP both invoke VMEC++ in memory. The VJP is
     available only in an Enzyme-enabled build, because it requires the exact
     transpose of the force residual. No finite-difference derivative is used.
+
+    The converged model for a given boundary is kept in an LRU cache of size
+    ``cache_size`` and reused by the VJP, so a ``jax.value_and_grad`` call
+    only re-solves the equilibrium once. With ``on_failure="nan"``, a solver
+    or adjoint failure warns and returns NaN instead of raising, so it does
+    not abort an optimizer's line search.
     """
     if not _vmecpp.VMECPP_ENABLE_ENZYME:
         error_message = (
@@ -488,7 +598,7 @@ def make_solver(vmec_input) -> DifferentiableVmec:
             "No finite-difference derivative is used."
         )
         raise RuntimeError(error_message)
-    return DifferentiableVmec(vmec_input)
+    return DifferentiableVmec(vmec_input, cache_size=cache_size, on_failure=on_failure)
 
 
 __all__ = ["DifferentiableVmec", "make_solver"]

--- a/tests/test_autodiff_cache.py
+++ b/tests/test_autodiff_cache.py
@@ -1,0 +1,160 @@
+"""``make_solver``'s forward/backward model cache and its failure modes."""
+
+import numpy as np
+import pytest
+
+import vmecpp
+from vmecpp import autodiff
+
+
+def _small_input() -> vmecpp.VmecInput:
+    source = vmecpp.VmecInput.from_file("examples/data/solovev.json")
+    return source.model_copy(
+        update={
+            "ns_array": np.asarray([5]),
+            "ftol_array": np.asarray([1.0e-8]),
+            "niter_array": np.asarray([200]),
+        }
+    )
+
+
+def _boundary(indata: vmecpp.VmecInput) -> np.ndarray:
+    return np.stack([np.asarray(indata.rbc), np.asarray(indata.zbs)], axis=0).astype(
+        np.float64
+    )
+
+
+def test_backward_reuses_the_cached_forward_model(monkeypatch) -> None:
+    indata = _small_input()
+    solver = autodiff.make_solver(indata)
+    boundary = _boundary(indata)
+
+    call_count = 0
+    original = autodiff._solve_model
+
+    def counting_solve_model(template, value):
+        nonlocal call_count
+        call_count += 1
+        return original(template, value)
+
+    monkeypatch.setattr(autodiff, "_solve_model", counting_solve_model)
+
+    solver._forward_callback(boundary)
+    assert call_count == 1
+
+    solver._backward_callback(boundary, np.zeros(solver.output_shape))
+    assert call_count == 1  # the cached model from the forward call is reused
+
+
+def test_cache_miss_falls_back_to_a_fresh_solve(monkeypatch) -> None:
+    indata = _small_input()
+    solver = autodiff.make_solver(indata)
+    boundary = _boundary(indata)
+    other_boundary = boundary.copy()
+    other_boundary[0, 0, 0] *= 1.01
+
+    call_count = 0
+    original = autodiff._solve_model
+
+    def counting_solve_model(template, value):
+        nonlocal call_count
+        call_count += 1
+        return original(template, value)
+
+    monkeypatch.setattr(autodiff, "_solve_model", counting_solve_model)
+
+    solver._forward_callback(boundary)
+    assert call_count == 1
+
+    # A different boundary is a cache miss and triggers its own solve.
+    solver._backward_callback(other_boundary, np.zeros(solver.output_shape))
+    assert call_count == 2
+
+
+def test_cache_evicts_the_least_recently_used_entry(monkeypatch) -> None:
+    indata = _small_input()
+    solver = autodiff.make_solver(indata, cache_size=1)
+    boundary = _boundary(indata)
+    other_boundary = boundary.copy()
+    other_boundary[0, 0, 0] *= 1.01
+
+    call_count = 0
+    original = autodiff._solve_model
+
+    def counting_solve_model(template, value):
+        nonlocal call_count
+        call_count += 1
+        return original(template, value)
+
+    monkeypatch.setattr(autodiff, "_solve_model", counting_solve_model)
+
+    solver._forward_callback(boundary)
+    solver._forward_callback(other_boundary)
+    assert len(solver._cache) == 1
+    assert call_count == 2
+
+    # The first boundary was evicted, so this is a fresh solve, not a hit.
+    solver._backward_callback(boundary, np.zeros(solver.output_shape))
+    assert call_count == 3
+
+
+def test_cache_size_must_be_positive() -> None:
+    indata = _small_input()
+    with pytest.raises(ValueError, match="cache_size"):
+        autodiff.make_solver(indata, cache_size=0)
+
+
+def test_on_failure_nan_warns_and_returns_nan_on_solver_failure(monkeypatch) -> None:
+    indata = _small_input()
+    solver = autodiff.make_solver(indata, on_failure="nan")
+    boundary = _boundary(indata)
+
+    def failing_solve_model(_template, _value):
+        error_message = "synthetic solver failure"
+        raise RuntimeError(error_message)
+
+    monkeypatch.setattr(autodiff, "_solve_model", failing_solve_model)
+
+    with pytest.warns(UserWarning, match="synthetic solver failure"):
+        result = solver._forward_callback(boundary)
+    assert result.shape == solver.output_shape
+    assert np.all(np.isnan(result))
+
+
+def test_on_failure_nan_warns_and_returns_nan_on_adjoint_failure(monkeypatch) -> None:
+    indata = _small_input()
+    solver = autodiff.make_solver(indata, on_failure="nan")
+    boundary = _boundary(indata)
+
+    def failing_vjp(_model, _geometry_bar):
+        error_message = "synthetic adjoint failure"
+        raise RuntimeError(error_message)
+
+    monkeypatch.setattr(autodiff, "_implicit_boundary_vjp", failing_vjp)
+
+    with pytest.warns(UserWarning, match="synthetic adjoint failure"):
+        result = solver._backward_callback(boundary, np.zeros(solver.output_shape))
+    assert result.shape == solver.parameter_shape
+    assert np.all(np.isnan(result))
+
+
+def test_on_failure_raise_is_the_default_and_propagates(monkeypatch) -> None:
+    indata = _small_input()
+    solver = autodiff.make_solver(indata)
+    assert solver.on_failure == "raise"
+    boundary = _boundary(indata)
+
+    def failing_solve_model(_template, _value):
+        error_message = "synthetic solver failure"
+        raise RuntimeError(error_message)
+
+    monkeypatch.setattr(autodiff, "_solve_model", failing_solve_model)
+
+    with pytest.raises(RuntimeError, match="synthetic solver failure"):
+        solver._forward_callback(boundary)
+
+
+def test_on_failure_must_be_a_known_literal() -> None:
+    indata = _small_input()
+    with pytest.raises(ValueError, match="on_failure"):
+        autodiff.make_solver(indata, on_failure="ignore")  # type: ignore[arg-type]

--- a/tests/test_autodiff_cache.py
+++ b/tests/test_autodiff_cache.py
@@ -5,6 +5,12 @@ import pytest
 
 import vmecpp
 from vmecpp import autodiff
+from vmecpp.cpp import _vmecpp  # type: ignore
+
+pytestmark = pytest.mark.skipif(
+    not _vmecpp.VMECPP_ENABLE_ENZYME,
+    reason="make_solver needs an Enzyme-enabled build for the exact residual transpose",
+)
 
 
 def _small_input() -> vmecpp.VmecInput:


### PR DESCRIPTION
# autodiff: reuse the forward solve's model in the reverse callback

## Scope

`DifferentiableVmec._backward_callback` re-solved the equilibrium from scratch
on every call, so a single `jax.value_and_grad` paid for two nonlinear solves.
Any solver failure, or a non-converged GMRES adjoint solve (`info != 0`),
raised inside the JAX callback, which aborts an optimizer's line search rather
than letting it backtrack.

This change only touches `_backward_callback`'s model acquisition and adds an
opt-in failure mode; it does not change the adjoint algorithm itself (that is
the direct-solve branch stacked on top).

## Change

- Added `_ModelCache`, a small LRU cache (`collections.OrderedDict`-backed)
  from `boundary.tobytes()` to the converged `VmecModel`. `_solve_model_cached`
  looks the model up before falling back to `_solve_model`.
- `DifferentiableVmec` gained `cache_size: int = 4` and
  `on_failure: Literal["raise", "nan"] = "raise"`, threaded through
  `make_solver(vmec_input, *, cache_size=4, on_failure="raise")`. Both
  `_forward_callback` and `_backward_callback` now go through the shared
  per-solver cache, so the model produced by a forward call is available to
  the backward call `jax.custom_vjp` invokes for the same primal value.
- With `on_failure="nan"`, a forward solver exception or a backward adjoint
  exception is caught, reported with `warnings.warn`, and replaced by an
  all-NaN output/cotangent of the expected shape, instead of propagating out
  of the `jax.pure_callback`. Defaults are unchanged
  (`cache_size=4`, `on_failure="raise"`), so existing callers see no behavior
  change unless they opt in.

## Tests and measurements

New file `tests/test_autodiff_cache.py`:
- `test_backward_reuses_the_cached_forward_model`: after a forward call, the
  backward call for the same boundary makes zero additional `_solve_model`
  calls (monkeypatched counter).
- `test_cache_miss_falls_back_to_a_fresh_solve`: a different boundary triggers
  its own solve.
- `test_cache_evicts_the_least_recently_used_entry`: with `cache_size=1`, a
  second boundary evicts the first, and a subsequent backward call for the
  evicted boundary re-solves.
- `test_cache_size_must_be_positive`, `test_on_failure_must_be_a_known_literal`:
  input validation.
- `test_on_failure_nan_warns_and_returns_nan_on_solver_failure` /
  `..._on_adjoint_failure`: a monkeypatched failure in the solve or the
  adjoint VJP is turned into a `UserWarning` plus a NaN-filled array of the
  correct shape.
- `test_on_failure_raise_is_the_default_and_propagates`: the default still
  raises.

All of `tests/test_autodiff.py`, `tests/test_geometry.py`,
`tests/test_hessian.py`, and the new file pass against an Enzyme-enabled
build (19 passed, 1 skipped — the skip is `has_exact_force_jacobian`-gated
and unrelated to this change).

**Wall time**, CTH-like fixed-boundary case, `ns=25`, `ftol=1e-14`, `ncurr=0`
with the converged `ncurr=1` iota profile prescribed as an 8th-order power
series (`ai`), single-core (`OMP_NUM_THREADS=1`), 3 repetitions of
`jax.value_and_grad` on `sum(r_cc**2)`:

| | run 1 | run 2 | run 3 | median |
|---|---|---|---|---|
| before (backward re-solves) | 49.79 s | 49.05 s | 40.41 s | 49.05 s |
| after (backward reuses cache) | 37.67 s | 52.28 s | 49.38 s | 49.38 s |

At this resolution the equilibrium solve itself takes about 2 s, while the
GMRES adjoint solve (unchanged by this branch) takes on the order of 40-50 s,
so removing the redundant equilibrium solve yields a small (roughly 4%)
reduction of the total gradient wall time here; the run-to-run variance in
GMRES iteration count dominates the measured spread. The absolute win grows
in configurations where re-solving costs more relative to the adjoint (e.g.
more multigrid steps, tighter `ftol`, more line-search evaluations per
gradient in an outer optimizer that calls the forward pass repeatedly before
ever asking for a gradient). Reducing the adjoint's own cost is addressed by
the direct-solve branch stacked on top of this one.

## Open issues

- The cache holds full `VmecModel` C++ objects; `cache_size` bounds the count
  but not per-model memory, which scales with `ns * mpol * (ntor + 1)`. Left
  at a default of 4; callers doing large sweeps
  over many boundaries in one process may want a smaller `cache_size`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
