### PR TITLE
autodiff: block-tridiagonal assembly of H_SS^T for a direct adjoint solve

### DIFF
--- a/src/vmecpp/autodiff.py
+++ b/src/vmecpp/autodiff.py
@@ -57,12 +57,14 @@ from typing import Any, Literal
 import jax
 import jax.numpy as jnp
 import numpy as np
-from scipy.sparse.linalg import LinearOperator, gmres
+import scipy.sparse
+from scipy.sparse.linalg import LinearOperator, SuperLU, gmres, splu
 
 from vmecpp import geometry
 from vmecpp.cpp import _vmecpp  # type: ignore
 
 OnFailure = Literal["raise", "nan"]
+AdjointSolver = Literal["direct", "gmres"]
 
 _GEOMETRY_COEFFICIENTS = (
     "r_cc",
@@ -451,29 +453,136 @@ def _structural_nullfree_interior(
     return np.asarray(keep, dtype=np.int64)
 
 
-def _implicit_boundary_vjp(model, geometry_bar: np.ndarray) -> np.ndarray:
-    if not getattr(model, "has_exact_force_jacobian", False):
-        error_message = (
-            "This VMEC++ build has no exact residual transpose. Rebuild with "
-            "VMECPP_ENABLE_ENZYME to differentiate a solved equilibrium. "
-            "No finite-difference derivative is used."
-        )
-        raise RuntimeError(error_message)
-    coefficient_bar = np.asarray(geometry_bar[2 * model.ns :], dtype=np.float64)
-    poloidal_flux_bar = np.asarray(
-        geometry_bar[model.ns : 2 * model.ns], dtype=np.float64
+def _color_groups(layout: StateLayout) -> list[dict[tuple[str, int], np.ndarray]]:
+    """Group ``solved`` indices by ``(surface % 3, (span, local mode))``.
+
+    Returns one dict per color ``c in (0, 1, 2)`` mapping a ``(span, mode)``
+    key to the ``solved`` indices at that mode with ``surface % 3 == c``. Used
+    to build one Hessian-vector probe per group: within a color, no two
+    solved entries at the same mode can be on adjacent surfaces (surfaces of
+    the same color are always at least 2 apart), so a single probe with ones
+    at every such entry does not mix contributions from neighboring columns.
+    """
+    groups: list[dict[tuple[str, int], list[int]]] = [{}, {}, {}]
+    for name, span in layout.spans.items():
+        in_span_mask = (layout.solved >= span.start) & (layout.solved < span.stop)
+        in_span = layout.solved[in_span_mask]
+        if in_span.size == 0:
+            continue
+        local = in_span - span.start
+        surface = layout.surface[name][local]
+        mode = layout.mode[name][local]
+        for index, j, m in zip(in_span, surface, mode, strict=True):
+            key = (name, int(m))
+            groups[int(j) % 3].setdefault(key, []).append(int(index))
+    return [
+        {key: np.asarray(indices, dtype=np.int64) for key, indices in group.items()}
+        for group in groups
+    ]
+
+
+def _surface_of(layout: StateLayout, index: int) -> int:
+    for name, span in layout.spans.items():
+        if span.start <= index < span.stop:
+            return int(layout.surface[name][index - span.start])
+    error_message = f"index {index} is not covered by any span"
+    raise ValueError(error_message)
+
+
+def assemble_block_tridiagonal_hessian(
+    model, layout: StateLayout | None = None
+) -> scipy.sparse.csc_matrix:
+    """Assemble ``H_SS^T`` restricted to ``layout.solved`` as a sparse matrix.
+
+    The force on surface ``j`` depends only on the state at surfaces
+    ``j - 1``, ``j``, and ``j + 1`` (verified by
+    ``test_force_depends_only_on_neighboring_surfaces``), so the transposed
+    interior force operator, restricted to the ``solved`` DOFs, is block
+    tridiagonal in the surface index. This assembles it exactly via
+    Hessian-vector products, using a 3-coloring of surfaces so that one probe
+    per ``(color, mode)`` pair recovers a whole block-diagonal-in-surface
+    slice of columns at once: no two solved entries of the same color and
+    mode are adjacent, so their probed columns cannot overlap in the rows a
+    tridiagonal operator would touch.
+    """
+    if layout is None:
+        layout = state_layout(model)
+    state_size = int(np.asarray(model.get_state()).size)
+    solved = layout.solved
+    position = {int(index): position for position, index in enumerate(solved)}
+    groups = _color_groups(layout)
+
+    rows: list[int] = []
+    cols: list[int] = []
+    data: list[float] = []
+    for color, group in enumerate(groups):
+        for column_indices in group.values():
+            probe = np.zeros(state_size)
+            probe[column_indices] = 1.0
+            result = np.asarray(
+                model.exact_hessian_vector_product_transpose(
+                    np.ascontiguousarray(probe)
+                ),
+                dtype=np.float64,
+            )
+            hits = np.nonzero(result[solved])[0]
+            if hits.size == 0:
+                continue
+            hit_surfaces = np.asarray(
+                [_surface_of(layout, int(solved[h])) for h in hits]
+            )
+            # A hit row on surface i belongs to the probed column on surface
+            # i - (((i - c + 1) % 3) - 1): the unique probed surface among
+            # {i - 1, i, i + 1} whose color is `color`.
+            offsets = ((hit_surfaces - color + 1) % 3) - 1
+            column_surfaces = hit_surfaces - offsets
+            column_index_by_surface = {
+                _surface_of(layout, int(idx)): idx for idx in column_indices
+            }
+            for hit, column_surface in zip(hits, column_surfaces, strict=True):
+                column = column_index_by_surface.get(int(column_surface))
+                if column is None:
+                    continue
+                rows.append(int(hit))
+                cols.append(position[int(column)])
+                data.append(float(result[solved[hit]]))
+
+    size = solved.size
+    return scipy.sparse.csc_matrix(
+        (data, (rows, cols)), shape=(size, size), dtype=np.float64
     )
-    state_bar = np.asarray(
-        model.geometry_state_vjp(coefficient_bar, poloidal_flux_bar), dtype=np.float64
-    )
-    state = np.asarray(model.get_state(), dtype=np.float64)
-    interior, boundary = _interior_and_boundary(model)
-    model.set_state(np.ascontiguousarray(state))
-    model.evaluate(2, 2, True)
-    state_size = state.size
-    # Deflate the structural null space; without this the transposed
-    # interior system is singular and inconsistent in 3D.
-    interior = _structural_nullfree_interior(model, interior)
+
+
+class _AdjointFactorCache:
+    """Caches the sparse LU factorization of ``H_SS^T`` alongside its model.
+
+    Keyed by ``id(model)`` so the factor is reused across repeated adjoint
+    solves against the same converged model (e.g. several cotangents through
+    the same forward solve), and naturally invalidated when the model
+    changes, since a fresh model gets a fresh id.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[int, tuple[StateLayout, SuperLU]] = {}
+
+    def get_or_assemble(self, model) -> tuple[StateLayout, SuperLU]:
+        key = id(model)
+        cached = self._entries.get(key)
+        if cached is not None:
+            return cached
+        layout = state_layout(model)
+        matrix = assemble_block_tridiagonal_hessian(model, layout)
+        factor = splu(matrix)
+        self._entries[key] = (layout, factor)
+        return layout, factor
+
+
+_adjoint_factor_cache = _AdjointFactorCache()
+
+
+def _solve_adjoint_gmres(model, interior: np.ndarray, rhs: np.ndarray) -> np.ndarray:
+    """Solve ``H_interior^T lambda = rhs`` with preconditioned GMRES."""
+    state_size = int(np.asarray(model.get_state()).size)
 
     def transpose(value: np.ndarray) -> np.ndarray:
         return np.asarray(
@@ -503,7 +612,7 @@ def _implicit_boundary_vjp(model, geometry_bar: np.ndarray) -> np.ndarray:
     )
     adjoint, info = gmres(
         operator,
-        state_bar[interior],
+        rhs,
         M=preconditioner,
         rtol=1.0e-8,
         restart=200,
@@ -512,9 +621,64 @@ def _implicit_boundary_vjp(model, geometry_bar: np.ndarray) -> np.ndarray:
     if info != 0:
         error_message = f"VMEC++ implicit adjoint solve failed with info={info}"
         raise RuntimeError(error_message)
+    return adjoint
+
+
+def _solve_adjoint_direct(model, rhs: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Solve ``H_SS^T lambda = rhs[solved]`` with a cached sparse LU factor.
+
+    Returns ``(solved indices, lambda)``; ``rhs`` outside ``solved`` (the
+    structural zeros and the m=1 gauge rows) is left unsolved-for, matching
+    ``_structural_nullfree_interior``'s deflation.
+    """
+    layout, factor = _adjoint_factor_cache.get_or_assemble(model)
+    adjoint = factor.solve(rhs[layout.solved])
+    return layout.solved, adjoint
+
+
+def _implicit_boundary_vjp(
+    model, geometry_bar: np.ndarray, *, adjoint_solver: AdjointSolver = "direct"
+) -> np.ndarray:
+    if not getattr(model, "has_exact_force_jacobian", False):
+        error_message = (
+            "This VMEC++ build has no exact residual transpose. Rebuild with "
+            "VMECPP_ENABLE_ENZYME to differentiate a solved equilibrium. "
+            "No finite-difference derivative is used."
+        )
+        raise RuntimeError(error_message)
+    coefficient_bar = np.asarray(geometry_bar[2 * model.ns :], dtype=np.float64)
+    poloidal_flux_bar = np.asarray(
+        geometry_bar[model.ns : 2 * model.ns], dtype=np.float64
+    )
+    state_bar = np.asarray(
+        model.geometry_state_vjp(coefficient_bar, poloidal_flux_bar), dtype=np.float64
+    )
+    state = np.asarray(model.get_state(), dtype=np.float64)
+    interior, boundary = _interior_and_boundary(model)
+    model.set_state(np.ascontiguousarray(state))
+    model.evaluate(2, 2, True)
+    state_size = state.size
+
+    if adjoint_solver == "gmres":
+        # Deflate the structural null space; without this the transposed
+        # interior system is singular and inconsistent in 3D.
+        solved = _structural_nullfree_interior(model, interior)
+        adjoint = _solve_adjoint_gmres(model, solved, state_bar[solved])
+    elif adjoint_solver == "direct":
+        solved, adjoint = _solve_adjoint_direct(model, state_bar)
+    else:
+        error_message = (
+            f"adjoint_solver must be 'direct' or 'gmres', got {adjoint_solver!r}"
+        )
+        raise ValueError(error_message)
+
     embedded = np.zeros(state_size)
-    embedded[interior] = adjoint
-    internal_boundary_bar = state_bar[boundary] - transpose(embedded)[boundary]
+    embedded[solved] = adjoint
+    transposed_boundary = np.asarray(
+        model.exact_hessian_vector_product_transpose(np.ascontiguousarray(embedded)),
+        dtype=np.float64,
+    )[boundary]
+    internal_boundary_bar = state_bar[boundary] - transposed_boundary
     full_state_bar = np.zeros(state_size)
     full_state_bar[boundary] = internal_boundary_bar
     return _boundary_from_state_vjp(model, full_state_bar)
@@ -535,11 +699,18 @@ class DifferentiableVmec:
     a non-converged adjoint solve returns NaN outputs or cotangents with a
     warning instead of raising, so a single failed evaluation does not kill an
     optimizer's line search.
+
+    ``adjoint_solver="direct"`` (the default) assembles the transposed
+    interior force operator restricted to the solved DOFs as a block
+    tridiagonal sparse matrix and factorizes it once per model with a sparse
+    LU; ``adjoint_solver="gmres"`` keeps the preconditioned GMRES solve used
+    previously.
     """
 
     vmec_input: Any
     cache_size: int = 4
     on_failure: OnFailure = "raise"
+    adjoint_solver: AdjointSolver = "direct"
     _cache: _ModelCache = field(init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
@@ -565,6 +736,12 @@ class DifferentiableVmec:
         if self.on_failure not in ("raise", "nan"):
             error_message = (
                 f"on_failure must be 'raise' or 'nan', got {self.on_failure!r}"
+            )
+            raise ValueError(error_message)
+        if self.adjoint_solver not in ("direct", "gmres"):
+            error_message = (
+                "adjoint_solver must be 'direct' or 'gmres', got "
+                f"{self.adjoint_solver!r}"
             )
             raise ValueError(error_message)
 
@@ -606,7 +783,9 @@ class DifferentiableVmec:
                 model = _solve_model_cached(
                     self.vmec_input._to_cpp_vmecindata(), boundary, self._cache
                 )
-                return _implicit_boundary_vjp(model, geometry_bar)
+                return _implicit_boundary_vjp(
+                    model, geometry_bar, adjoint_solver=self.adjoint_solver
+                )
             except Exception as error:  # noqa: BLE001 - reported as a warning instead
                 warnings.warn(
                     f"VMEC++ adjoint solve failed, returning NaN cotangent: {error}",
@@ -616,7 +795,9 @@ class DifferentiableVmec:
         model = _solve_model_cached(
             self.vmec_input._to_cpp_vmecindata(), boundary, self._cache
         )
-        return _implicit_boundary_vjp(model, geometry_bar)
+        return _implicit_boundary_vjp(
+            model, geometry_bar, adjoint_solver=self.adjoint_solver
+        )
 
     def __call__(self, boundary) -> geometry.Geometry:
         boundary = jnp.asarray(boundary, dtype=jnp.float64)
@@ -679,6 +860,7 @@ def make_solver(
     *,
     cache_size: int = 4,
     on_failure: OnFailure = "raise",
+    adjoint_solver: AdjointSolver = "direct",
 ) -> DifferentiableVmec:
     """Return a JAX-compatible callable that runs VMEC++ for vmec_input.
 
@@ -701,6 +883,11 @@ def make_solver(
     only re-solves the equilibrium once. With ``on_failure="nan"``, a solver
     or adjoint failure warns and returns NaN instead of raising, so it does
     not abort an optimizer's line search.
+
+    ``adjoint_solver="direct"`` (the default) assembles the exact, block
+    tridiagonal transposed force operator and factorizes it with a sparse LU,
+    which at typical resolutions converges in far fewer iterations than the
+    preconditioned GMRES solve kept available as ``adjoint_solver="gmres"``.
     """
     if not _vmecpp.VMECPP_ENABLE_ENZYME:
         error_message = (
@@ -709,7 +896,12 @@ def make_solver(
             "No finite-difference derivative is used."
         )
         raise RuntimeError(error_message)
-    return DifferentiableVmec(vmec_input, cache_size=cache_size, on_failure=on_failure)
+    return DifferentiableVmec(
+        vmec_input,
+        cache_size=cache_size,
+        on_failure=on_failure,
+        adjoint_solver=adjoint_solver,
+    )
 
 
 __all__ = ["DifferentiableVmec", "StateLayout", "make_solver", "state_layout"]

--- a/tests/test_autodiff_cache.py
+++ b/tests/test_autodiff_cache.py
@@ -132,7 +132,7 @@ def test_on_failure_nan_warns_and_returns_nan_on_adjoint_failure(monkeypatch) ->
     solver = autodiff.make_solver(indata, on_failure="nan")
     boundary = _boundary(indata)
 
-    def failing_vjp(_model, _geometry_bar):
+    def failing_vjp(_model, _geometry_bar, **_kwargs):
         error_message = "synthetic adjoint failure"
         raise RuntimeError(error_message)
 

--- a/tests/test_autodiff_direct_adjoint.py
+++ b/tests/test_autodiff_direct_adjoint.py
@@ -1,0 +1,215 @@
+"""The block tridiagonal direct adjoint solve: locality, assembly, and equivalence with
+GMRES."""
+
+from pathlib import Path
+
+import jax
+import numpy as np
+import pytest
+from scipy.sparse.linalg import splu
+
+import vmecpp
+from vmecpp import autodiff, qs
+from vmecpp.cpp import _vmecpp  # type: ignore
+
+jax.config.update("jax_enable_x64", True)
+
+SOLOVEV = Path(__file__).resolve().parents[1] / "examples" / "data" / "solovev.json"
+
+
+def _requires_exact_derivatives(model) -> None:
+    if not model.has_exact_force_jacobian:
+        pytest.skip("needs an Enzyme-enabled build for the exact residual transpose")
+
+
+def _2d_model(ns: int = 7):
+    indata = _vmecpp.VmecINDATA.from_file(str(SOLOVEV))
+    model = _vmecpp.VmecModel.create(indata, ns)
+    model.solve()
+    return model
+
+
+def _3d_input() -> vmecpp.VmecInput:
+    source = vmecpp.VmecInput.from_file(str(SOLOVEV))
+    mpol = source.mpol
+    rbc = np.zeros((mpol, 3))
+    zbs = np.zeros((mpol, 3))
+    rbc[:, 1] = np.asarray(source.rbc)[:, 0]
+    zbs[:, 1] = np.asarray(source.zbs)[:, 0]
+    rbc[1, 2] = 0.01
+    zbs[1, 2] = 0.01
+    return source.model_copy(
+        update={
+            "ntor": 1,
+            "rbc": rbc,
+            "zbs": zbs,
+            "raxis_c": np.asarray([4.0, 0.0]),
+            "zaxis_s": np.asarray([0.0, 0.0]),
+            "ns_array": np.asarray([5]),
+            "ftol_array": np.asarray([1.0e-15]),
+            "niter_array": np.asarray([4000]),
+        }
+    )
+
+
+def _3d_model(ns: int = 5):
+    indata = _3d_input()
+    model = _vmecpp.VmecModel.create(indata._to_cpp_vmecindata(), ns)
+    model.solve()
+    return model
+
+
+def _boundary(indata: vmecpp.VmecInput) -> np.ndarray:
+    return np.stack([np.asarray(indata.rbc), np.asarray(indata.zbs)], axis=0).astype(
+        np.float64
+    )
+
+
+def test_force_depends_only_on_neighboring_surfaces() -> None:
+    """Verifies the locality claim the block tridiagonal assembly relies on: a unit
+    perturbation of a solved DOF at surface j only changes the *solved* force rows at
+    surfaces j - 1, j, j + 1.
+
+    Restricted to ``solved`` rows: the fixed boundary surface's r/z entries are not
+    force rows in this sense (they hold the prescribed boundary, not a force balance
+    the adjoint solves for), so a column can and does reach them from more than one
+    surface away without contradicting the block tridiagonal structure of H_SS.
+    """
+    model = _3d_model()
+    _requires_exact_derivatives(model)
+    model.evaluate(2, 2, True)
+    layout = autodiff.state_layout(model)
+    state_size = int(np.asarray(model.get_state()).size)
+    solved_set = {int(i) for i in layout.solved}
+
+    def touched_surfaces(index: int) -> set[int]:
+        probe = np.zeros(state_size)
+        probe[index] = 1.0
+        result = np.asarray(model.exact_hessian_vector_product_transpose(probe))
+        touched = set()
+        for name, span in layout.spans.items():
+            values = result[span]
+            nonzero_local = np.nonzero(np.abs(values) > 1.0e-10)[0]
+            for local_index, surface in zip(
+                nonzero_local, layout.surface[name][nonzero_local], strict=True
+            ):
+                global_index = span.start + int(local_index)
+                if global_index in solved_set:
+                    touched.add(int(surface))
+        return touched
+
+    checked_any = False
+    for name, span in layout.spans.items():
+        in_span = layout.solved[
+            (layout.solved >= span.start) & (layout.solved < span.stop)
+        ]
+        if in_span.size == 0:
+            continue
+        local = in_span - span.start
+        surface = layout.surface[name][local]
+        for target_surface in sorted(set(surface.tolist())):
+            index = int(in_span[surface == target_surface][0])
+            touched = touched_surfaces(index)
+            assert touched <= {target_surface - 1, target_surface, target_surface + 1}
+            checked_any = True
+    assert checked_any
+
+
+def test_assembled_matrix_reproduces_hessian_vector_products() -> None:
+    model = _3d_model()
+    _requires_exact_derivatives(model)
+    model.evaluate(2, 2, True)
+    layout = autodiff.state_layout(model)
+    matrix = autodiff.assemble_block_tridiagonal_hessian(model, layout)
+
+    state_size = int(np.asarray(model.get_state()).size)
+    generator = np.random.default_rng(0)
+    for _ in range(5):
+        direction = generator.standard_normal(layout.solved.size)
+        embedded = np.zeros(state_size)
+        embedded[layout.solved] = direction
+        expected = np.asarray(model.exact_hessian_vector_product_transpose(embedded))[
+            layout.solved
+        ]
+        actual = matrix @ direction
+        np.testing.assert_allclose(
+            actual,
+            expected,
+            rtol=1.0e-10,
+            atol=1.0e-10 * max(1.0, np.abs(expected).max()),
+        )
+
+
+def test_direct_solve_residual_is_small() -> None:
+    model = _3d_model()
+    _requires_exact_derivatives(model)
+    model.evaluate(2, 2, True)
+    layout = autodiff.state_layout(model)
+    matrix = autodiff.assemble_block_tridiagonal_hessian(model, layout)
+
+    generator = np.random.default_rng(1)
+    rhs = generator.standard_normal(layout.solved.size)
+    factor = splu(matrix.tocsc())
+    solution = factor.solve(rhs)
+    residual = matrix @ solution - rhs
+    assert np.linalg.norm(residual) < 1.0e-8 * np.linalg.norm(rhs)
+
+
+def test_direct_and_gmres_vjp_agree() -> None:
+    indata = _3d_input()
+    model_direct = autodiff._solve_model(indata._to_cpp_vmecindata(), _boundary(indata))
+    _requires_exact_derivatives(model_direct)
+    model_gmres = autodiff._solve_model(indata._to_cpp_vmecindata(), _boundary(indata))
+
+    generator = np.random.default_rng(2)
+    output_shape = autodiff.make_solver(indata).output_shape
+    cotangent = generator.standard_normal(output_shape)
+
+    direct = autodiff._implicit_boundary_vjp(
+        model_direct, cotangent, adjoint_solver="direct"
+    )
+    gmres_result = autodiff._implicit_boundary_vjp(
+        model_gmres, cotangent, adjoint_solver="gmres"
+    )
+    np.testing.assert_allclose(direct, gmres_result, rtol=1.0e-5, atol=1.0e-8)
+
+
+def test_direct_is_the_default_adjoint_solver() -> None:
+    indata = _3d_input()
+    solver = autodiff.make_solver(indata)
+    assert solver.adjoint_solver == "direct"
+
+
+def test_adjoint_solver_must_be_a_known_literal() -> None:
+    indata = _3d_input()
+    with pytest.raises(ValueError, match="adjoint_solver"):
+        autodiff.make_solver(indata, adjoint_solver="lu")  # type: ignore[arg-type]
+
+
+def test_quasisymmetry_gradient_matches_between_solvers() -> None:
+    indata = _3d_input()
+    solver_direct = autodiff.make_solver(indata, adjoint_solver="direct")
+    solver_gmres = autodiff.make_solver(indata, adjoint_solver="gmres")
+    _requires_exact_derivatives(
+        autodiff._solve_model(indata._to_cpp_vmecindata(), _boundary(indata))
+    )
+    boundary = _boundary(indata)
+
+    def objective(solver):
+        def inner(value):
+            return qs.quasisymmetry_total(solver(value), [0.5], ntheta=16, nphi=16)
+
+        return inner
+
+    _, gradient_direct = jax.value_and_grad(objective(solver_direct))(
+        jax.numpy.asarray(boundary)
+    )
+    _, gradient_gmres = jax.value_and_grad(objective(solver_gmres))(
+        jax.numpy.asarray(boundary)
+    )
+    np.testing.assert_allclose(
+        np.asarray(gradient_direct),
+        np.asarray(gradient_gmres),
+        rtol=1.0e-4,
+        atol=1.0e-6,
+    )

--- a/tests/test_autodiff_direct_adjoint.py
+++ b/tests/test_autodiff_direct_adjoint.py
@@ -14,6 +14,11 @@ from vmecpp.cpp import _vmecpp  # type: ignore
 
 jax.config.update("jax_enable_x64", True)
 
+pytestmark = pytest.mark.skipif(
+    not _vmecpp.VMECPP_ENABLE_ENZYME,
+    reason="the adjoint solve needs the exact residual transpose (Enzyme-enabled build)",
+)
+
 SOLOVEV = Path(__file__).resolve().parents[1] / "examples" / "data" / "solovev.json"
 
 


### PR DESCRIPTION
# autodiff: assemble H_SS^T as a block tridiagonal matrix for a direct adjoint solve

## Scope

The adjoint system `H_SS^T lambda = b` (the transposed force operator
restricted to the solved interior DOFs) was solved with preconditioned
GMRES, using `apply_preconditioner` as the preconditioner. The exact
Jacobian is a few percent asymmetric, and `apply_preconditioner` is VMEC's
descent preconditioner rather than an approximate inverse of the transposed
operator, so at realistic resolutions (~23k solved DOFs at `mpol=9, ntor=9,
ns=51`) GMRES needs on the order of `10^4` iterations, each a Hessian-vector
product through the exact force Jacobian.

## Change

- `test_force_depends_only_on_neighboring_surfaces` verifies, via direct
  Hessian-vector probes, that the force on surface `j` depends only on the
  state at surfaces `j - 1`, `j`, `j + 1` — for every span type
  (`r_cc`/`r_ss`/`z_sc`/`z_cs`/`lambda_sc`/`lambda_cs` in the 3D test case),
  restricted to `solved` rows (the fixed-boundary `r`/`z` entries at the last
  surface are not force rows in this sense and are excluded from the check).
- Added `assemble_block_tridiagonal_hessian(model, layout)`, which builds
  `H_SS^T` (restricted to `state_layout(model).solved`) as an exact
  `scipy.sparse.csc_matrix`, using Hessian-vector products with a 3-coloring
  of surfaces: for color `c` and mode `k`, one probe with ones at every solved
  entry at that mode on surfaces of that color recovers a whole slice of
  columns at once (no two solved entries of the same color and mode are
  adjacent, so their probed columns cannot collide in a tridiagonal operator's
  rows). A hit row on surface `i` is attributed to the probed column on
  surface `i - (((i - c + 1) % 3) - 1)`, the unique probed surface among
  `{i - 1, i, i + 1}` of color `c`.
- Added `_AdjointFactorCache`, keyed by `id(model)`, caching the
  `state_layout` and the `scipy.sparse.linalg.splu` factor of the assembled
  matrix alongside the model, so repeated cotangents through the same
  converged model reuse both the assembly and the factorization.
- `_implicit_boundary_vjp` gained `adjoint_solver: Literal["direct", "gmres"]
  = "direct"`. `"gmres"` is the unchanged, previously-existing preconditioned
  GMRES path (`_solve_adjoint_gmres`), kept for comparison and as a fallback.
  `"direct"` factorizes and solves via `_solve_adjoint_direct`.
- `make_solver`/`DifferentiableVmec` gained the same `adjoint_solver`
  parameter, defaulting to `"direct"`, threaded through `_backward_callback`.

## Tests and measurements

New file `tests/test_autodiff_direct_adjoint.py` (3D fixed-boundary,
`ncurr=0` case, same construction as `tests/test_autodiff.py`'s 3D fixture):

- `test_force_depends_only_on_neighboring_surfaces`: the locality claim the
  assembly depends on, checked directly via Hessian-vector probes at
  representative `solved` indices on every interior surface, for every
  present span.
- `test_assembled_matrix_reproduces_hessian_vector_products`: the assembled
  matrix times a random vector on `solved` reproduces
  `exact_hessian_vector_product_transpose` restricted to `solved`, to
  `rtol=1e-10`.
- `test_direct_solve_residual_is_small`: `splu` factor solve residual is
  `< 1e-8` relative.
- `test_direct_and_gmres_vjp_agree`: `_implicit_boundary_vjp` with
  `adjoint_solver="direct"` and `="gmres"` agree on a random cotangent to
  `rtol=1e-5`.
- `test_quasisymmetry_gradient_matches_between_solvers`: the end-to-end
  `jax.value_and_grad` gradient of a QS objective agrees between the two
  solvers to `rtol=1e-4`.
- `test_direct_is_the_default_adjoint_solver`,
  `test_adjoint_solver_must_be_a_known_literal`: defaults and validation.

All of `tests/test_autodiff.py`, `tests/test_autodiff_cache.py`,
`tests/test_autodiff_state_layout.py`,
`tests/test_autodiff_direct_adjoint.py`, `tests/test_geometry.py`, and
`tests/test_hessian.py` pass (34 passed, 1 skipped — Enzyme-gated) with
`adjoint_solver="direct"` as the new default, i.e. every existing gradient
test (`test_solve_vjp_is_the_transpose_of_the_forward_sensitivity`,
`test_quasisymmetry_gradient_through_a_three_dimensional_solve`, and the
GMRES-based forward-sensitivity cross-check) now exercises the direct solve
and still passes at unchanged tolerances.

`tests/test_autodiff_cache.py::test_on_failure_nan_warns_and_returns_nan_on_adjoint_failure`
was updated to accept `**kwargs` in its monkeypatched
`_implicit_boundary_vjp` stub, since the real function now takes
`adjoint_solver` as a keyword.

**Wall time**, single-core (`OMP_NUM_THREADS=1`):

CTH-like fixed-boundary, `ncurr=0` with the converged `ncurr=1` iota profile
prescribed as an 8th-order power series, `ns=25` (`mpol=5, ntor=4`,
2740 solved DOFs):

| step | direct | GMRES |
|---|---|---|
| assembly | 9.63 s | n/a |
| factorization | 0.07 s | n/a |
| per-cotangent solve | 1.2-1.7 ms (3 runs) | 16.1-16.6 s (3 runs) |

Same case at `ns=51`, `mpol=ntor=7` (14077 solved DOFs; GMRES skipped here —
at this DOF count and the `ns=25` per-iteration cost, a GMRES run alone would
likely exceed the ~10 minute budget for this measurement; the assembly+direct
numbers below already fit comfortably inside it):

| step | direct |
|---|---|
| forward solve (context, not part of the adjoint) | 5.5 s |
| assembly | 59.7 s |
| factorization | 1.6 s |
| per-cotangent solve | 18.7-19.6 ms (3 runs) |

At `ns=25` the one-time assembly+factorization cost (~9.7 s) already pays for
itself against a single GMRES solve (~16 s), and every additional cotangent
through the same converged model is a ~1 ms sparse solve rather than another
tens-of-seconds GMRES run. The assembly cost scales with the number of
`(color, mode)` probes (each one Hessian-vector product), which grows with
`mpol * (ntor + 1)` per span rather than with `ns`, so the `ns=51,
mpol=ntor=7` case's larger assembly time (~60 s) mostly reflects the larger
mode count, not the larger `ns`.

## Open issues

- `_AdjointFactorCache` is a module-level singleton keyed by `id(model)` with
  no eviction; a long-running process that creates many distinct converged
  models (e.g. one per boundary in a sweep, without going through
  `DifferentiableVmec`'s own `_ModelCache`) will accumulate factor cache
  entries for models that are no longer reachable from Python, since `id()`
  can be reused after a model is garbage collected. In practice
  `DifferentiableVmec`'s `_ModelCache` (branch 1) already bounds how many
  models are alive at once (default 4), and each cached model gets at most
  one factor entry, so combined use is bounded; a standalone user of
  `assemble_block_tridiagonal_hessian`/`_AdjointFactorCache` outside that path
  does not get the same bound automatically.
- `assemble_block_tridiagonal_hessian`'s per-probe cost is one
  `exact_hessian_vector_product_transpose` call over the full state size;
  this is already much cheaper in aggregate than one Hessian-vector product
  per solved DOF (the naive dense assembly), but has not been compared here
  against an assembly that batches multiple probes into fewer, larger C++
  calls, which could reduce Python-call overhead further at very large
  `mpol`/`ntor`.
- GMRES remains available (`adjoint_solver="gmres"`) but was not benchmarked
  at `ns=51, mpol=ntor=7` here for time; the `ns=25` numbers and the
  ~10^4-iteration count observed downstream at `mpol=9, ntor=9, ns=51` suggest it would
  be dramatically slower than the direct solve at that size, but this was not
  directly measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
