### PR TITLE
Bound the force cotangent gather in applyExactForceJacobianTranspose

### DIFF
--- a/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
+++ b/src/vmecpp/cpp/vmecpp/vmec/ideal_mhd_model/ideal_mhd_model.cc
@@ -3072,9 +3072,15 @@ void IdealMhdModel::applyExactForceJacobianTranspose(
   }
 
   // Gather the force-density member cotangents into the flat block layout.
+  // The R/Z/constraint force members (armn/azmn/brmn/bzmn/frcon/fzcon and the
+  // 3d crmn/czmn) are only sized up to nsMaxF, one surface short of nForce's
+  // nsMaxFIncludingLcfs; only blmn/clmn span the full range. Bound the copy by
+  // src.size() so the LCFS slots for the shorter members are left at zero
+  // instead of reading past the end of the Eigen vector.
   std::vector<double> force_bar(kLocalForceBlocks * nForce, 0.0);
   auto gather = [&](int b, const Eigen::VectorXd& src) {
-    for (int i = 0; i < nForce; ++i) force_bar[b * nForce + i] = src[i];
+    const int sz = std::min(nForce, static_cast<int>(src.size()));
+    for (int i = 0; i < sz; ++i) force_bar[b * nForce + i] = src[i];
   };
   gather(0, armn_e);
   gather(1, armn_o);


### PR DESCRIPTION
## Summary

`IdealMhdModel::applyExactForceJacobianTranspose` (Enzyme-only build, `VMECPP_ENABLE_ENZYME`) gathers sixteen real-space force-density members (`armn_e/o`, `azmn_e/o`, `brmn_e/o`, `bzmn_e/o`, `frcon_e/o`, `fzcon_e/o`, and the 3D-only `crmn_e/o`, `czmn_e/o`) into a flat cotangent buffer sized `nForce = nZnT * (nsMaxFIncludingLcfs - nsMinF)`. Those sixteen `Eigen::VectorXd` members are actually allocated one surface shorter, `nZnT * (nsMaxF - nsMinF)` (only `blmn_e/o` and `clmn_e/o` are allocated at the full `nForce` length). At production-size fixed-boundary problems, the thread holding the last flux surface has `nsMaxFIncludingLcfs == nsMaxF + 1`, so the gather loop reads `nZnT` doubles past the end of each of those sixteen vectors — a silent heap over-read in release builds (Eigen has no bounds checking). The values read from the out-of-bounds region are discarded by the reverse-mode kernel (the primal force-density computation never writes those LCFS-row cotangent slots), so the fix has no effect on outputs — it only removes the invalid read.

## Change

Bound the `gather` lambda's copy loop by `src.size()` (mirroring the existing, already-correct `put`/`scat` lambdas nearby, which bound by their Eigen destination's `size()`), leaving the untouched LCFS slots at their initialized zero:

```cpp
auto gather = [&](int b, const Eigen::VectorXd& src) {
  const int sz = std::min(nForce, static_cast<int>(src.size()));
  for (int i = 0; i < sz; ++i) force_bar[b * nForce + i] = src[i];
};
```

I audited the rest of `ideal_mhd_model.cc` for the same pattern (searched for `nForce` and for any loop copying Eigen members into a flat `force`/`force_bar` array):
- `applyExactForceJacobian`'s `put` lambda already bounds by `dst.size()` (the destination, i.e. the same, shorter Eigen vectors) — correct as-is.
- `chipStateVjp` seeds only a single flat scalar block (`force_bar[20 * nForce + jH] = chip_bar[jH]`) and never gathers from the Eigen force members, so it isn't affected.