### PR TITLE
Skip the make_solver tests on builds without Enzyme

### DIFF
--- a/tests/test_autodiff.py
+++ b/tests/test_autodiff.py
@@ -93,6 +93,10 @@ def _coefficients(value) -> np.ndarray:
     return np.concatenate([array.ravel() for array in arrays])
 
 
+@pytest.mark.skipif(
+    not _vmecpp.VMECPP_ENABLE_ENZYME,
+    reason="needs an Enzyme-enabled build for make_solver's exact residual transpose",
+)
 def test_solver_runs_vmecpp_and_matches_native_geometry() -> None:
     indata = _small_input()
     boundary = _boundary(indata)
@@ -109,6 +113,10 @@ def test_solver_runs_vmecpp_and_matches_native_geometry() -> None:
     )
 
 
+@pytest.mark.skipif(
+    not _vmecpp.VMECPP_ENABLE_ENZYME,
+    reason="needs an Enzyme-enabled build for make_solver's exact residual transpose",
+)
 def test_solver_is_usable_under_jit() -> None:
     indata = _small_input()
     solver = autodiff.make_solver(indata)
@@ -117,16 +125,14 @@ def test_solver_is_usable_under_jit() -> None:
     assert np.isfinite(float(value))
 
 
+@pytest.mark.skipif(
+    _vmecpp.VMECPP_ENABLE_ENZYME,
+    reason="exact Enzyme derivative support is enabled, so make_solver succeeds",
+)
 def test_solver_does_not_fall_back_to_finite_differences() -> None:
     indata = _small_input()
-    solver = autodiff.make_solver(indata)
-    boundary = _boundary(indata)
-    if _vmecpp.VmecModel.create(
-        indata._to_cpp_vmecindata(), 5
-    ).has_exact_force_jacobian:
-        pytest.skip("exact Enzyme derivative support is enabled")
-    with pytest.raises(RuntimeError, match="no exact residual transpose"):
-        solver._backward_callback(boundary, np.zeros(solver.output_shape))
+    with pytest.raises(RuntimeError, match="VMECPP_ENABLE_ENZYME"):
+        autodiff.make_solver(indata)
 
 
 def test_has_exact_force_jacobian_agrees_with_the_model_property() -> None:

--- a/tests/test_autodiff_ncurr1.py
+++ b/tests/test_autodiff_ncurr1.py
@@ -230,6 +230,10 @@ def test_geometry_state_vjp_poloidal_flux_route_matches_finite_difference() -> N
     assert errors[1.0e-5] < errors[1.0e-4] < errors[1.0e-3]
 
 
+@pytest.mark.skipif(
+    not _vmecpp.VMECPP_ENABLE_ENZYME,
+    reason="needs an Enzyme-enabled build for make_solver's exact residual transpose",
+)
 def test_differentiable_vmec_accepts_ncurr1() -> None:
     indata = _ncurr1_input()
     solver = autodiff.make_solver(indata)


### PR DESCRIPTION
## Scope

`vmecpp.autodiff.make_solver` now raises `RuntimeError` when the C++ extension
was built without Enzyme (`_vmecpp.VMECPP_ENABLE_ENZYME` is `False`, i.e.
`vmecpp.has_exact_force_jacobian()` is `False`), since it has no exact
residual transpose to hand back to JAX. This is the default CMake
configuration and the configuration of the published PyPI wheel.

Several tests in `tests/test_autodiff.py` and `tests/test_autodiff_ncurr1.py`
called `make_solver` unconditionally and started failing hard on a
non-Enzyme build instead of skipping.

## Change

- Added `pytest.mark.skipif(not _vmecpp.VMECPP_ENABLE_ENZYME, ...)` to every
  test that calls `make_solver` directly and therefore requires an
  Enzyme-enabled build:
  - `test_solver_runs_vmecpp_and_matches_native_geometry`
  - `test_solver_is_usable_under_jit`
  - `test_differentiable_vmec_accepts_ncurr1`

  This reuses the existing skip-gate convention already used by the
  `_requires_exact_derivatives` helper elsewhere in these files, rather than
  introducing a new mechanism.

- Rewrote `test_solver_does_not_fall_back_to_finite_differences`. It is meant
  to run only on a non-Enzyme build and assert there is no silent
  finite-difference fallback. Previously it constructed a solver and checked
  a model property before deciding whether to skip, which itself depended on
  `make_solver` succeeding. It now directly asserts that `make_solver` raises
  `RuntimeError` mentioning `VMECPP_ENABLE_ENZYME`, and skips outright (via
  `pytest.mark.skipif(_vmecpp.VMECPP_ENABLE_ENZYME, ...)`) on an
  Enzyme-enabled build, where `make_solver` is expected to succeed instead.

- No changes were needed in `tests/test_hessian.py` (uses the plain,
  non-Enzyme-gated `hessian_vector_product`) or `tests/test_geometry.py`
  (does not exercise `make_solver` or any Enzyme-gated path). No changes were
  made to `src/`.

## Tests

Non-Enzyme build (default CMake configuration, `VMECPP_ENABLE_ENZYME` off):

```
tests/test_autodiff.py tests/test_autodiff_ncurr1.py tests/test_hessian.py tests/test_geometry.py
11 passed, 11 skipped in 6.54s
```

`test_solver_does_not_fall_back_to_finite_differences` is among the 11 that
pass on this build; every `make_solver`-dependent test correctly skips.

Enzyme-enabled build (same four test files):

```
21 passed, 1 skipped in 50.23s
```

Only `test_solver_does_not_fall_back_to_finite_differences` skips on this
build; every other previously-skipping test now runs and passes.

`ruff check` and `ruff format --check` pass on both modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
