### PR TITLE
autodiff: expose the flat state layout as a public StateLayout

### DIFF
--- a/src/vmecpp/autodiff.py
+++ b/src/vmecpp/autodiff.py
@@ -21,6 +21,30 @@ supports the stellarator-symmetric fixed-boundary case. The geometry API
 itself already supports asymmetric snapshots; profile and free-boundary
 parameter VJPs remain explicit unsupported cases until their residual
 dependence is exposed by the exact C++ derivative path.
+
+State layout
+------------
+
+``VmecModel.get_state()`` and ``get_forces()`` return one flat vector that
+concatenates a fixed sequence of coefficient spans (see :func:`state_layout`):
+``r_cc``, and depending on ``lthreed``/``lasym``, ``r_ss``, ``r_sc``, ``r_cs``,
+then the analogous ``z_*`` spans, then the analogous ``lambda_*`` spans. Which
+spans are present follows the same combination of ``lthreed``/``lasym`` used
+throughout the C++ layer: the sine-cosine mode is always present, the
+three-dimensional mode is added under ``lthreed``, the asymmetric mode under
+``lasym``, and the mixed one only when both hold.
+
+Each span holds ``ns * mpol * (ntor + 1)`` entries in surface-major order:
+surface index varies slowest, then poloidal mode ``m`` from ``0`` to
+``mpol - 1``, then toroidal mode ``n`` from ``0`` to ``ntor``. This matches
+the ``(ns, mpol, ntor + 1)`` block shape used by :class:`vmecpp.Geometry` and
+by ``VmecModel.get_geometry()``. The last surface's ``r``/``z`` entries are
+the fixed plasma boundary; the corresponding ``lambda`` entries at that
+surface are still solved for. The mode amplitudes stored in the state are
+scaled relative to the external, "combined" Fourier basis (``rmnc``, ``zmns``,
+...): entries with ``m != 0`` and ``n != 0`` carry an extra factor of
+``sqrt(2)`` for each nonzero index, matching ``Boundaries::ensureM1Constrained``
+and the parser inverted by :func:`_boundary_from_state_vjp`.
 """
 
 from __future__ import annotations
@@ -165,8 +189,100 @@ def _solve_model_cached(template, boundary: np.ndarray, cache: _ModelCache):
     return model
 
 
+_RZ_SPAN_NAMES = ("r_cc", "r_ss", "r_sc", "r_cs", "z_sc", "z_cs", "z_cc", "z_ss")
+
+# The m=1 gauge entries zeroed by FourierForces::zeroZForceForM1: the force
+# row is identically zero, but the Hessian column is not, because the state
+# entry still feeds the m=1 constraint coupling to r_ss/z_cs (M1Constraint).
+_GAUGE_SPAN_NAMES = {"z_cs": "lthreed", "z_cc": "lasym"}
+
+
+@dataclass(frozen=True)
+class StateLayout:
+    """The flat solver state's span structure and derived index sets.
+
+    ``VmecModel.get_state()``/``get_forces()`` concatenate coefficient spans
+    in a fixed order (see the module docstring); this layout names that order
+    and partitions the flat indices by role. ``interior`` and ``boundary``
+    partition the whole state; ``solved`` is ``interior`` with the structural
+    zeros and the m=1 gauge entries removed, i.e. the DOFs the adjoint system
+    is actually solved for.
+    """
+
+    spans: dict[str, slice]
+    surface: dict[str, np.ndarray]
+    mode: dict[str, np.ndarray]
+    boundary: np.ndarray
+    interior: np.ndarray
+    structural_zero: np.ndarray
+    gauge: np.ndarray
+    solved: np.ndarray
+
+
+def state_layout(
+    model, n_probe: int = 6, tol: float = 1.0e-9, seed: int = 0
+) -> StateLayout:
+    """Return the flat state's span structure and index sets for ``model``.
+
+    ``n_probe``, ``tol``, and ``seed`` control the Hessian-vector probing used
+    to separate ``structural_zero`` and ``gauge`` entries from ``solved``
+    entries; see :func:`_structural_nullfree_interior`.
+    """
+    spans = _span_slices(model)
+    modes_per_surface = model.mpol * (model.ntor + 1)
+    surface: dict[str, np.ndarray] = {}
+    mode: dict[str, np.ndarray] = {}
+    for name, span in spans.items():
+        local = np.arange(span.stop - span.start)
+        surface[name] = local // modes_per_surface
+        mode[name] = local % modes_per_surface
+    interior, boundary = _interior_and_boundary(model)
+    nullfree = _structural_nullfree_interior(
+        model, interior, n_probe=n_probe, tol=tol, seed=seed
+    )
+    # zeroZForceForM1 makes the gauge force row identically zero, so the
+    # column-and-row probe in _structural_nullfree_interior already puts the
+    # gauge entries in interior - nullfree, alongside the genuine structural
+    # zeros. Split them out by name/mode instead of by probing: z_cs/z_cc are
+    # r/z spans, so their boundary-surface row is already part of `boundary`;
+    # restrict to the interior surfaces.
+    gauge = np.intersect1d(_gauge_indices(model, spans), interior)
+    structural_zero = np.setdiff1d(np.setdiff1d(interior, nullfree), gauge)
+    solved = nullfree
+    return StateLayout(
+        spans=spans,
+        surface=surface,
+        mode=mode,
+        boundary=boundary,
+        interior=interior,
+        structural_zero=structural_zero,
+        gauge=gauge,
+        solved=solved,
+    )
+
+
+def _gauge_indices(model, spans: dict[str, slice]) -> np.ndarray:
+    """The m=1 constraint-gauge entries zeroed by ``zeroZForceForM1``."""
+    modes_per_surface = model.mpol * (model.ntor + 1)
+    indices: list[int] = []
+    for name, flag_name in _GAUGE_SPAN_NAMES.items():
+        if name not in spans or not getattr(model, flag_name):
+            continue
+        span = spans[name]
+        for j in range(model.ns):
+            surface_start = span.start + j * modes_per_surface
+            m = 1
+            row_start = surface_start + m * (model.ntor + 1)
+            indices.extend(range(row_start, row_start + model.ntor + 1))
+    return np.asarray(sorted(indices), dtype=np.int64)
+
+
 def _span_slices(model) -> dict[str, slice]:
-    """Return slices in VmecModel's canonical active-state ordering."""
+    """Return slices in VmecModel's canonical active-state ordering.
+
+    Thin wrapper kept for the existing private call sites; use
+    :func:`state_layout` for new code.
+    """
     names: list[str] = ["r_cc"]
     if model.lthreed:
         names.append("r_ss")
@@ -196,21 +312,16 @@ def _span_slices(model) -> dict[str, slice]:
 
 
 def _interior_and_boundary(model) -> tuple[np.ndarray, np.ndarray]:
+    """Thin wrapper kept for the existing private call sites.
+
+    Use ``state_layout(model).interior`` / ``.boundary`` for new code.
+    """
     slices = _span_slices(model)
     state_size = int(np.asarray(model.get_state()).size)
     boundary: list[int] = []
     modes_per_surface = model.mpol * (model.ntor + 1)
     edge_start = (model.ns - 1) * modes_per_surface
-    for name in (
-        "r_cc",
-        "r_ss",
-        "r_sc",
-        "r_cs",
-        "z_sc",
-        "z_cs",
-        "z_cc",
-        "z_ss",
-    ):
+    for name in _RZ_SPAN_NAMES:
         if name in slices:
             span = slices[name]
             boundary.extend(range(span.start + edge_start, span.stop))
@@ -601,4 +712,4 @@ def make_solver(
     return DifferentiableVmec(vmec_input, cache_size=cache_size, on_failure=on_failure)
 
 
-__all__ = ["DifferentiableVmec", "make_solver"]
+__all__ = ["DifferentiableVmec", "StateLayout", "make_solver", "state_layout"]

--- a/tests/test_autodiff_state_layout.py
+++ b/tests/test_autodiff_state_layout.py
@@ -1,0 +1,143 @@
+"""``autodiff.state_layout``'s index sets and their agreement with the private helpers
+it replaces."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import vmecpp
+from vmecpp import autodiff
+from vmecpp.cpp import _vmecpp  # type: ignore
+
+SOLOVEV = Path(__file__).resolve().parents[1] / "examples" / "data" / "solovev.json"
+
+
+def _requires_exact_derivatives(model) -> None:
+    if not model.has_exact_force_jacobian:
+        pytest.skip("needs an Enzyme-enabled build for the exact residual transpose")
+
+
+def _2d_model(ns: int = 5):
+    indata = _vmecpp.VmecINDATA.from_file(str(SOLOVEV))
+    model = _vmecpp.VmecModel.create(indata, ns)
+    model.solve()
+    return model
+
+
+def _3d_model(ns: int = 5):
+    """A genuinely three-dimensional fixed-boundary, ncurr=0 case.
+
+    The 2D case cannot exercise the ``r_ss``, ``z_cs`` and ``lambda_cs``
+    blocks at all, and it is exactly the ``z_cs``/``z_cc`` blocks that carry
+    the m=1 constraint gauge entries.
+    """
+    source = vmecpp.VmecInput.from_file(str(SOLOVEV))
+    mpol = source.mpol
+    rbc = np.zeros((mpol, 3))
+    zbs = np.zeros((mpol, 3))
+    rbc[:, 1] = np.asarray(source.rbc)[:, 0]
+    zbs[:, 1] = np.asarray(source.zbs)[:, 0]
+    rbc[1, 2] = 0.01
+    zbs[1, 2] = 0.01
+    indata = source.model_copy(
+        update={
+            "ntor": 1,
+            "rbc": rbc,
+            "zbs": zbs,
+            "raxis_c": np.asarray([4.0, 0.0]),
+            "zaxis_s": np.asarray([0.0, 0.0]),
+            "ns_array": np.asarray([ns]),
+            "ftol_array": np.asarray([1.0e-15]),
+            "niter_array": np.asarray([4000]),
+        }
+    )
+    model = _vmecpp.VmecModel.create(indata._to_cpp_vmecindata(), ns)
+    model.solve()
+    return model
+
+
+@pytest.mark.parametrize("make_model", [_2d_model, _3d_model])
+def test_index_sets_partition_the_state(make_model) -> None:
+    model = make_model()
+    _requires_exact_derivatives(model)
+    model.evaluate(2, 2, True)
+    layout = autodiff.state_layout(model)
+
+    state_size = int(np.asarray(model.get_state()).size)
+    assert np.array_equal(
+        np.sort(np.concatenate([layout.boundary, layout.interior])),
+        np.arange(state_size),
+    )
+    assert np.intersect1d(layout.boundary, layout.interior).size == 0
+
+    reassembled_interior = np.sort(
+        np.concatenate([layout.structural_zero, layout.gauge, layout.solved])
+    )
+    assert np.array_equal(reassembled_interior, np.sort(layout.interior))
+    for first, second in (
+        (layout.structural_zero, layout.gauge),
+        (layout.structural_zero, layout.solved),
+        (layout.gauge, layout.solved),
+    ):
+        assert np.intersect1d(first, second).size == 0
+
+
+@pytest.mark.parametrize("make_model", [_2d_model, _3d_model])
+def test_solved_matches_the_previous_structural_nullfree_interior(make_model) -> None:
+    """``solved`` must equal the interior DOFs the adjoint solve used before this
+    change, minus the m=1 gauge rows introduced by this layout."""
+    model = make_model()
+    _requires_exact_derivatives(model)
+    model.evaluate(2, 2, True)
+
+    interior, _ = autodiff._interior_and_boundary(model)
+    nullfree = autodiff._structural_nullfree_interior(model, interior)
+    layout = autodiff.state_layout(model)
+
+    expected_solved = np.setdiff1d(nullfree, layout.gauge)
+    assert np.array_equal(np.sort(layout.solved), np.sort(expected_solved))
+
+
+def test_gauge_is_empty_in_two_dimensions() -> None:
+    """2D has no lthreed/lasym blocks, so there is nothing for zeroZForceForM1 to
+    zero."""
+    model = _2d_model()
+    _requires_exact_derivatives(model)
+    model.evaluate(2, 2, True)
+    layout = autodiff.state_layout(model)
+    assert layout.gauge.size == 0
+
+
+def test_gauge_force_rows_are_zero() -> None:
+    model = _3d_model()
+    _requires_exact_derivatives(model)
+    model.evaluate(2, 2, True)
+    layout = autodiff.state_layout(model)
+
+    assert layout.gauge.size > 0
+    forces = np.asarray(model.get_forces(), dtype=np.float64)
+    np.testing.assert_allclose(forces[layout.gauge], 0.0, atol=1.0e-12)
+
+
+def test_spans_partition_the_flat_state() -> None:
+    model = _2d_model()
+    layout = autodiff.state_layout(model)
+    state_size = int(np.asarray(model.get_state()).size)
+    covered = np.zeros(state_size, dtype=bool)
+    for span in layout.spans.values():
+        assert not covered[span].any()
+        covered[span] = True
+    assert covered.all()
+
+
+def test_surface_and_mode_indices_agree_with_the_span_shape() -> None:
+    model = _3d_model()
+    layout = autodiff.state_layout(model)
+    modes_per_surface = model.mpol * (model.ntor + 1)
+    for name, span in layout.spans.items():
+        span_length = span.stop - span.start
+        assert layout.surface[name].shape == (span_length,)
+        assert layout.mode[name].shape == (span_length,)
+        assert layout.surface[name].max() == model.ns - 1
+        assert layout.mode[name].max() == modes_per_surface - 1

--- a/tests/test_autodiff_state_layout.py
+++ b/tests/test_autodiff_state_layout.py
@@ -10,6 +10,11 @@ import vmecpp
 from vmecpp import autodiff
 from vmecpp.cpp import _vmecpp  # type: ignore
 
+pytestmark = pytest.mark.skipif(
+    not _vmecpp.VMECPP_ENABLE_ENZYME,
+    reason="state_layout probes the exact residual transpose (Enzyme-enabled build)",
+)
+
 SOLOVEV = Path(__file__).resolve().parents[1] / "examples" / "data" / "solovev.json"
 
 


### PR DESCRIPTION
# autodiff: expose the flat state layout as a public StateLayout

## Scope

The flat solver state (`VmecModel.get_state()`/`get_forces()`) is only
accessible through private helpers (`_span_slices`, `_interior_and_boundary`,
`_structural_nullfree_interior`, `_boundary_from_state_vjp`,
`_cpp_geometry_flat`, `_solve_model`), so downstream code has no supported way
to ask which flat index belongs to which coefficient span, surface, or mode.

## Change

- Added a public, frozen `StateLayout` dataclass and `state_layout(model)`
  constructor. `StateLayout` has:
  - `spans: dict[str, slice]` — the same span order as before, named.
  - `surface: dict[str, np.ndarray]` / `mode: dict[str, np.ndarray]` — per-span
    arrays giving each flat entry's surface index and its `(m, n)`-flattened
    mode index within the surface.
  - `boundary` / `interior` — partition the whole state (fixed `r`/`z` at the
    last surface vs. everything else).
  - `structural_zero` / `gauge` / `solved` — partition `interior`:
    - `structural_zero`: DOFs with both a zero Hessian row and column (no
      force depends on them and they produce no force) — unconstrained
      gauge/parity modes.
    - `gauge`: the m=1 constraint-gauge entries zeroed by
      `FourierForces::zeroZForceForM1` (`z_cs` under `lthreed`, `z_cc` under
      `lasym`). Their force row is identically zero, but unlike
      `structural_zero`, their Hessian *column* is not: the state entry still
      feeds the m=1 constraint coupling (`M1Constraint`) that other rows
      depend on.
    - `solved`: what `_structural_nullfree_interior` returned before this
      change, i.e. the DOFs the adjoint system is actually solved for, with
      the gauge rows now split out by name/mode instead of left folded into
      the general row/column probe. `gauge` rows already fail the probe's
      "row nonzero" test (since the force row is exactly zero), so they were
      already excluded from the old `nullfree` set; this change only gives
      that subset a name and an explicit, structural (not probed)
      derivation.
- `_span_slices` and `_interior_and_boundary` are now thin wrappers, kept for
  the existing private call sites (`_boundary_from_state_vjp`,
  `_implicit_boundary_vjp`, and the tests that probe them directly).
- The module docstring gained a "State layout" section documenting the state
  <-> `Geometry` correspondence: span order and which spans exist for a given
  `lthreed`/`lasym` combination, the `(ns, mpol, ntor + 1)` surface-major block
  layout matching `vmecpp.Geometry`/`get_geometry()`, and the `sqrt(2)` scaling
  of `m, n != 0` modes relative to the external combined basis.
- `StateLayout` and `state_layout` are added to `__all__`.

## Tests and measurements

New file `tests/test_autodiff_state_layout.py`, parameterized over a 2D
(solovev) and a 3D model (the same construction
`tests/test_autodiff.py::_small_3d_input` uses, so the `r_ss`/`z_cs`/`lambda_cs`
blocks and the `z_cs` gauge rows are exercised):

- `test_index_sets_partition_the_state`: `boundary ⊔ interior` covers the full
  state with no overlap, and `structural_zero ⊔ gauge ⊔ solved` covers
  `interior` with no overlap, for both the 2D and 3D cases.
- `test_solved_matches_the_previous_structural_nullfree_interior`: `solved`
  equals `_structural_nullfree_interior(model, interior)` minus `gauge`, i.e.
  the previously-returned interior set, now split into gauge and solved.
- `test_gauge_is_empty_in_two_dimensions`: the 2D case has no
  `lthreed`/`lasym` blocks, so there is nothing for `zeroZForceForM1` to zero.
- `test_gauge_force_rows_are_zero`: in the 3D case, `gauge` is nonempty and
  the raw force at those indices is exactly zero (to `1e-12`).
- `test_spans_partition_the_flat_state`: the named spans tile the flat state
  with no gaps or overlaps.
- `test_surface_and_mode_indices_agree_with_the_span_shape`: `surface`/`mode`
  arrays have the right shape and range for each span.

All of `tests/test_autodiff.py`, `tests/test_autodiff_cache.py` (from the
stacked branch below this one), `tests/test_autodiff_state_layout.py`,
`tests/test_geometry.py`, and `tests/test_hessian.py` pass: 27 passed,
1 skipped (Enzyme-gated), against an Enzyme-enabled build.

## Open issues

- `state_layout`'s `n_probe`/`tol`/`seed` defaults match
  `_structural_nullfree_interior`'s; a caller who wants a different
  probe budget for a larger `mpol`/`ntor` can already pass them through, but
  there is no guidance yet on how to size them for a much larger case (this
  is inherited from the pre-existing probing, not new to this change).
- `gauge` is derived from `zeroZForceForM1`'s `(m=1, all n)` rule read off the
  C++ source rather than from a Hessian probe, so it is exact but tied to
  that specific constraint; if a future constraint changes which entries are
  gauge-fixed, this derivation needs a matching update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
